### PR TITLE
add support for release verify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
 install: true
 
 before_script: 
-  - bash ./travis/prepare-artifact.sh
+  - bash .travis/prepare-artifact.sh
   - cd java
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ before_script:
   - cd java
 
 script:
-  - ./mvnw -U --batch-mode --no-transfer-progress --settings .mvn/settings.xml clean install -pl dubbo-maven-address-plugin -Ddubbo.version=2.7.5-SNAPSHOT
+  - ./mvnw -U --batch-mode --no-transfer-progress --settings .mvn/settings.xml clean install -pl dubbo-maven-address-plugin -Ddubbo.version=${INTERGARTION_TEST_VERSION}
   - while sleep 8m; do echo "=====[ $SECONDS seconds, buildroot still building... ]====="; done &
-  - travis_wait 30 ./mvnw -U --batch-mode --no-transfer-progress --settings .mvn/settings.xml clean verify -Pdubbo-integration-test -Djava-image.name=${JAVA_BASE_IMAGE} -Ddubbo.version=2.7.5-SNAPSHOT -Ddocker.showLogs > output.log
+  - travis_wait 30 ./mvnw -U --batch-mode --no-transfer-progress --settings .mvn/settings.xml clean verify -Pdubbo-integration-test -Djava-image.name=${JAVA_BASE_IMAGE} -Ddubbo.version=${INTERGARTION_TEST_VERSION} -Ddocker.showLogs > output.log
 
 after_failure:
   - tail -n 5000 output.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ cache:
 install: true
 
 before_script: 
+  - bash ./travis/prepare-artifact.sh
   - cd java
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
 install: true
 
 before_script: 
-  - bash .travis/prepare-artifact.sh
+  - . .travis/prepare-artifact.sh
   - cd java
 
 script:

--- a/.travis/prepare-artifact.sh
+++ b/.travis/prepare-artifact.sh
@@ -2,11 +2,11 @@
 env
 
 if [[ -z "${RELEASE_BRANCH}" ]]; then
-  export INTERGARTION_TEST_VERSION = '2.7.6-SNAPSHOT'
+  export INTERGARTION_TEST_VERSION='2.7.6-SNAPSHOT'
 else
   git clone https://github.com/apache/dubbo.git
   cd dubbo
   git checkout ${RELEASE_BRANCH}
   ./mwnw clean install -DskipTests -Drevision=${RELEASE_BRANCH}
-  export INTERGARTION_TEST_VERSION = ${RELEASE_BRANCH}
+  export INTERGARTION_TEST_VERSION=${RELEASE_BRANCH}
 fi

--- a/.travis/prepare-artifact.sh
+++ b/.travis/prepare-artifact.sh
@@ -1,0 +1,2 @@
+#! /usr/bin/env bash
+env

--- a/.travis/prepare-artifact.sh
+++ b/.travis/prepare-artifact.sh
@@ -1,2 +1,12 @@
 #! /usr/bin/env bash
 env
+
+if [[ -z "${RELEASE_BRANCH}" ]]; then
+  export INTERGARTION_TEST_VERSION = '2.7.6-SNAPSHOT'
+else
+  git clone --depth 1 git@github.com:apache/dubbo.git
+  cd dubbo
+  git checkout ${RELEASE_BRANCH}
+  ./mwnw clean install -DskipTests -Drevision=${RELEASE_BRANCH}
+  export INTERGARTION_TEST_VERSION = ${RELEASE_BRANCH}
+fi

--- a/.travis/prepare-artifact.sh
+++ b/.travis/prepare-artifact.sh
@@ -7,8 +7,10 @@ else
   git clone https://github.com/apache/dubbo.git
   cd dubbo
   git checkout ${RELEASE_BRANCH}
-  ./mwnw clean install -DskipTests -Drevision=${RELEASE_BRANCH}
+  ls
+  ./mvnw clean install -DskipTests -Drevision=${RELEASE_BRANCH}
   export INTERGARTION_TEST_VERSION=${RELEASE_BRANCH}
+  cd ..
 fi
 
 env|grep INTERGARTION_TEST_VERSION

--- a/.travis/prepare-artifact.sh
+++ b/.travis/prepare-artifact.sh
@@ -2,7 +2,7 @@
 env
 
 if [[ -z "${RELEASE_BRANCH}" ]]; then
-  export INTERGARTION_TEST_VERSION='2.7.6-SNAPSHOT'
+  export INTERGARTION_TEST_VERSION=2.7.6-SNAPSHOT
 else
   git clone https://github.com/apache/dubbo.git
   cd dubbo
@@ -10,3 +10,5 @@ else
   ./mwnw clean install -DskipTests -Drevision=${RELEASE_BRANCH}
   export INTERGARTION_TEST_VERSION=${RELEASE_BRANCH}
 fi
+
+env|grep INTERGARTION_TEST_VERSION

--- a/.travis/prepare-artifact.sh
+++ b/.travis/prepare-artifact.sh
@@ -4,7 +4,7 @@ env
 if [[ -z "${RELEASE_BRANCH}" ]]; then
   export INTERGARTION_TEST_VERSION = '2.7.6-SNAPSHOT'
 else
-  git clone --depth 1 git@github.com:apache/dubbo.git
+  git clone https://github.com/apache/dubbo.git
   cd dubbo
   git checkout ${RELEASE_BRANCH}
   ./mwnw clean install -DskipTests -Drevision=${RELEASE_BRANCH}

--- a/java/dubbo-samples-cloud-native/pom.xml
+++ b/java/dubbo-samples-cloud-native/pom.xml
@@ -29,6 +29,7 @@
         <target.level>1.8</target.level>
         <skip_maven_deploy>true</skip_maven_deploy>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
+        <dubbo.version>2.7.5-SNAPSHOT</dubbo.version>
     </properties>
 
     <modules>
@@ -45,7 +46,7 @@
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-bom</artifactId>
-                <version>2.7.5-SNAPSHOT</version>
+                <version>${dubbo.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/java/dubbo-samples-protobuf/pom.xml
+++ b/java/dubbo-samples-protobuf/pom.xml
@@ -31,6 +31,7 @@
         <proto_dubbo_plugin_version>1.19.0-SNAPSHOT</proto_dubbo_plugin_version>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
         <dubbo.compiler.version>0.0.1-SNAPSHOT</dubbo.compiler.version>
+        <dubbo.version>2.7.5-SNAPSHOT</dubbo.version>
     </properties>
 
     <modules>
@@ -43,7 +44,7 @@
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-bom</artifactId>
-                <version>2.7.5-SNAPSHOT</version>
+                <version>${dubbo.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/java/dubbo-samples-tengine/pom.xml
+++ b/java/dubbo-samples-tengine/pom.xml
@@ -8,6 +8,7 @@
     <description>The demo module of tengine dubbo</description>
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
+        <dubbo.version>2.7.5-SNAPSHOT</dubbo.version>
     </properties>
     <modules>
         <module>dubbo-samples-tengine-interface</module>
@@ -27,14 +28,14 @@
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-dependencies-bom</artifactId>
-                <version>2.7.5-SNAPSHOT</version>
+                <version>${dubbo.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo</artifactId>
-                <version>2.7.5-SNAPSHOT</version>
+                <version>${dubbo.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.springframework</groupId>


### PR DESCRIPTION
<img width="954" alt="屏幕快照 2019-12-27 上午10 37 46" src="https://user-images.githubusercontent.com/659135/71497855-fb068200-2894-11ea-80e1-c7ef3a5577bf.png">

Use travis custom build.  for example
```
before_install: export RELEASE_BRANCH=2.7.5-release
```

By default, it will use 2.7.6-snapshot