### PR TITLE
Remove unused dependencies

### DIFF
--- a/dubbo-maven-address-plugin/pom.xml
+++ b/dubbo-maven-address-plugin/pom.xml
@@ -38,6 +38,20 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>${maven-plugin.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.enterprise</groupId>
+                    <artifactId>cdi-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-component-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.inject</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
@@ -48,6 +62,36 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>${maven-plugin.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.sonatype.plexus</groupId>
+                    <artifactId>plexus-sec-dispatcher</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.inject</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-component-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.j2objc</groupId>
+                    <artifactId>j2objc-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/dubbo-maven-address-plugin/pom.xml
+++ b/dubbo-maven-address-plugin/pom.xml
@@ -44,10 +44,6 @@
                     <artifactId>cdi-api</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.codehaus.plexus</groupId>
-                    <artifactId>plexus-component-annotations</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>javax.inject</groupId>
                     <artifactId>javax.inject</artifactId>
                 </exclusion>
@@ -70,27 +66,7 @@
                 <exclusion>
                     <groupId>javax.inject</groupId>
                     <artifactId>javax.inject</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.codehaus.plexus</groupId>
-                    <artifactId>plexus-component-annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>animal-sniffer-annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.j2objc</groupId>
-                    <artifactId>j2objc-annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.errorprone</groupId>
-                    <artifactId>error_prone_annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.code.findbugs</groupId>
-                    <artifactId>jsr305</artifactId>
-                </exclusion>
+               </exclusion>
             </exclusions>
         </dependency>
     </dependencies>


### PR DESCRIPTION
@chickenlj Hi, I am a user of project **_org.apache.dubbo:dubbo-maven-address-plugin:1.0-SNAPSHOT_**. I found that its pom file introduced **_39_** dependencies. However, among them, **_10_** libraries (**_25%_**) have not been used by your project (the redundant dependencies are listed below). This PR helps **_org.apache.dubbo:dubbo-maven-address-plugin:1.0-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
com.google.code.findbugs:jsr305:jar:3.0.2:compile
org.sonatype.plexus:plexus-sec-dispatcher:jar:1.4:compile
com.google.j2objc:j2objc-annotations:jar:1.1:compile
org.codehaus.mojo:animal-sniffer-annotations:jar:1.14:compile
javax.enterprise:cdi-api:jar:1.0:compile
com.google.errorprone:error_prone_annotations:jar:2.1.3:compile
org.codehaus.plexus:plexus-component-annotations:jar:1.7.1:compile
javax.inject:javax.inject:jar:1:compile
javax.annotation:jsr250-api:jar:1.0:compile
org.sonatype.plexus:plexus-cipher:jar:1.4:compile
</code></pre>