### PR TITLE
Dubbo-samples-async-onerror ${dubbo.version} ， ${dubbo.rpc.version} 2.7.3-SNAPSHOT not found and Dubbo-configcenter-zookeeper configuration has two

### DIFF
--- a/dubbo-samples-annotation/pom.xml
+++ b/dubbo-samples-annotation/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring-test.version>4.3.16.RELEASE</spring-test.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-api/pom.xml
+++ b/dubbo-samples-api/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>
         <jib-maven-plugin.version>1.2.0</jib-maven-plugin.version>

--- a/dubbo-samples-async/dubbo-samples-async-generated-future/pom.xml
+++ b/dubbo-samples-async/dubbo-samples-async-generated-future/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-async/dubbo-samples-async-onerror/pom.xml
+++ b/dubbo-samples-async/dubbo-samples-async-onerror/pom.xml
@@ -32,8 +32,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.3-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.7.3-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.7.3</dubbo.version>
+        <dubbo.rpc.version>2.7.3</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -198,10 +198,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.dubbo</groupId>
-            <artifactId>dubbo-configcenter-zookeeper</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/dubbo-samples-async/dubbo-samples-async-original-future/pom.xml
+++ b/dubbo-samples-async/dubbo-samples-async-original-future/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-async/dubbo-samples-async-provider/pom.xml
+++ b/dubbo-samples-async/dubbo-samples-async-provider/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-async/dubbo-samples-async-simple/pom.xml
+++ b/dubbo-samples-async/dubbo-samples-async-simple/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-attachment/pom.xml
+++ b/dubbo-samples-attachment/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-basic/pom.xml
+++ b/dubbo-samples-basic/pom.xml
@@ -28,7 +28,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <junit.version>4.12</junit.version>
         <spring-test.version>4.3.16.RELEASE</spring-test.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-cache/pom.xml
+++ b/dubbo-samples-cache/pom.xml
@@ -28,7 +28,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-callback/pom.xml
+++ b/dubbo-samples-callback/pom.xml
@@ -28,7 +28,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <junit.version>4.12</junit.version>
         <spring-test.version>4.3.16.RELEASE</spring-test.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-chain/pom.xml
+++ b/dubbo-samples-chain/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>

--- a/dubbo-samples-compatible/pom.xml
+++ b/dubbo-samples-compatible/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-configcenter/dubbo-samples-configcenter-annotation/pom.xml
+++ b/dubbo-samples-configcenter/dubbo-samples-configcenter-annotation/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-configcenter/dubbo-samples-configcenter-api/pom.xml
+++ b/dubbo-samples-configcenter/dubbo-samples-configcenter-api/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-configcenter/dubbo-samples-configcenter-apollo/pom.xml
+++ b/dubbo-samples-configcenter/dubbo-samples-configcenter-apollo/pom.xml
@@ -33,8 +33,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>2.7.3</dubbo.version>
+        <dubbo.rpc.version>2.7.3</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-configcenter/dubbo-samples-configcenter-externalconfiguration/pom.xml
+++ b/dubbo-samples-configcenter/dubbo-samples-configcenter-externalconfiguration/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <spring.boot.version>1.5.21.RELEASE</spring.boot.version>
         <junit.version>4.12</junit.version>

--- a/dubbo-samples-configcenter/dubbo-samples-configcenter-multi-registries/pom.xml
+++ b/dubbo-samples-configcenter/dubbo-samples-configcenter-multi-registries/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-configcenter/dubbo-samples-configcenter-multiprotocol/pom.xml
+++ b/dubbo-samples-configcenter/dubbo-samples-configcenter-multiprotocol/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-configcenter/dubbo-samples-configcenter-xml/pom.xml
+++ b/dubbo-samples-configcenter/dubbo-samples-configcenter-xml/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.3-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-consul/pom.xml
+++ b/dubbo-samples-consul/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-context/pom.xml
+++ b/dubbo-samples-context/pom.xml
@@ -28,7 +28,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-direct/pom.xml
+++ b/dubbo-samples-direct/pom.xml
@@ -28,7 +28,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-docker/pom.xml
+++ b/dubbo-samples-docker/pom.xml
@@ -28,7 +28,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <spring.boot.version>1.5.21.RELEASE</spring.boot.version>
         <junit.version>4.12</junit.version>

--- a/dubbo-samples-echo/pom.xml
+++ b/dubbo-samples-echo/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-edas/dubbo-samples-edas-consumer/pom.xml
+++ b/dubbo-samples-edas/dubbo-samples-edas-consumer/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <spring-boot.version>2.1.1.RELEASE</spring-boot.version>
-        <dubbo.version>2.7.1</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
     </properties>
 
     <dependencyManagement>

