### PR TITLE
Adjusted dubbo dependency  version to 2.6.7

### DIFF
--- a/dubbo-samples-annotation/pom.xml
+++ b/dubbo-samples-annotation/pom.xml
@@ -28,8 +28,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-api-client/pom.xml
+++ b/dubbo-samples-api-client/pom.xml
@@ -28,8 +28,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-api/pom.xml
+++ b/dubbo-samples-api/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-async/pom.xml
+++ b/dubbo-samples-async/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-attachment/pom.xml
+++ b/dubbo-samples-attachment/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-basic/pom.xml
+++ b/dubbo-samples-basic/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-cache/pom.xml
+++ b/dubbo-samples-cache/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-callback/pom.xml
+++ b/dubbo-samples-callback/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-context/pom.xml
+++ b/dubbo-samples-context/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-direct/pom.xml
+++ b/dubbo-samples-direct/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-docker/pom.xml
+++ b/dubbo-samples-docker/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>
@@ -142,7 +142,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>dubbo</artifactId>
-            <version>2.6.6-SNAPSHOT</version>
+            <version>2.6.7</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/dubbo-samples-echo/pom.xml
+++ b/dubbo-samples-echo/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-generic/pom.xml
+++ b/dubbo-samples-generic/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-group/pom.xml
+++ b/dubbo-samples-group/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-http/pom.xml
+++ b/dubbo-samples-http/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-local/pom.xml
+++ b/dubbo-samples-local/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-merge/pom.xml
+++ b/dubbo-samples-merge/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-mock/pom.xml
+++ b/dubbo-samples-mock/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-monitor/pom.xml
+++ b/dubbo-samples-monitor/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-multi-registry/pom.xml
+++ b/dubbo-samples-multi-registry/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-notify/pom.xml
+++ b/dubbo-samples-notify/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-rest/pom.xml
+++ b/dubbo-samples-rest/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-scala/pom.xml
+++ b/dubbo-samples-scala/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-spring-boot-hystrix/pom.xml
+++ b/dubbo-samples-spring-boot-hystrix/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-spring-hystrix/pom.xml
+++ b/dubbo-samples-spring-hystrix/pom.xml
@@ -31,8 +31,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-stub/pom.xml
+++ b/dubbo-samples-stub/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-switch-serialization-thread/pom.xml
+++ b/dubbo-samples-switch-serialization-thread/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-validation/pom.xml
+++ b/dubbo-samples-validation/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-version/pom.xml
+++ b/dubbo-samples-version/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-zipkin/pom.xml
+++ b/dubbo-samples-zipkin/pom.xml
@@ -31,8 +31,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>

--- a/dubbo-samples-zookeeper/pom.xml
+++ b/dubbo-samples-zookeeper/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.6.6-SNAPSHOT</dubbo.version>
-        <dubbo.rpc.version>2.6.6-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>2.6.7</dubbo.version>
+        <dubbo.rpc.version>2.6.7</dubbo.rpc.version>
         <curator.version>2.12.0</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>


### PR DESCRIPTION
Dubbo 2.6.6-SNAPSHOT lack `import com.alibaba.dubbo.config.annotation.Method`cause `AnnotationService2Impl.java` error，so adjusted Dubbo dependency  version to 2.6.7 .