### PR TITLE
add javax support when use jdk11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,11 @@ script:
 
 after_failure:
   - tail -n 5000 output.log
+  - curl -i -F randomname=randomname -F file=@output.log https://uguu.se/api.php\?d\=upload-tool
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
 jobs:
   allow_failures:
   - jdk: openjdk11
+    env: JAVA_BASE_IMAGE=openjdk:11

--- a/.travis/prepare-artifact.sh
+++ b/.travis/prepare-artifact.sh
@@ -2,7 +2,7 @@
 env
 
 if [[ -z "${RELEASE_BRANCH}" ]]; then
-  export INTERGARTION_TEST_VERSION=2.7.6-SNAPSHOT
+  export INTERGARTION_TEST_VERSION=2.7.7-SNAPSHOT
 else
   git clone https://github.com/apache/dubbo.git
   cd dubbo

--- a/java/dubbo-samples-annotation/pom.xml
+++ b/java/dubbo-samples-annotation/pom.xml
@@ -189,6 +189,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-async/dubbo-samples-async-generated-future/pom.xml
+++ b/java/dubbo-samples-async/dubbo-samples-async-generated-future/pom.xml
@@ -189,6 +189,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-async/dubbo-samples-async-onerror/pom.xml
+++ b/java/dubbo-samples-async/dubbo-samples-async-onerror/pom.xml
@@ -318,6 +318,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <repositories>