--- a/dubbo-samples-edas/dubbo-samples-edas-provider/pom.xml
+++ b/dubbo-samples-edas/dubbo-samples-edas-provider/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <spring-boot.version>2.1.1.RELEASE</spring-boot.version>
-        <dubbo.version>2.7.1</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
     </properties>
 
     <dependencyManagement>

--- a/dubbo-samples-environment-keys/pom.xml
+++ b/dubbo-samples-environment-keys/pom.xml
@@ -28,7 +28,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.3-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>
         <jib-maven-plugin.version>1.2.0</jib-maven-plugin.version>

--- a/dubbo-samples-generic/dubbo-samples-generic-call/dubbo-samples-generic-call-consumer/pom.xml
+++ b/dubbo-samples-generic/dubbo-samples-generic-call/dubbo-samples-generic-call-consumer/pom.xml
@@ -31,7 +31,7 @@
     <artifactId>dubbo-samples-generic-call-consumer</artifactId>
 
     <properties>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
     </properties>
 
     <dependencies>

--- a/dubbo-samples-generic/dubbo-samples-generic-call/dubbo-samples-generic-call-provider/pom.xml
+++ b/dubbo-samples-generic/dubbo-samples-generic-call/dubbo-samples-generic-call-provider/pom.xml
@@ -33,7 +33,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-generic/dubbo-samples-generic-impl/dubbo-samples-generic-impl-consumer/pom.xml
+++ b/dubbo-samples-generic/dubbo-samples-generic-impl/dubbo-samples-generic-impl-consumer/pom.xml
@@ -31,7 +31,7 @@
     <artifactId>dubbo-samples-generic-impl-consumer</artifactId>
 
     <properties>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
     </properties>
 
     <dependencies>

--- a/dubbo-samples-generic/dubbo-samples-generic-impl/dubbo-samples-generic-impl-provider/pom.xml
+++ b/dubbo-samples-generic/dubbo-samples-generic-impl/dubbo-samples-generic-impl-provider/pom.xml
@@ -33,7 +33,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-generic/dubbo-samples-generic-type/pom.xml
+++ b/dubbo-samples-generic/dubbo-samples-generic-type/pom.xml
@@ -33,7 +33,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-governance/dubbo-samples-applevel-override/pom.xml
+++ b/dubbo-samples-governance/dubbo-samples-applevel-override/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.3-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-governance/dubbo-samples-configconditionrouter/pom.xml
+++ b/dubbo-samples-governance/dubbo-samples-configconditionrouter/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.3-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-governance/dubbo-samples-servicelevel-override/pom.xml
+++ b/dubbo-samples-governance/dubbo-samples-servicelevel-override/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-governance/dubbo-samples-tagrouter/pom.xml
+++ b/dubbo-samples-governance/dubbo-samples-tagrouter/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.3-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-group/pom.xml
+++ b/dubbo-samples-group/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-http/pom.xml
+++ b/dubbo-samples-http/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-jetty/pom.xml
+++ b/dubbo-samples-jetty/pom.xml
@@ -31,8 +31,8 @@
     <source.level>1.8</source.level>
     <target.level>1.8</target.level>
     <spring.version>4.3.16.RELEASE</spring.version>
-    <dubbo.version>2.7.0</dubbo.version>
-    <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+    <dubbo.version>2.7.3</dubbo.version>
+    <dubbo.rpc.version>2.7.3</dubbo.rpc.version>
     <zookeeper.version>3.4.13</zookeeper.version>
     <curator.version>4.0.1</curator.version>
     <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-local/pom.xml
+++ b/dubbo-samples-local/pom.xml
@@ -28,7 +28,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>

--- a/dubbo-samples-merge/dubbo-samples-merge-consumer/pom.xml
+++ b/dubbo-samples-merge/dubbo-samples-merge-consumer/pom.xml
@@ -29,7 +29,7 @@
     <artifactId>dubbo-samples-merge-consumer</artifactId>
 
     <properties>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <maven-failsafe-plugin.version>2.21.0</maven-failsafe-plugin.version>

--- a/dubbo-samples-merge/dubbo-samples-merge-provider1/pom.xml
+++ b/dubbo-samples-merge/dubbo-samples-merge-provider1/pom.xml
@@ -29,7 +29,7 @@
     <artifactId>dubbo-samples-merge-provider1</artifactId>
 
     <properties>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <jib-maven-plugin.version>1.2.0</jib-maven-plugin.version>
         <image.name>${artifactId}:${dubbo.version}</image.name>
         <java-image.name>openjdk:8</java-image.name>

