### PR TITLE
fix builtin zookeeper address

### DIFF
--- a/test/dubbo-scenario-builder/src/main/resources/configs/app-builtin-zookeeper.yml
+++ b/test/dubbo-scenario-builder/src/main/resources/configs/app-builtin-zookeeper.yml
@@ -36,7 +36,7 @@ services:
     basedir: .
     mainClass: ${main_class}
     systemProps:
-      - zookeeper.address=127.0.0.1
+      - zookeeper.address=${project_name}
       - zookeeper.port=${zookeeper_port}
 #    checkPortsAfterRun:
 #      - ${zookeeper_port}


### PR DESCRIPTION
set builtin zookeeper address to hostname, fix error of configcenter share provider's zookeeper address