--- a/java/dubbo-samples-async/dubbo-samples-async-onerror/pom.xml
+++ b/java/dubbo-samples-async/dubbo-samples-async-onerror/pom.xml
@@ -32,7 +32,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.6-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.6</dubbo.version>
+        <dubbo.configcenter.zookeeper.version>2.7.4</dubbo.configcenter.zookeeper.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -91,6 +92,11 @@
                 <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-rpc-rest</artifactId>
                 <version>${dubbo.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.dubbo</groupId>
+                <artifactId>dubbo-configcenter-zookeeper</artifactId>
+                <version>${dubbo.configcenter.zookeeper.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>
@@ -189,6 +195,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-configcenter-zookeeper</artifactId>
+            <version>${dubbo.configcenter.zookeeper.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/java/dubbo-samples-async/dubbo-samples-async-original-future/pom.xml
+++ b/java/dubbo-samples-async/dubbo-samples-async-original-future/pom.xml
@@ -189,6 +189,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-async/dubbo-samples-async-original-future/pom.xml
+++ b/java/dubbo-samples-async/dubbo-samples-async-original-future/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.6-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.7-SNAPSHOT</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/java/dubbo-samples-async/dubbo-samples-async-provider/pom.xml
+++ b/java/dubbo-samples-async/dubbo-samples-async-provider/pom.xml
@@ -189,6 +189,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-async/dubbo-samples-async-simple/pom.xml
+++ b/java/dubbo-samples-async/dubbo-samples-async-simple/pom.xml
@@ -189,6 +189,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-attachment/pom.xml
+++ b/java/dubbo-samples-attachment/pom.xml
@@ -189,6 +189,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-basic/pom.xml
+++ b/java/dubbo-samples-basic/pom.xml
@@ -183,6 +183,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-cache/pom.xml
+++ b/java/dubbo-samples-cache/pom.xml
@@ -183,6 +183,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-callback/pom.xml
+++ b/java/dubbo-samples-callback/pom.xml
@@ -180,6 +180,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-chain/dubbo-samples-chain-backend/pom.xml
+++ b/java/dubbo-samples-chain/dubbo-samples-chain-backend/pom.xml
@@ -101,5 +101,19 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/java/dubbo-samples-chain/dubbo-samples-chain-front/pom.xml
+++ b/java/dubbo-samples-chain/dubbo-samples-chain-front/pom.xml
@@ -172,6 +172,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
 </project>

--- a/java/dubbo-samples-chain/dubbo-samples-chain-middle/pom.xml
+++ b/java/dubbo-samples-chain/dubbo-samples-chain-middle/pom.xml
@@ -100,5 +100,19 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/java/dubbo-samples-cloud-native/dubbo-call-sc/dubbo-sc-consumer/pom.xml
+++ b/java/dubbo-samples-cloud-native/dubbo-call-sc/dubbo-sc-consumer/pom.xml
@@ -29,6 +29,7 @@
     <description>The demo consumer module of dubbo project</description>
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
+        <dubbo.configcenter.zookeeper.version>2.7.4</dubbo.configcenter.zookeeper.version>
     </properties>
     <dependencies>
         <dependency>
@@ -55,6 +56,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-configcenter-zookeeper</artifactId>
+            <version>${dubbo.configcenter.zookeeper.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/java/dubbo-samples-cloud-native/dubbo-call-scdubbo/dubbo-scdubbo-consumer/pom.xml
+++ b/java/dubbo-samples-cloud-native/dubbo-call-scdubbo/dubbo-scdubbo-consumer/pom.xml
@@ -29,6 +29,7 @@
     <description>The demo consumer module of dubbo project</description>
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
+        <dubbo.configcenter.zookeeper.version>2.7.4</dubbo.configcenter.zookeeper.version>
     </properties>
     <dependencies>
         <dependency>
@@ -55,6 +56,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-configcenter-zookeeper</artifactId>
+            <version>${dubbo.configcenter.zookeeper.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/java/dubbo-samples-cloud-native/dubbo-call-scdubbo/dubbo-scdubbo-provider2/pom.xml
+++ b/java/dubbo-samples-cloud-native/dubbo-call-scdubbo/dubbo-scdubbo-provider2/pom.xml
@@ -30,6 +30,7 @@
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
         <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
+        <dubbo.configcenter.zookeeper.version>2.7.4</dubbo.configcenter.zookeeper.version>
     </properties>
 
     <dependencies>
@@ -57,6 +58,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-configcenter-zookeeper</artifactId>
+            <version>${dubbo.configcenter.zookeeper.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/java/dubbo-samples-cloud-native/dubbo-demo-servicediscovery-xml/servicediscovery-consumer/pom.xml
+++ b/java/dubbo-samples-cloud-native/dubbo-demo-servicediscovery-xml/servicediscovery-consumer/pom.xml
@@ -29,6 +29,7 @@
     <description>The demo consumer module of dubbo project</description>
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
+        <dubbo.configcenter.zookeeper.version>2.7.4</dubbo.configcenter.zookeeper.version>
     </properties>
     <dependencies>
         <dependency>
@@ -55,6 +56,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-configcenter-zookeeper</artifactId>
+            <version>${dubbo.configcenter.zookeeper.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/java/dubbo-samples-cloud-native/dubbo-demo-servicediscovery-xml/servicediscovery-provider/pom.xml
+++ b/java/dubbo-samples-cloud-native/dubbo-demo-servicediscovery-xml/servicediscovery-provider/pom.xml
@@ -30,6 +30,7 @@
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
         <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
+        <dubbo.configcenter.zookeeper.version>2.7.4</dubbo.configcenter.zookeeper.version>
     </properties>
 
     <dependencies>
@@ -57,6 +58,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-configcenter-zookeeper</artifactId>
+            <version>${dubbo.configcenter.zookeeper.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/java/dubbo-samples-cloud-native/sc-call-dubbo/sc-dubbo-provider/pom.xml
+++ b/java/dubbo-samples-cloud-native/sc-call-dubbo/sc-dubbo-provider/pom.xml
@@ -31,6 +31,7 @@
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
         <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
+        <dubbo.configcenter.zookeeper.version>2.7.4</dubbo.configcenter.zookeeper.version>
     </properties>
 
     <artifactId>sc-dubbo-provider</artifactId>
@@ -64,6 +65,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-configcenter-zookeeper</artifactId>
+            <version>${dubbo.configcenter.zookeeper.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/java/dubbo-samples-cloud-native/servicediscovery-transfer/servicediscovery-transfer-consumer-old/pom.xml
+++ b/java/dubbo-samples-cloud-native/servicediscovery-transfer/servicediscovery-transfer-consumer-old/pom.xml
@@ -28,6 +28,7 @@
     <description>The demo consumer module of dubbo project</description>
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
+        <dubbo.configcenter.zookeeper.version>2.7.4</dubbo.configcenter.zookeeper.version>
     </properties>
     <dependencies>
         <dependency>
@@ -54,6 +55,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-configcenter-zookeeper</artifactId>
+            <version>${dubbo.configcenter.zookeeper.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/java/dubbo-samples-cloud-native/servicediscovery-transfer/servicediscovery-transfer-consumer/pom.xml
+++ b/java/dubbo-samples-cloud-native/servicediscovery-transfer/servicediscovery-transfer-consumer/pom.xml
@@ -29,6 +29,7 @@
     <description>The demo consumer module of dubbo project</description>
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
+        <dubbo.configcenter.zookeeper.version>2.7.4</dubbo.configcenter.zookeeper.version>
     </properties>
     <dependencies>
         <dependency>
@@ -55,6 +56,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-configcenter-zookeeper</artifactId>
+            <version>${dubbo.configcenter.zookeeper.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/java/dubbo-samples-cloud-native/servicediscovery-transfer/servicediscovery-transfer-provider/pom.xml
+++ b/java/dubbo-samples-cloud-native/servicediscovery-transfer/servicediscovery-transfer-provider/pom.xml
@@ -30,6 +30,7 @@
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
         <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
+        <dubbo.configcenter.zookeeper.version>2.7.4</dubbo.configcenter.zookeeper.version>
     </properties>
 
     <dependencies>
@@ -57,6 +58,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-configcenter-zookeeper</artifactId>
+            <version>${dubbo.configcenter.zookeeper.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/java/dubbo-samples-compatible/pom.xml
+++ b/java/dubbo-samples-compatible/pom.xml
@@ -189,6 +189,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-configcenter/dubbo-samples-configcenter-annotation/pom.xml
+++ b/java/dubbo-samples-configcenter/dubbo-samples-configcenter-annotation/pom.xml
@@ -194,6 +194,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-configcenter/dubbo-samples-configcenter-apollo/pom.xml
+++ b/java/dubbo-samples-configcenter/dubbo-samples-configcenter-apollo/pom.xml
@@ -89,6 +89,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
+            <version>4.3.16.RELEASE</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/java/dubbo-samples-configcenter/dubbo-samples-configcenter-apollo/pom.xml
+++ b/java/dubbo-samples-configcenter/dubbo-samples-configcenter-apollo/pom.xml
@@ -212,6 +212,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-configcenter/dubbo-samples-configcenter-externalconfiguration/pom.xml
+++ b/java/dubbo-samples-configcenter/dubbo-samples-configcenter-externalconfiguration/pom.xml
@@ -206,6 +206,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-configcenter/dubbo-samples-configcenter-multi-registries/pom.xml
+++ b/java/dubbo-samples-configcenter/dubbo-samples-configcenter-multi-registries/pom.xml
@@ -198,6 +198,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-configcenter/dubbo-samples-configcenter-multiprotocol/pom.xml
+++ b/java/dubbo-samples-configcenter/dubbo-samples-configcenter-multiprotocol/pom.xml
@@ -75,16 +75,19 @@
         <dependency>
             <groupId>com.caucho</groupId>
             <artifactId>hessian</artifactId>
+            <version>4.0.63</version>
         </dependency>
 
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
+            <version>9.4.11.v20180605</version>
         </dependency>
 
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
+            <version>9.4.11.v20180605</version>
         </dependency>
 
         <dependency>
@@ -97,6 +100,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
+            <version>4.3.16.RELEASE</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/java/dubbo-samples-configcenter/dubbo-samples-configcenter-multiprotocol/pom.xml
+++ b/java/dubbo-samples-configcenter/dubbo-samples-configcenter-multiprotocol/pom.xml
@@ -220,6 +220,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-configcenter/dubbo-samples-configcenter-xml/pom.xml
+++ b/java/dubbo-samples-configcenter/dubbo-samples-configcenter-xml/pom.xml
@@ -193,6 +193,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-consul/pom.xml
+++ b/java/dubbo-samples-consul/pom.xml
@@ -122,6 +122,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-context/pom.xml
+++ b/java/dubbo-samples-context/pom.xml
@@ -103,6 +103,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-default-config/pom.xml
+++ b/java/dubbo-samples-default-config/pom.xml
@@ -121,6 +121,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-direct/pom.xml
+++ b/java/dubbo-samples-direct/pom.xml
@@ -203,6 +203,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-echo/pom.xml
+++ b/java/dubbo-samples-echo/pom.xml
@@ -188,6 +188,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-environment-keys/pom.xml
+++ b/java/dubbo-samples-environment-keys/pom.xml
@@ -182,6 +182,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-gateway/pom.xml
+++ b/java/dubbo-samples-gateway/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.6-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.6</dubbo.version>
         <junit.version>4.12</junit.version>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     </properties>

--- a/java/dubbo-samples-generic/dubbo-samples-generic-call/dubbo-samples-generic-call-provider/pom.xml
+++ b/java/dubbo-samples-generic/dubbo-samples-generic-call/dubbo-samples-generic-call-provider/pom.xml
@@ -212,5 +212,19 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/java/dubbo-samples-generic/dubbo-samples-generic-type/pom.xml
+++ b/java/dubbo-samples-generic/dubbo-samples-generic-type/pom.xml
@@ -192,6 +192,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-governance/dubbo-samples-applevel-override/pom.xml
+++ b/java/dubbo-samples-governance/dubbo-samples-applevel-override/pom.xml
@@ -214,6 +214,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-governance/dubbo-samples-configconditionrouter/pom.xml
+++ b/java/dubbo-samples-governance/dubbo-samples-configconditionrouter/pom.xml
@@ -214,6 +214,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-governance/dubbo-samples-servicelevel-override/pom.xml
+++ b/java/dubbo-samples-governance/dubbo-samples-servicelevel-override/pom.xml
@@ -196,6 +196,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-governance/dubbo-samples-tagrouter/pom.xml
+++ b/java/dubbo-samples-governance/dubbo-samples-tagrouter/pom.xml
@@ -213,6 +213,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-group/pom.xml
+++ b/java/dubbo-samples-group/pom.xml
@@ -188,6 +188,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-grpc/dubbo-samples-original/pom.xml
+++ b/java/dubbo-samples-grpc/dubbo-samples-original/pom.xml
@@ -125,6 +125,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-http/pom.xml
+++ b/java/dubbo-samples-http/pom.xml
@@ -42,6 +42,8 @@
         <servlet.container.1>tomcat</servlet.container.1>
         <servlet.port.2>8081</servlet.port.2>
         <servlet.container.2>jetty</servlet.container.2>
+        <servlet.version>3.0.1</servlet.version>
+        <tomcat.version>7.0.88</tomcat.version>
         <zookeeper.port>2181</zookeeper.port>
         <main-class>org.apache.dubbo.samples.http.HttpProvider</main-class>
     </properties>
@@ -75,26 +77,31 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
+            <version>${servlet.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
+            <version>${tomcat.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
+            <version>9.4.11.v20180605</version>
         </dependency>
 
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
+            <version>9.4.11.v20180605</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
+            <version>${spring.version}</version>
         </dependency>
 
         <dependency>

--- a/java/dubbo-samples-jetty/pom.xml
+++ b/java/dubbo-samples-jetty/pom.xml
@@ -34,6 +34,7 @@
     <dubbo.version>2.7.5</dubbo.version>
     <dubbo.rpc.version>2.7.5</dubbo.rpc.version>
     <zookeeper.version>3.4.13</zookeeper.version>
+    <dubbo.configcenter.zookeeper.version>2.7.4</dubbo.configcenter.zookeeper.version>
     <curator.version>4.0.1</curator.version>
     <validation-api.version>1.1.0.Final</validation-api.version>
     <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>
@@ -192,6 +193,7 @@
     <dependency>
       <groupId>org.apache.dubbo</groupId>
       <artifactId>dubbo-configcenter-zookeeper</artifactId>
+      <version>${dubbo.configcenter.zookeeper.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>

--- a/java/dubbo-samples-local/pom.xml
+++ b/java/dubbo-samples-local/pom.xml
@@ -91,6 +91,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-merge/dubbo-samples-merge-consumer/pom.xml
+++ b/java/dubbo-samples-merge/dubbo-samples-merge-consumer/pom.xml
@@ -29,7 +29,7 @@
     <artifactId>dubbo-samples-merge-consumer</artifactId>
 
     <properties>
-        <dubbo.version>2.7.6-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.7-SNAPSHOT</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <maven-failsafe-plugin.version>2.21.0</maven-failsafe-plugin.version>

--- a/java/dubbo-samples-merge/dubbo-samples-merge-consumer/pom.xml
+++ b/java/dubbo-samples-merge/dubbo-samples-merge-consumer/pom.xml
@@ -180,6 +180,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
 </project>

--- a/java/dubbo-samples-merge/dubbo-samples-merge-provider1/pom.xml
+++ b/java/dubbo-samples-merge/dubbo-samples-merge-provider1/pom.xml
@@ -113,5 +113,19 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/java/dubbo-samples-merge/dubbo-samples-merge-provider1/pom.xml
+++ b/java/dubbo-samples-merge/dubbo-samples-merge-provider1/pom.xml
@@ -29,7 +29,7 @@
     <artifactId>dubbo-samples-merge-provider1</artifactId>
 
     <properties>
-        <dubbo.version>2.7.6-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.7-SNAPSHOT</dubbo.version>
         <jib-maven-plugin.version>1.2.0</jib-maven-plugin.version>
         <image.name>${project.artifactId}:${dubbo.version}</image.name>
         <java-image.name>openjdk:8</java-image.name>

--- a/java/dubbo-samples-merge/dubbo-samples-merge-provider2/pom.xml
+++ b/java/dubbo-samples-merge/dubbo-samples-merge-provider2/pom.xml
@@ -113,5 +113,19 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/java/dubbo-samples-merge/dubbo-samples-merge-provider2/pom.xml
+++ b/java/dubbo-samples-merge/dubbo-samples-merge-provider2/pom.xml
@@ -29,7 +29,7 @@
     <artifactId>dubbo-samples-merge-provider2</artifactId>
 
     <properties>
-        <dubbo.version>2.7.6-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.7-SNAPSHOT</dubbo.version>
         <jib-maven-plugin.version>1.2.0</jib-maven-plugin.version>
         <image.name>${project.artifactId}:${dubbo.version}</image.name>
         <java-image.name>openjdk:8</java-image.name>

--- a/java/dubbo-samples-metadata-report/dubbo-samples-metadata-report-configcenter/pom.xml
+++ b/java/dubbo-samples-metadata-report/dubbo-samples-metadata-report-configcenter/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.6-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.7-SNAPSHOT</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/java/dubbo-samples-metadata-report/dubbo-samples-metadata-report-configcenter/pom.xml
+++ b/java/dubbo-samples-metadata-report/dubbo-samples-metadata-report-configcenter/pom.xml
@@ -209,6 +209,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-annotation/pom.xml
+++ b/java/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-annotation/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.6-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.7-SNAPSHOT</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/java/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-annotation/pom.xml
+++ b/java/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-annotation/pom.xml
@@ -209,6 +209,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/pom.xml
+++ b/java/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.6-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.7-SNAPSHOT</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/java/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/pom.xml
+++ b/java/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/pom.xml
@@ -210,6 +210,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-xml/pom.xml
+++ b/java/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-xml/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.6-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.7-SNAPSHOT</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/java/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-xml/pom.xml
+++ b/java/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-xml/pom.xml
@@ -209,6 +209,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-metrics/pom.xml
+++ b/java/dubbo-samples-metrics/pom.xml
@@ -194,6 +194,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-mock/pom.xml
+++ b/java/dubbo-samples-mock/pom.xml
@@ -218,6 +218,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
 </project>

--- a/java/dubbo-samples-monitor/pom.xml
+++ b/java/dubbo-samples-monitor/pom.xml
@@ -194,6 +194,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-multi-registry/pom.xml
+++ b/java/dubbo-samples-multi-registry/pom.xml
@@ -189,6 +189,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-nacos/dubbo-samples-nacos-conditionrouter/pom.xml
+++ b/java/dubbo-samples-nacos/dubbo-samples-nacos-conditionrouter/pom.xml
@@ -226,6 +226,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-nacos/dubbo-samples-nacos-configcenter/pom.xml
+++ b/java/dubbo-samples-nacos/dubbo-samples-nacos-configcenter/pom.xml
@@ -208,6 +208,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-nacos/dubbo-samples-nacos-override/pom.xml
+++ b/java/dubbo-samples-nacos/dubbo-samples-nacos-override/pom.xml
@@ -208,6 +208,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-nacos/dubbo-samples-nacos-registry/pom.xml
+++ b/java/dubbo-samples-nacos/dubbo-samples-nacos-registry/pom.xml
@@ -208,6 +208,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-nacos/dubbo-samples-nacos-tagrouter/pom.xml
+++ b/java/dubbo-samples-nacos/dubbo-samples-nacos-tagrouter/pom.xml
@@ -225,6 +225,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-notify/pom.xml
+++ b/java/dubbo-samples-notify/pom.xml
@@ -189,6 +189,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-protobuf/protobuf-consumer/pom.xml
+++ b/java/dubbo-samples-protobuf/protobuf-consumer/pom.xml
@@ -28,6 +28,8 @@
     <description>The demo consumer module of dubbo project</description>
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
+        <zookeeper.version>3.4.3</zookeeper.version>
+        <dubbo.configcenter.zookeeper.version>2.7.4</dubbo.configcenter.zookeeper.version>
     </properties>
     <dependencies>
         <dependency>
@@ -65,6 +67,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-configcenter-zookeeper</artifactId>
+            <version>${dubbo.configcenter.zookeeper.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/java/dubbo-samples-protobuf/protobuf-provider/pom.xml
+++ b/java/dubbo-samples-protobuf/protobuf-provider/pom.xml
@@ -31,6 +31,8 @@
         <spring-test.version>4.3.16.RELEASE</spring-test.version>
         <skip_maven_deploy>true</skip_maven_deploy>
         <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
+        <zookeeper.version>3.4.3</zookeeper.version>
+        <dubbo.configcenter.zookeeper.version>2.7.4</dubbo.configcenter.zookeeper.version>
     </properties>
 
     <dependencies>
@@ -65,6 +67,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-configcenter-zookeeper</artifactId>
+            <version>${dubbo.configcenter.zookeeper.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/java/dubbo-samples-resilience4j/dubbo-samples-resilience4j-filter/pom.xml
+++ b/java/dubbo-samples-resilience4j/dubbo-samples-resilience4j-filter/pom.xml
@@ -35,6 +35,7 @@
         <dubbo.version>2.7.5</dubbo.version>
         <dubbo.rpc.version>2.7.5</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
+        <dubbo.configcenter.zookeeper.version>2.7.4</dubbo.configcenter.zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>
@@ -191,6 +192,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-configcenter-zookeeper</artifactId>
+            <version>${dubbo.configcenter.zookeeper.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/java/dubbo-samples-resilience4j/dubbo-samples-resilience4j-springboot2/pom.xml
+++ b/java/dubbo-samples-resilience4j/dubbo-samples-resilience4j-springboot2/pom.xml
@@ -36,6 +36,7 @@
         <dubbo.version>2.7.5</dubbo.version>
         <dubbo.rpc.version>2.7.5</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
+        <dubbo.configcenter.zookeeper.version>2.7.4</dubbo.configcenter.zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>
@@ -192,6 +193,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-configcenter-zookeeper</artifactId>
+            <version>${dubbo.configcenter.zookeeper.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/java/dubbo-samples-rest/pom.xml
+++ b/java/dubbo-samples-rest/pom.xml
@@ -370,5 +370,19 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/java/dubbo-samples-rest/pom.xml
+++ b/java/dubbo-samples-rest/pom.xml
@@ -33,6 +33,7 @@
         <dubbo.version>2.7.5</dubbo.version>
         <dubbo.rpc.version>2.7.5</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
+        <dubbo.configcenter.zookeeper.version>2.7.4</dubbo.configcenter.zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>
@@ -188,6 +189,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-configcenter-zookeeper</artifactId>
+            <version>${dubbo.configcenter.zookeeper.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -229,6 +231,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
+            <version>${spring.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/java/dubbo-samples-scala/pom.xml
+++ b/java/dubbo-samples-scala/pom.xml
@@ -33,6 +33,7 @@
         <dubbo.version>2.7.5</dubbo.version>
         <dubbo.rpc.version>2.7.5</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
+        <dubbo.configcenter.zookeeper.version>2.7.4</dubbo.configcenter.zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <hibernate-validator.version>4.2.0.Final</hibernate-validator.version>
@@ -189,6 +190,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-configcenter-zookeeper</artifactId>
+            <version>${dubbo.configcenter.zookeeper.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/java/dubbo-samples-scala/pom.xml
+++ b/java/dubbo-samples-scala/pom.xml
@@ -350,5 +350,19 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/java/dubbo-samples-serialization/dubbo-samples-serialization-java/pom.xml
+++ b/java/dubbo-samples-serialization/dubbo-samples-serialization-java/pom.xml
@@ -186,6 +186,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-annotation/pom.xml
+++ b/java/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-annotation/pom.xml
@@ -190,6 +190,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-annotation/pom.xml
+++ b/java/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-annotation/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.6-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.7-SNAPSHOT</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/java/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-nosimple/pom.xml
+++ b/java/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-nosimple/pom.xml
@@ -190,6 +190,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-nosimple/pom.xml
+++ b/java/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-nosimple/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.6-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.7-SNAPSHOT</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/java/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-properties/pom.xml
+++ b/java/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-properties/pom.xml
@@ -189,6 +189,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-properties/pom.xml
+++ b/java/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-properties/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.6-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.6</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/java/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-xml/pom.xml
+++ b/java/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-xml/pom.xml
@@ -190,6 +190,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-xml/pom.xml
+++ b/java/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-xml/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.6-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.6</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/java/dubbo-samples-spi-compatible/pom.xml
+++ b/java/dubbo-samples-spi-compatible/pom.xml
@@ -186,6 +186,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-spring-hystrix/pom.xml
+++ b/java/dubbo-samples-spring-hystrix/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.5</dubbo.version>
+        <dubbo.version>2.7.7-SNAPSHOT</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <hystrix.version>1.5.18</hystrix.version>
         <junit.version>4.12</junit.version>
@@ -165,6 +165,7 @@
                                         </ports>
                                         <wait>
                                             <log>dubbo service started</log>
+                                            <time>20000</time>
                                         </wait>
                                     </run>
                                 </image>

--- a/java/dubbo-samples-spring-hystrix/pom.xml
+++ b/java/dubbo-samples-spring-hystrix/pom.xml
@@ -212,6 +212,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-spring-hystrix/src/main/resources/log4j.properties
+++ b/java/dubbo-samples-spring-hystrix/src/main/resources/log4j.properties
@@ -18,7 +18,7 @@
 #
 
 ###set log levels###
-log4j.rootLogger=info, stdout
+log4j.rootLogger=debug, stdout
 ###output to the console###
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out

--- a/java/dubbo-samples-spring-hystrix/src/main/resources/spring/hystrix-dubbo-provider.properties
+++ b/java/dubbo-samples-spring-hystrix/src/main/resources/spring/hystrix-dubbo-provider.properties
@@ -17,6 +17,7 @@
 #
 #
 dubbo.application.name=hystrix-annotation-provider
+dubbo.application.qos.enable=disable
 dubbo.registry.address=zookeeper://${zookeeper.address:127.0.0.1}:2181
 dubbo.protocol.name=dubbo
 dubbo.protocol.port=20885

--- a/java/dubbo-samples-stub/pom.xml
+++ b/java/dubbo-samples-stub/pom.xml
@@ -189,6 +189,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-stub/pom.xml
+++ b/java/dubbo-samples-stub/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.6-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.6</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>

--- a/java/dubbo-samples-switch-serialization-thread/pom.xml
+++ b/java/dubbo-samples-switch-serialization-thread/pom.xml
@@ -186,6 +186,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-thrift/dubbo-samples-thrift-impl/pom.xml
+++ b/java/dubbo-samples-thrift/dubbo-samples-thrift-impl/pom.xml
@@ -227,5 +227,19 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/java/dubbo-samples-transaction/pom.xml
+++ b/java/dubbo-samples-transaction/pom.xml
@@ -336,6 +336,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-validation/pom.xml
+++ b/java/dubbo-samples-validation/pom.xml
@@ -214,6 +214,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-validation/pom.xml
+++ b/java/dubbo-samples-validation/pom.xml
@@ -29,9 +29,12 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.6-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.7-SNAPSHOT</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
+        <validation.api.version>2.0.1.Final</validation.api.version>
+        <hibernate.validator.version>6.1.2.Final</hibernate.validator.version>
+        <javax.el.version>3.0.0</javax.el.version>
         <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>
         <jib-maven-plugin.version>1.2.0</jib-maven-plugin.version>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
@@ -72,16 +75,19 @@
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
+            <version>${validation.api.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
+            <version>${hibernate.validator.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.el</artifactId>
+            <version>${javax.el.version}</version>
         </dependency>
 
         <dependency>

--- a/java/dubbo-samples-version/pom.xml
+++ b/java/dubbo-samples-version/pom.xml
@@ -237,6 +237,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-zipkin/pom.xml
+++ b/java/dubbo-samples-zipkin/pom.xml
@@ -28,7 +28,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.6-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.7.7-SNAPSHOT</dubbo.version>
         <curator.version>2.12.0</curator.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>

--- a/java/dubbo-samples-zipkin/pom.xml
+++ b/java/dubbo-samples-zipkin/pom.xml
@@ -297,6 +297,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>

--- a/java/dubbo-samples-zookeeper/pom.xml
+++ b/java/dubbo-samples-zookeeper/pom.xml
@@ -201,6 +201,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>


### PR DESCRIPTION
See [DubboIssue#5793](https://github.com/apache/dubbo/issues/5793)

use jdk11 

Becase  `[AbstractConfig.addIntoConfigManager()](https://github.com/apache/dubbo/blob/12d99d686f3b7946758a02554f81f562fc394419/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractConfig.java#L577)`  has  `@PostConstruct` annotation but Jdk11 removed JavaEE 

So when use Jdk11 to run sample , it will throw exception:
```
Exception in thread "main" java.lang.IllegalStateException: No application config found or it's not a valid config! Please add <dubbo:application name="..." /> to your spring config.
	at org.apache.dubbo.config.utils.ConfigValidationUtils.validateApplicationConfig(ConfigValidationUtils.java:371)
	at org.apache.dubbo.config.bootstrap.DubboBootstrap.checkGlobalConfigs(DubboBootstrap.java:529)
	at org.apache.dubbo.config.bootstrap.DubboBootstrap.initialize(DubboBootstrap.java:514)
	at org.apache.dubbo.config.bootstrap.DubboBootstrap.start(DubboBootstrap.java:698)
	at org.apache.dubbo.config.spring.context.DubboBootstrapApplicationListener.onContextRefreshedEvent(DubboBootstrapApplicationListener.java:52)
	at org.apache.dubbo.config.spring.context.DubboBootstrapApplicationListener.onApplicationContextEvent(DubboBootstrapApplicationListener.java:45)
	at org.apache.dubbo.config.spring.context.OneTimeExecutionApplicationContextEventListener.onApplicationEvent(OneTimeExecutionApplicationContextEventListener.java:40)
	at org.springframework.context.event.SimpleApplicationEventMulticaster.doInvokeListener(SimpleApplicationEventMulticaster.java:172)
	at org.springframework.context.event.SimpleApplicationEventMulticaster.invokeListener(SimpleApplicationEventMulticaster.java:165)
	at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:139)
	at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:393)
	at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:347)
	at org.springframework.context.support.AbstractApplicationContext.finishRefresh(AbstractApplicationContext.java:883)
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:546)
	at org.springframework.context.support.ClassPathXmlApplicationContext.<init>(ClassPathXmlApplicationContext.java:139)
	at org.springframework.context.support.ClassPathXmlApplicationContext.<init>(ClassPathXmlApplicationContext.java:83)
```

add profile

```
<profile>
            <id>javax.annotation</id>
            <activation>
                <jdk>[1.11,)</jdk>
            </activation>
            <dependencies>
                <dependency>
                    <groupId>javax.annotation</groupId>
                    <artifactId>javax.annotation-api</artifactId>
                    <version>1.3.2</version>
                </dependency>
            </dependencies>
</profile>
```

It will activation dependency when use jdk 11