--- a/dubbo-samples-merge/dubbo-samples-merge-provider2/pom.xml
+++ b/dubbo-samples-merge/dubbo-samples-merge-provider2/pom.xml
@@ -29,7 +29,7 @@
     <artifactId>dubbo-samples-merge-provider2</artifactId>
 
     <properties>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <jib-maven-plugin.version>1.2.0</jib-maven-plugin.version>
         <image.name>${artifactId}:${dubbo.version}</image.name>
         <java-image.name>openjdk:8</java-image.name>

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-configcenter/pom.xml
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-configcenter/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-annotation/pom.xml
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-annotation/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/pom.xml
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-xml/pom.xml
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-xml/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-metrics/pom.xml
+++ b/dubbo-samples-metrics/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <junit.version>4.12</junit.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-mock/pom.xml
+++ b/dubbo-samples-mock/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
         <junit.version>4.12</junit.version>
         <maven_checkstyle_version>3.0.0</maven_checkstyle_version>

--- a/dubbo-samples-monitor/pom.xml
+++ b/dubbo-samples-monitor/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-multi-registry/pom.xml
+++ b/dubbo-samples-multi-registry/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-nacos/dubbo-samples-nacos-conditionrouter/pom.xml
+++ b/dubbo-samples-nacos/dubbo-samples-nacos-conditionrouter/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.3-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-nacos/dubbo-samples-nacos-configcenter/pom.xml
+++ b/dubbo-samples-nacos/dubbo-samples-nacos-configcenter/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.3-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-nacos/dubbo-samples-nacos-override/pom.xml
+++ b/dubbo-samples-nacos/dubbo-samples-nacos-override/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.3-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-nacos/dubbo-samples-nacos-registry/pom.xml
+++ b/dubbo-samples-nacos/dubbo-samples-nacos-registry/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.3-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-nacos/dubbo-samples-nacos-tagrouter/pom.xml
+++ b/dubbo-samples-nacos/dubbo-samples-nacos-tagrouter/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.3-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-notify/pom.xml
+++ b/dubbo-samples-notify/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-resilience4j/dubbo-samples-resilience4j-filter/pom.xml
+++ b/dubbo-samples-resilience4j/dubbo-samples-resilience4j-filter/pom.xml
@@ -32,8 +32,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>2.7.3</dubbo.version>
+        <dubbo.rpc.version>2.7.3</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-resilience4j/dubbo-samples-resilience4j-springboot2/pom.xml
+++ b/dubbo-samples-resilience4j/dubbo-samples-resilience4j-springboot2/pom.xml
@@ -33,8 +33,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>2.7.3</dubbo.version>
+        <dubbo.rpc.version>2.7.3</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-rest/pom.xml
+++ b/dubbo-samples-rest/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>2.7.3</dubbo.version>
+        <dubbo.rpc.version>2.7.3</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-scala/pom.xml
+++ b/dubbo-samples-scala/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>2.7.3</dubbo.version>
+        <dubbo.rpc.version>2.7.3</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-annotation/pom.xml
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-annotation/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-nosimple/pom.xml
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-nosimple/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-properties/pom.xml
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-properties/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-xml/pom.xml
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-xml/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-spi-compatible/pom.xml
+++ b/dubbo-samples-spi-compatible/pom.xml
@@ -28,7 +28,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-spring-boot-hystrix/pom.xml
+++ b/dubbo-samples-spring-boot-hystrix/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <spring.boot.version>1.5.21.RELEASE</spring.boot.version>
         <hystrix-starter.version>1.4.7.RELEASE</hystrix-starter.version>

--- a/dubbo-samples-spring-hystrix/pom.xml
+++ b/dubbo-samples-spring-hystrix/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <hystrix.version>1.5.18</hystrix.version>
         <junit.version>4.12</junit.version>

--- a/dubbo-samples-stub/pom.xml
+++ b/dubbo-samples-stub/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-switch-serialization-thread/pom.xml
+++ b/dubbo-samples-switch-serialization-thread/pom.xml
@@ -28,7 +28,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-thrift/pom.xml
+++ b/dubbo-samples-thrift/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
     </properties>

--- a/dubbo-samples-transaction/pom.xml
+++ b/dubbo-samples-transaction/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <seata.version>0.5.0</seata.version>
         <mysql-connector.version>8.0.15</mysql-connector.version>
         <spring.version>4.3.16.RELEASE</spring.version>

--- a/dubbo-samples-validation/pom.xml
+++ b/dubbo-samples-validation/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-version/pom.xml
+++ b/dubbo-samples-version/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/dubbo-samples-zipkin/pom.xml
+++ b/dubbo-samples-zipkin/pom.xml
@@ -28,7 +28,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.3-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <curator.version>2.12.0</curator.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>

--- a/dubbo-samples-zookeeper/pom.xml
+++ b/dubbo-samples-zookeeper/pom.xml
@@ -28,7 +28,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.2</dubbo.version>
+        <dubbo.version>2.7.3</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>


### PR DESCRIPTION
Update ${dubbo.rpc.version} 2.7.3-SNAPSHOT to 2.7.3 and remove dubbo-configcenter-zookeeper duplicate configuration