### PR TITLE
Improve consumer metadata checking tests compatible with dubbo 3

### DIFF
--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-configcenter/src/main/java/org/apache/dubbo/samples/metadatareport/configcenter/action/AnnotationAction.java
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-configcenter/src/main/java/org/apache/dubbo/samples/metadatareport/configcenter/action/AnnotationAction.java
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component;
 @Component("annotationAction")
 public class AnnotationAction {
 
-    @Reference(version = "1.1.1", group = "d-test")
+    @Reference(version = "1.1.1", group = "d-test", init = true)
     private AnnotationService annotationService;
 
     public String doSayHello(String name) {

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-annotation/src/main/java/org/apache/dubbo/samples/metadatareport/local/annotation/action/AnnotationAction.java
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-annotation/src/main/java/org/apache/dubbo/samples/metadatareport/local/annotation/action/AnnotationAction.java
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component;
 @Component("annotationAction")
 public class AnnotationAction {
 
-    @Reference(version = "1.1.8", group = "d-test")
+    @Reference(version = "1.1.8", group = "d-test", init = true)
     private AnnotationService annotationService;
 
     public String doSayHello(String name) {

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/src/main/resources/spring/metadata-consumer.xml
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/src/main/resources/spring/metadata-consumer.xml
@@ -29,6 +29,6 @@
 
     <dubbo:metadata-report address="zookeeper://${zookeeper.address:127.0.0.1}:2181"/>
 
-    <dubbo:reference id="demoService"
+    <dubbo:reference id="demoService" init="true"
                      interface="org.apache.dubbo.samples.metadatareport.local.properties.api.DemoService"/>
 </beans>

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/src/test/java/org/apache/dubbo/samples/metadatareport/local/properties/MetadataIT.java
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/src/test/java/org/apache/dubbo/samples/metadatareport/local/properties/MetadataIT.java
@@ -131,6 +131,7 @@ public class MetadataIT {
      */
     @Test
     public void testConsumerMetadata() throws Exception {
+
         //wait for consumer metadata report finish
         Thread.sleep(1000);
 

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-xml/src/main/resources/spring/metadata-consumer.xml
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-xml/src/main/resources/spring/metadata-consumer.xml
@@ -30,6 +30,6 @@
     <dubbo:metadata-report address="zookeeper://${zookeeper.address:127.0.0.1}:2181" group="dubbo3" cycle-report="false"
                            retry-period="4590" sync-report="true" retry-times="23"/>
 
-    <dubbo:reference id="demoService" interface="org.apache.dubbo.samples.metadatareport.local.xml.api.DemoService"/>
+    <dubbo:reference id="demoService" interface="org.apache.dubbo.samples.metadatareport.local.xml.api.DemoService" init="true"/>
 
 </beans>

--- a/dubbo-samples-nacos/dubbo-samples-nacos-override/src/test/java/org/apache/dubbo/samples/governance/DemoServiceIT.java
+++ b/dubbo-samples-nacos/dubbo-samples-nacos-override/src/test/java/org/apache/dubbo/samples/governance/DemoServiceIT.java
@@ -21,35 +21,36 @@ import org.apache.dubbo.rpc.RpcException;
 import org.apache.dubbo.samples.governance.api.DemoService;
 import org.apache.dubbo.samples.governance.util.NacosUtils;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/dubbo-demo-consumer.xml"})
 public class DemoServiceIT {
-    @Autowired
-    private DemoService demoService;
 
     @Test(expected = RpcException.class)
-    public void testWithoutRule() throws Exception {
-        Thread.sleep(2000);
-        demoService.sayHello("world", 3000);
+    public void testWithoutRule() throws Throwable {
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("classpath:/spring/dubbo-demo-consumer.xml");
+        context.start();
+        try {
+            Thread.sleep(2000);
+            DemoService demoService = (DemoService) context.getBean("demoService");
+            demoService.sayHello("world", 3000);
+        } finally {
+            context.close();
+        }
     }
 
     @Test
     public void testWithAppRuleWithSufficientTimeout() throws Throwable {
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("classpath:/spring/dubbo-demo-consumer.xml");
+        context.start();
         try {
             NacosUtils.writeAppRule();
             Thread.sleep(2000);
+            DemoService demoService = (DemoService) context.getBean("demoService");
             Assert.assertTrue(demoService.sayHello("world", 1000).startsWith("Hello world"));
         } finally {
             NacosUtils.clearAppRule();
+            context.close();
         }
     }
 }

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-annotation/src/main/java/org/apache/dubbo/samples/simplified/annotation/action/AnnotationAction.java
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-annotation/src/main/java/org/apache/dubbo/samples/simplified/annotation/action/AnnotationAction.java
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component;
 @Component("annotationAction")
 public class AnnotationAction {
 
-    @Reference(version = "1.1.8", group = "d-test", owner = "vvvanno", retries = 4, actives = 6, timeout = 4500)
+    @Reference(version = "1.1.8", group = "d-test", owner = "vvvanno", retries = 4, actives = 6, timeout = 4500, init = true)
     private AnnotationService annotationService;
 
     public String doSayHello(String name) {

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-nosimple/src/main/resources/spring/simplified-consumer.xml
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-nosimple/src/main/resources/spring/simplified-consumer.xml
@@ -31,5 +31,5 @@
                     check="true"/>
 
     <dubbo:reference id="demoService" interface="org.apache.dubbo.samples.simplified.registry.nosimple.api.DemoService"
-                     owner="vvv" retries="4" actives="6" timeout="4500" version="1.2.3" group="dubbo-simple"/>
+                     owner="vvv" retries="4" actives="6" timeout="4500" version="1.2.3" group="dubbo-simple" init="true"/>
 </beans>

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-properties/src/main/resources/spring/simplified-consumer.xml
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-properties/src/main/resources/spring/simplified-consumer.xml
@@ -26,5 +26,5 @@
 
     <dubbo:reference id="demoService"
                      interface="org.apache.dubbo.samples.simplified.registry.properties.api.DemoService"
-                     owner="vvv" retries="4" actives="6" timeout="4500" version="1.2.3" group="dubbo-simple"/>
+                     owner="vvv" retries="4" actives="6" timeout="4500" version="1.2.3" group="dubbo-simple" init="true"/>
 </beans>

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-xml/src/main/resources/spring/simplified-consumer.xml
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-xml/src/main/resources/spring/simplified-consumer.xml
@@ -28,5 +28,5 @@
     <dubbo:registry address="zookeeper://${zookeeper.address:127.0.0.1}:2181" check="true" simplified="true"/>
 
     <dubbo:reference id="demoService" interface="org.apache.dubbo.samples.simplified.registry.xml.api.DemoService"
-                     owner="vvv" retries="4" actives="6" timeout="4500" version="1.2.3" group="dubbo-simple"/>
+                     owner="vvv" retries="4" actives="6" timeout="4500" version="1.2.3" group="dubbo-simple" init="true"/>
 </beans>


### PR DESCRIPTION
* Improve consumer metadata checking tests compatible with dubbo 3,  set  reference `init=true` to make sure pre-init it in dubbo starting
* Improve `dubbo-samples-nacos-override`  testcase