### PR TITLE
fix: make dubbo-samples 3.x build successfully

### DIFF
--- a/dubbo-samples-SPI-compatible/pom.xml
+++ b/dubbo-samples-SPI-compatible/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.1</dubbo.version>
-        <dubbo.rpc.version>2.7.1-SNAPSHOT</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -203,6 +203,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-compatible</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
     </dependencies>
 

--- a/dubbo-samples-annotation/pom.xml
+++ b/dubbo-samples-annotation/pom.xml
@@ -31,8 +31,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -201,11 +201,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-        </dependency>
-        <!-- Remove this dependency whenever  -->
-        <dependency>
-            <groupId>org.apache.dubbo</groupId>
-            <artifactId>dubbo-metadata-report-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.alibaba.spring</groupId>

--- a/dubbo-samples-api/pom.xml
+++ b/dubbo-samples-api/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-async/dubbo-samples-async-original-future/pom.xml
+++ b/dubbo-samples-async/dubbo-samples-async-original-future/pom.xml
@@ -190,6 +190,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-configcenter-zookeeper</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -202,6 +203,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-configcenter-zookeeper</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -210,10 +212,12 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-rpc-hessian</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-rpc-http</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
     </dependencies>
 

--- a/dubbo-samples-async/dubbo-samples-async-original-future/src/main/java/org/apache/dubbo/samples/governance/filter/AsyncPostprocessFilter.java
+++ b/dubbo-samples-async/dubbo-samples-async-original-future/src/main/java/org/apache/dubbo/samples/governance/filter/AsyncPostprocessFilter.java
@@ -16,7 +16,7 @@
  */
 package org.apache.dubbo.samples.governance.filter;
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.extension.Activate;
 import org.apache.dubbo.rpc.Filter;
 import org.apache.dubbo.rpc.Invocation;
@@ -27,7 +27,7 @@ import org.apache.dubbo.rpc.RpcException;
 /**
  *
  */
-@Activate(group = {Constants.PROVIDER, Constants.CONSUMER})
+@Activate(group = {CommonConstants.PROVIDER, CommonConstants.CONSUMER})
 public class AsyncPostprocessFilter implements Filter {
     @Override
     public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {

--- a/dubbo-samples-async/dubbo-samples-async-original-future/src/main/java/org/apache/dubbo/samples/governance/filter/LegacyBlockFilter.java
+++ b/dubbo-samples-async/dubbo-samples-async-original-future/src/main/java/org/apache/dubbo/samples/governance/filter/LegacyBlockFilter.java
@@ -16,7 +16,7 @@
  */
 package org.apache.dubbo.samples.governance.filter;
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.extension.Activate;
 import org.apache.dubbo.rpc.Filter;
 import org.apache.dubbo.rpc.Invocation;
@@ -27,7 +27,7 @@ import org.apache.dubbo.rpc.RpcException;
 /**
  *
  */
-@Activate(group = {Constants.PROVIDER, Constants.CONSUMER})
+@Activate(group = {CommonConstants.PROVIDER, CommonConstants.CONSUMER})
 public class LegacyBlockFilter implements Filter {
     @Override
     public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {

--- a/dubbo-samples-attachment/pom.xml
+++ b/dubbo-samples-attachment/pom.xml
@@ -32,8 +32,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-basic/pom.xml
+++ b/dubbo-samples-basic/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-cache/pom.xml
+++ b/dubbo-samples-cache/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-callback/pom.xml
+++ b/dubbo-samples-callback/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-chain/dubbo-samples-chain-api/pom.xml
+++ b/dubbo-samples-chain/dubbo-samples-chain-api/pom.xml
@@ -32,8 +32,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -210,6 +210,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-metadata-report-api</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
     </dependencies>
 

--- a/dubbo-samples-chain/dubbo-samples-chain-backend/pom.xml
+++ b/dubbo-samples-chain/dubbo-samples-chain-backend/pom.xml
@@ -32,8 +32,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -210,6 +210,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-metadata-report-api</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-samples-chain/dubbo-samples-chain-front/pom.xml
+++ b/dubbo-samples-chain/dubbo-samples-chain-front/pom.xml
@@ -32,8 +32,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -210,6 +210,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-metadata-report-api</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-samples-chain/dubbo-samples-chain-front/src/main/java/org/apache/dubbo/samples/governance/FrontendConsumer.java
+++ b/dubbo-samples-chain/dubbo-samples-chain-front/src/main/java/org/apache/dubbo/samples/governance/FrontendConsumer.java
@@ -19,7 +19,7 @@
 
 package org.apache.dubbo.samples.governance;
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.rpc.RpcContext;
 import org.apache.dubbo.samples.governance.api.AmericanService;
 import org.apache.dubbo.samples.governance.api.CatService;
@@ -67,7 +67,7 @@ public class FrontendConsumer {
         executorService.submit(() -> {
             while (true) {
                 try {
-                    RpcContext.getContext().setAttachment(Constants.TAG_KEY, "tag1");
+                    RpcContext.getContext().setAttachment(CommonConstants.TAG_KEY, "tag1");
                     DogService dogService = (DogService) context.getBean("dogService");
                     System.out.println(dogService.dog());
                     Thread.sleep(interval);
@@ -102,7 +102,7 @@ public class FrontendConsumer {
         executorService.submit(() -> {
             while (true) {
                 try {
-                    RpcContext.getContext().setAttachment(Constants.TAG_KEY, "tag1");
+                    RpcContext.getContext().setAttachment(CommonConstants.TAG_KEY, "tag1");
                     ChineseService chineseService = (ChineseService) context.getBean("chineseService");
                     System.out.println(chineseService.eat());
                     Thread.sleep(interval);
@@ -117,7 +117,7 @@ public class FrontendConsumer {
         executorService.submit(() -> {
             while (true) {
                 try {
-                    RpcContext.getContext().setAttachment(Constants.TAG_KEY, "tag1");
+                    RpcContext.getContext().setAttachment(CommonConstants.TAG_KEY, "tag1");
                     AmericanService americanService = (AmericanService) context.getBean("americanService");
                     System.out.println(americanService.eat());
                     Thread.sleep(interval);

--- a/dubbo-samples-chain/dubbo-samples-chain-middle/pom.xml
+++ b/dubbo-samples-chain/dubbo-samples-chain-middle/pom.xml
@@ -32,8 +32,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -210,6 +210,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-metadata-report-api</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-samples-compatible/pom.xml
+++ b/dubbo-samples-compatible/pom.xml
@@ -31,8 +31,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-configcenter/dubbo-samples-configcenter-annotation/pom.xml
+++ b/dubbo-samples-configcenter/dubbo-samples-configcenter-annotation/pom.xml
@@ -33,8 +33,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -211,6 +211,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-metadata-report-api</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
     </dependencies>
 

--- a/dubbo-samples-configcenter/dubbo-samples-configcenter-api/pom.xml
+++ b/dubbo-samples-configcenter/dubbo-samples-configcenter-api/pom.xml
@@ -31,8 +31,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-configcenter/dubbo-samples-configcenter-apollo/pom.xml
+++ b/dubbo-samples-configcenter/dubbo-samples-configcenter-apollo/pom.xml
@@ -33,8 +33,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -211,10 +211,12 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-metadata-report-api</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-configcenter-apollo</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
     </dependencies>
 

--- a/dubbo-samples-configcenter/dubbo-samples-configcenter-externalconfiguration/pom.xml
+++ b/dubbo-samples-configcenter/dubbo-samples-configcenter-externalconfiguration/pom.xml
@@ -32,8 +32,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -210,6 +210,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-metadata-report-api</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/dubbo-samples-configcenter/dubbo-samples-configcenter-multi-registries/pom.xml
+++ b/dubbo-samples-configcenter/dubbo-samples-configcenter-multi-registries/pom.xml
@@ -33,8 +33,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -211,6 +211,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-metadata-report-api</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
     </dependencies>
 

--- a/dubbo-samples-configcenter/dubbo-samples-configcenter-multiprotocol/pom.xml
+++ b/dubbo-samples-configcenter/dubbo-samples-configcenter-multiprotocol/pom.xml
@@ -33,8 +33,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -211,14 +211,17 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-metadata-report-api</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-rpc-hessian</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-remoting-http</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/dubbo-samples-configcenter/dubbo-samples-configcenter-xml/pom.xml
+++ b/dubbo-samples-configcenter/dubbo-samples-configcenter-xml/pom.xml
@@ -33,8 +33,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -211,6 +211,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-metadata-report-api</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
     </dependencies>
 

--- a/dubbo-samples-context/pom.xml
+++ b/dubbo-samples-context/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-direct/pom.xml
+++ b/dubbo-samples-direct/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-docker/pom.xml
+++ b/dubbo-samples-docker/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-echo/pom.xml
+++ b/dubbo-samples-echo/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-generic/dubbo-samples-generic-call/pom.xml
+++ b/dubbo-samples-generic/dubbo-samples-generic-call/pom.xml
@@ -219,6 +219,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-metadata-report-api</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
     </dependencies>
 

--- a/dubbo-samples-generic/dubbo-samples-generic-impl/dubbo-samples-generic-impl-api/pom.xml
+++ b/dubbo-samples-generic/dubbo-samples-generic-impl/dubbo-samples-generic-impl-api/pom.xml
@@ -35,8 +35,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-generic/dubbo-samples-generic-impl/pom.xml
+++ b/dubbo-samples-generic/dubbo-samples-generic-impl/pom.xml
@@ -219,6 +219,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-metadata-report-api</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
     </dependencies>
 

--- a/dubbo-samples-generic/dubbo-samples-generic-type/pom.xml
+++ b/dubbo-samples-generic/dubbo-samples-generic-type/pom.xml
@@ -213,6 +213,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-metadata-report-api</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
     </dependencies>
 

--- a/dubbo-samples-governance/dubbo-samples-applevel-override/pom.xml
+++ b/dubbo-samples-governance/dubbo-samples-applevel-override/pom.xml
@@ -32,8 +32,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -210,6 +210,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-metadata-report-api</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
     </dependencies>
 

--- a/dubbo-samples-governance/dubbo-samples-configconditionrouter/pom.xml
+++ b/dubbo-samples-governance/dubbo-samples-configconditionrouter/pom.xml
@@ -31,8 +31,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -209,6 +209,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-metadata-report-api</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
     </dependencies>
 

--- a/dubbo-samples-governance/dubbo-samples-servicelevel-override/pom.xml
+++ b/dubbo-samples-governance/dubbo-samples-servicelevel-override/pom.xml
@@ -32,8 +32,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -210,6 +210,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-metadata-report-api</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
     </dependencies>
 

--- a/dubbo-samples-governance/dubbo-samples-tagrouter/pom.xml
+++ b/dubbo-samples-governance/dubbo-samples-tagrouter/pom.xml
@@ -31,8 +31,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -209,6 +209,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-metadata-report-api</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
     </dependencies>
 

--- a/dubbo-samples-governance/dubbo-samples-tagrouter/src/main/java/org/apache/dubbo/samples/governance/BasicConsumer.java
+++ b/dubbo-samples-governance/dubbo-samples-tagrouter/src/main/java/org/apache/dubbo/samples/governance/BasicConsumer.java
@@ -19,7 +19,7 @@
 
 package org.apache.dubbo.samples.governance;
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.rpc.RpcContext;
 import org.apache.dubbo.samples.governance.api.DemoService;
 import org.apache.dubbo.samples.governance.api.DemoService2;
@@ -37,14 +37,14 @@ public class BasicConsumer {
         while (true) {
             try {
                 Thread.sleep(1000);
-                RpcContext.getContext().setAttachment(Constants.TAG_KEY, "tag1");
+                RpcContext.getContext().setAttachment(CommonConstants.TAG_KEY, "tag1");
                 String hello = demoService.sayHello("world"); // call remote method
                 System.out.println(hello); // get result
             } catch (Throwable throwable) {
                 throwable.printStackTrace();
             }
             try {
-                RpcContext.getContext().setAttachment(Constants.TAG_KEY, "tag2");
+                RpcContext.getContext().setAttachment(CommonConstants.TAG_KEY, "tag2");
 //                RpcContext.getContext().setAttachment(Constants.FORCE_USE_TAG, "true");
                 String hello2 = demoService2.sayHello("world again"); // call remote method
                 System.out.println(hello2); // get result

--- a/dubbo-samples-group/pom.xml
+++ b/dubbo-samples-group/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-http/pom.xml
+++ b/dubbo-samples-http/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -188,6 +188,11 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-configcenter-zookeeper</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-remoting-http</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/dubbo-samples-http/src/main/java/org/apache/dubbo/remoting/http/tomcat/TomcatHttpServer.java
+++ b/dubbo-samples-http/src/main/java/org/apache/dubbo/remoting/http/tomcat/TomcatHttpServer.java
@@ -16,10 +16,11 @@
  */
 package org.apache.dubbo.remoting.http.tomcat;
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.remoting.Constants;
 import org.apache.dubbo.remoting.http.HttpHandler;
 import org.apache.dubbo.remoting.http.servlet.DispatcherServlet;
 import org.apache.dubbo.remoting.http.servlet.ServletManager;
@@ -49,7 +50,7 @@ public class TomcatHttpServer extends AbstractHttpServer {
         tomcat.setBaseDir(baseDir);
         tomcat.setPort(url.getPort());
         tomcat.getConnector().setProperty(
-                "maxThreads", String.valueOf(url.getParameter(Constants.THREADS_KEY, Constants.DEFAULT_THREADS)));
+                "maxThreads", String.valueOf(url.getParameter(CommonConstants.THREADS_KEY, CommonConstants.DEFAULT_THREADS)));
 //        tomcat.getConnector().setProperty(
 //                "minSpareThreads", String.valueOf(url.getParameter(Constants.THREADS_KEY, Constants.DEFAULT_THREADS)));
 

--- a/dubbo-samples-jetty/pom.xml
+++ b/dubbo-samples-jetty/pom.xml
@@ -31,8 +31,8 @@
     <source.level>1.8</source.level>
     <target.level>1.8</target.level>
     <spring.version>4.3.16.RELEASE</spring.version>
-    <dubbo.version>2.7.0</dubbo.version>
-    <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+    <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+    <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
     <zookeeper.version>3.4.13</zookeeper.version>
     <curator.version>4.0.1</curator.version>
     <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-merge/pom.xml
+++ b/dubbo-samples-merge/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-merge/src/main/java/org/apache/dubbo/samples/merge/AnnotationConsumer.java
+++ b/dubbo-samples-merge/src/main/java/org/apache/dubbo/samples/merge/AnnotationConsumer.java
@@ -21,9 +21,9 @@ package org.apache.dubbo.samples.merge;
 
 //import com.alibaba.dubbo.config.spring.context.annotation.EnableDubbo;
 
-import org.apache.dubbo.common.Constants;
 import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.rpc.RpcContext;
+import org.apache.dubbo.rpc.cluster.Constants;
 import org.apache.dubbo.samples.merge.api.MergeService;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-configcenter/pom.xml
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-configcenter/pom.xml
@@ -31,8 +31,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-configcenter/src/main/java/org/apache/dubbo/samples/metadatareport/configcenter/MetadataConfigcenterConsumer.java
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-configcenter/src/main/java/org/apache/dubbo/samples/metadatareport/configcenter/MetadataConfigcenterConsumer.java
@@ -19,11 +19,11 @@
 
 package org.apache.dubbo.samples.metadatareport.configcenter;
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
-import org.apache.dubbo.metadata.identifier.MetadataIdentifier;
+import org.apache.dubbo.metadata.report.identifier.MetadataIdentifier;
 import org.apache.dubbo.remoting.zookeeper.ZookeeperClient;
 import org.apache.dubbo.remoting.zookeeper.ZookeeperTransporter;
 import org.apache.dubbo.samples.metadatareport.configcenter.action.AnnotationAction;
@@ -63,7 +63,7 @@ public class MetadataConfigcenterConsumer {
         // get service data(consumer) from zookeeper.
         ZookeeperClient zookeeperClient = ExtensionLoader.getExtensionLoader(ZookeeperTransporter.class).getExtension("curator").connect(new URL("zookeeper", "127.0.0.1", 2181));
         Thread.sleep(3000);
-        String data = zookeeperClient.getContent(ZkUtil.getNodePath(new MetadataIdentifier(AnnotationService.class.getName(), "1.1.1", "d-test", Constants.CONSUMER_SIDE, "metadatareport-configcenter-consumer")));
+        String data = zookeeperClient.getContent(ZkUtil.getNodePath(new MetadataIdentifier(AnnotationService.class.getName(), "1.1.1", "d-test", CommonConstants.CONSUMER_SIDE, "metadatareport-configcenter-consumer")));
         System.out.println("*********************************************************");
         System.out.println("Dubbo store consumer param into special store(as zk,redis) when configcenter:");
         System.out.println(data);

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-configcenter/src/main/java/org/apache/dubbo/samples/metadatareport/configcenter/MetadataConfigcenterProvider.java
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-configcenter/src/main/java/org/apache/dubbo/samples/metadatareport/configcenter/MetadataConfigcenterProvider.java
@@ -20,12 +20,12 @@
 package org.apache.dubbo.samples.metadatareport.configcenter;
 
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.config.ProviderConfig;
 import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
-import org.apache.dubbo.metadata.identifier.MetadataIdentifier;
+import org.apache.dubbo.metadata.report.identifier.MetadataIdentifier;
 import org.apache.dubbo.remoting.zookeeper.ZookeeperClient;
 import org.apache.dubbo.remoting.zookeeper.ZookeeperTransporter;
 import org.apache.dubbo.samples.metadatareport.configcenter.api.AnnotationService;
@@ -67,7 +67,7 @@ public class MetadataConfigcenterProvider {
         ZookeeperClient zookeeperClient = ExtensionLoader.getExtensionLoader(ZookeeperTransporter.class).getExtension("curator").connect(new URL("zookeeper", "127.0.0.1", 2181));
         Thread.sleep(3000);
 
-        String data = zookeeperClient.getContent(ZkUtil.getNodePath(new MetadataIdentifier(AnnotationService.class.getName(), "1.1.1", "d-test", Constants.PROVIDER_SIDE, "metadatareport-configcenter-provider")));
+        String data = zookeeperClient.getContent(ZkUtil.getNodePath(new MetadataIdentifier(AnnotationService.class.getName(), "1.1.1", "d-test", CommonConstants.PROVIDER_SIDE, "metadatareport-configcenter-provider")));
         System.out.println("*********************************************************");
         System.out.println("Dubbo store metadata into special store(as zk,redis) when configcenter:");
         System.out.println(data);

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-configcenter/src/main/java/org/apache/dubbo/samples/metadatareport/configcenter/ZkUtil.java
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-configcenter/src/main/java/org/apache/dubbo/samples/metadatareport/configcenter/ZkUtil.java
@@ -18,8 +18,9 @@
  */
 package org.apache.dubbo.samples.metadatareport.configcenter;
 
-import org.apache.dubbo.common.Constants;
-import org.apache.dubbo.metadata.identifier.MetadataIdentifier;
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.metadata.report.identifier.KeyTypeEnum;
+import org.apache.dubbo.metadata.report.identifier.MetadataIdentifier;
 
 /**
  * 2018/11/8
@@ -27,13 +28,13 @@ import org.apache.dubbo.metadata.identifier.MetadataIdentifier;
 public class ZkUtil {
 
     static String toRootDir(String root) {
-        if (root.equals(Constants.PATH_SEPARATOR)) {
+        if (root.equals(CommonConstants.PATH_SEPARATOR)) {
             return root;
         }
-        return root + Constants.PATH_SEPARATOR;
+        return root + CommonConstants.PATH_SEPARATOR;
     }
 
     public static String getNodePath(MetadataIdentifier metadataIdentifier) {
-        return toRootDir("/dubbo") + metadataIdentifier.getUniqueKey(MetadataIdentifier.KeyTypeEnum.PATH) + Constants.PATH_SEPARATOR + "service.data";
+        return toRootDir("/dubbo") + metadataIdentifier.getUniqueKey(KeyTypeEnum.PATH) + CommonConstants.PATH_SEPARATOR + "service.data";
     }
 }

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-annotaion/pom.xml
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-annotaion/pom.xml
@@ -31,8 +31,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-annotaion/src/main/java/org/apache/dubbo/samples/metadatareport/local/annotation/MetadataLocalAnnotationConsumer.java
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-annotaion/src/main/java/org/apache/dubbo/samples/metadatareport/local/annotation/MetadataLocalAnnotationConsumer.java
@@ -19,12 +19,12 @@
 
 package org.apache.dubbo.samples.metadatareport.local.annotation;
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.config.MetadataReportConfig;
 import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
-import org.apache.dubbo.metadata.identifier.MetadataIdentifier;
+import org.apache.dubbo.metadata.report.identifier.MetadataIdentifier;
 import org.apache.dubbo.remoting.zookeeper.ZookeeperClient;
 import org.apache.dubbo.remoting.zookeeper.ZookeeperTransporter;
 import org.apache.dubbo.samples.metadatareport.local.annotation.action.AnnotationAction;
@@ -70,7 +70,7 @@ public class MetadataLocalAnnotationConsumer {
         // get service data(consumer) from zookeeper.
         Thread.sleep(3000);
         ZookeeperClient zookeeperClient = ExtensionLoader.getExtensionLoader(ZookeeperTransporter.class).getExtension("curator").connect(new URL("zookeeper", "127.0.0.1", 2181));
-        String data = zookeeperClient.getContent(ZkUtil.getNodePath(new MetadataIdentifier(AnnotationService.class.getName(), "1.1.8", "d-test", Constants.CONSUMER_SIDE, "metadatareport-local-annotaion-consumer")));
+        String data = zookeeperClient.getContent(ZkUtil.getNodePath(new MetadataIdentifier(AnnotationService.class.getName(), "1.1.8", "d-test", CommonConstants.CONSUMER_SIDE, "metadatareport-local-annotaion-consumer")));
         System.out.println("*********************************************************");
         System.out.println("Dubbo store consumer param into special store(as zk,redis)  when local annotation:");
         System.out.println(data);

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-annotaion/src/main/java/org/apache/dubbo/samples/metadatareport/local/annotation/MetadataLocalAnnotationProvider.java
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-annotaion/src/main/java/org/apache/dubbo/samples/metadatareport/local/annotation/MetadataLocalAnnotationProvider.java
@@ -20,13 +20,13 @@
 package org.apache.dubbo.samples.metadatareport.local.annotation;
 
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.config.MetadataReportConfig;
 import org.apache.dubbo.config.ProviderConfig;
 import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
-import org.apache.dubbo.metadata.identifier.MetadataIdentifier;
+import org.apache.dubbo.metadata.report.identifier.MetadataIdentifier;
 import org.apache.dubbo.remoting.zookeeper.ZookeeperClient;
 import org.apache.dubbo.remoting.zookeeper.ZookeeperTransporter;
 import org.apache.dubbo.samples.metadatareport.local.annotation.api.AnnotationService;
@@ -75,7 +75,7 @@ public class MetadataLocalAnnotationProvider {
         // async store
         Thread.sleep(3000);
         ZookeeperClient zookeeperClient = ExtensionLoader.getExtensionLoader(ZookeeperTransporter.class).getExtension("curator").connect(new URL("zookeeper", "127.0.0.1", 2181));
-        String data = zookeeperClient.getContent(ZkUtil.getNodePath(new MetadataIdentifier(AnnotationService.class.getName(), "1.1.8", "d-test", Constants.PROVIDER_SIDE, "metadatareport-local-annotaion-provider")));
+        String data = zookeeperClient.getContent(ZkUtil.getNodePath(new MetadataIdentifier(AnnotationService.class.getName(), "1.1.8", "d-test", CommonConstants.PROVIDER_SIDE, "metadatareport-local-annotaion-provider")));
         System.out.println("*********************************************************");
         System.out.println("Dubbo store metadata into special store(as zk,redis) when local annotation:");
         System.out.println(data);

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-annotaion/src/main/java/org/apache/dubbo/samples/metadatareport/local/annotation/ZkUtil.java
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-annotaion/src/main/java/org/apache/dubbo/samples/metadatareport/local/annotation/ZkUtil.java
@@ -18,8 +18,9 @@
  */
 package org.apache.dubbo.samples.metadatareport.local.annotation;
 
-import org.apache.dubbo.common.Constants;
-import org.apache.dubbo.metadata.identifier.MetadataIdentifier;
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.metadata.report.identifier.KeyTypeEnum;
+import org.apache.dubbo.metadata.report.identifier.MetadataIdentifier;
 
 /**
  * 2018/11/8
@@ -27,13 +28,13 @@ import org.apache.dubbo.metadata.identifier.MetadataIdentifier;
 public class ZkUtil {
 
     static String toRootDir(String root) {
-        if (root.equals(Constants.PATH_SEPARATOR)) {
+        if (root.equals(CommonConstants.PATH_SEPARATOR)) {
             return root;
         }
-        return root + Constants.PATH_SEPARATOR;
+        return root + CommonConstants.PATH_SEPARATOR;
     }
 
     public static String getNodePath(MetadataIdentifier metadataIdentifier) {
-        return toRootDir("/dubbo") + metadataIdentifier.getUniqueKey(MetadataIdentifier.KeyTypeEnum.PATH) + Constants.PATH_SEPARATOR + "service.data";
+        return toRootDir("/dubbo") + metadataIdentifier.getUniqueKey(KeyTypeEnum.PATH) + CommonConstants.PATH_SEPARATOR + "service.data";
     }
 }

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/pom.xml
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/pom.xml
@@ -31,8 +31,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/src/main/java/org/apache/dubbo/samples/metadatareport/local/properties/MetadataLocalpropertiesConsumer.java
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/src/main/java/org/apache/dubbo/samples/metadatareport/local/properties/MetadataLocalpropertiesConsumer.java
@@ -19,10 +19,10 @@
 
 package org.apache.dubbo.samples.metadatareport.local.properties;
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
-import org.apache.dubbo.metadata.identifier.MetadataIdentifier;
+import org.apache.dubbo.metadata.report.identifier.MetadataIdentifier;
 import org.apache.dubbo.remoting.zookeeper.ZookeeperClient;
 import org.apache.dubbo.remoting.zookeeper.ZookeeperTransporter;
 import org.apache.dubbo.samples.metadatareport.local.properties.api.DemoService;
@@ -55,7 +55,7 @@ public class MetadataLocalpropertiesConsumer {
         // get service data(consumer) from zookeeper.
         Thread.sleep(3000);
         ZookeeperClient zookeeperClient = ExtensionLoader.getExtensionLoader(ZookeeperTransporter.class).getExtension("curator").connect(new URL("zookeeper", "127.0.0.1", 2181));
-        String data = zookeeperClient.getContent(ZkUtil.getNodePath(new MetadataIdentifier(DemoService.class.getName(), null, null, Constants.CONSUMER_SIDE, "metadatareport-local-properties-consumer")));
+        String data = zookeeperClient.getContent(ZkUtil.getNodePath(new MetadataIdentifier(DemoService.class.getName(), null, null, CommonConstants.CONSUMER_SIDE, "metadatareport-local-properties-consumer")));
         System.out.println("*********************************************************");
         System.out.println("Dubbo store consumer param into special store(as zk,redis) when local xml:");
         System.out.println(data);

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/src/main/java/org/apache/dubbo/samples/metadatareport/local/properties/MetadataLocalpropertiesProvider.java
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/src/main/java/org/apache/dubbo/samples/metadatareport/local/properties/MetadataLocalpropertiesProvider.java
@@ -19,10 +19,10 @@
 
 package org.apache.dubbo.samples.metadatareport.local.properties;
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
-import org.apache.dubbo.metadata.identifier.MetadataIdentifier;
+import org.apache.dubbo.metadata.report.identifier.MetadataIdentifier;
 import org.apache.dubbo.remoting.zookeeper.ZookeeperClient;
 import org.apache.dubbo.remoting.zookeeper.ZookeeperTransporter;
 import org.apache.dubbo.samples.metadatareport.local.properties.api.DemoService;
@@ -46,7 +46,7 @@ public class MetadataLocalpropertiesProvider {
         // get service data(provider) from zookeeper .
         Thread.sleep(3000);
         ZookeeperClient zookeeperClient = ExtensionLoader.getExtensionLoader(ZookeeperTransporter.class).getExtension("curator").connect(new URL("zookeeper", "127.0.0.1", 2181));
-        String data = zookeeperClient.getContent(ZkUtil.getNodePath(new MetadataIdentifier(DemoService.class.getName(), null, null, Constants.PROVIDER_SIDE, "metadatareport-local-properties-provider2")));
+        String data = zookeeperClient.getContent(ZkUtil.getNodePath(new MetadataIdentifier(DemoService.class.getName(), null, null, CommonConstants.PROVIDER_SIDE, "metadatareport-local-properties-provider2")));
         System.out.println("*********************************************************");
         System.out.println("Dubbo store metadata into special store(as zk,redis) when local xml:");
         System.out.println(data);

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/src/main/java/org/apache/dubbo/samples/metadatareport/local/properties/ZkUtil.java
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/src/main/java/org/apache/dubbo/samples/metadatareport/local/properties/ZkUtil.java
@@ -18,8 +18,9 @@
  */
 package org.apache.dubbo.samples.metadatareport.local.properties;
 
-import org.apache.dubbo.common.Constants;
-import org.apache.dubbo.metadata.identifier.MetadataIdentifier;
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.metadata.report.identifier.KeyTypeEnum;
+import org.apache.dubbo.metadata.report.identifier.MetadataIdentifier;
 
 /**
  * 2018/11/8
@@ -27,13 +28,13 @@ import org.apache.dubbo.metadata.identifier.MetadataIdentifier;
 public class ZkUtil {
 
     static String toRootDir(String root) {
-        if (root.equals(Constants.PATH_SEPARATOR)) {
+        if (root.equals(CommonConstants.PATH_SEPARATOR)) {
             return root;
         }
-        return root + Constants.PATH_SEPARATOR;
+        return root + CommonConstants.PATH_SEPARATOR;
     }
 
     public static String getNodePath(MetadataIdentifier metadataIdentifier) {
-        return toRootDir("/dubbo") + metadataIdentifier.getUniqueKey(MetadataIdentifier.KeyTypeEnum.PATH) + Constants.PATH_SEPARATOR + "service.data";
+        return toRootDir("/dubbo") + metadataIdentifier.getUniqueKey(KeyTypeEnum.PATH) + CommonConstants.PATH_SEPARATOR + "service.data";
     }
 }

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-xml/pom.xml
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-xml/pom.xml
@@ -31,8 +31,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-xml/src/main/java/org/apache/dubbo/samples/metadatareport/local/xml/MetadataLocalXmlConsumer.java
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-xml/src/main/java/org/apache/dubbo/samples/metadatareport/local/xml/MetadataLocalXmlConsumer.java
@@ -19,10 +19,10 @@
 
 package org.apache.dubbo.samples.metadatareport.local.xml;
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
-import org.apache.dubbo.metadata.identifier.MetadataIdentifier;
+import org.apache.dubbo.metadata.report.identifier.MetadataIdentifier;
 import org.apache.dubbo.remoting.zookeeper.ZookeeperClient;
 import org.apache.dubbo.remoting.zookeeper.ZookeeperTransporter;
 import org.apache.dubbo.samples.metadatareport.local.xml.api.DemoService;
@@ -55,7 +55,7 @@ public class MetadataLocalXmlConsumer {
         // get service data(consumer) from zookeeper.
         Thread.sleep(3000);
         ZookeeperClient zookeeperClient = ExtensionLoader.getExtensionLoader(ZookeeperTransporter.class).getExtension("curator").connect(new URL("zookeeper", "127.0.0.1", 2181));
-        String data = zookeeperClient.getContent(ZkUtil.getNodePath(new MetadataIdentifier(DemoService.class.getName(), null, null, Constants.CONSUMER_SIDE, "metadatareport-local-xml-consumer2")));
+        String data = zookeeperClient.getContent(ZkUtil.getNodePath(new MetadataIdentifier(DemoService.class.getName(), null, null, CommonConstants.CONSUMER_SIDE, "metadatareport-local-xml-consumer2")));
         System.out.println("*********************************************************");
         System.out.println("Dubbo store consumer param into special store(as zk,redis) when local xml:");
         System.out.println(data);

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-xml/src/main/java/org/apache/dubbo/samples/metadatareport/local/xml/MetadataLocalXmlProvider.java
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-xml/src/main/java/org/apache/dubbo/samples/metadatareport/local/xml/MetadataLocalXmlProvider.java
@@ -19,10 +19,10 @@
 
 package org.apache.dubbo.samples.metadatareport.local.xml;
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
-import org.apache.dubbo.metadata.identifier.MetadataIdentifier;
+import org.apache.dubbo.metadata.report.identifier.MetadataIdentifier;
 import org.apache.dubbo.remoting.zookeeper.ZookeeperClient;
 import org.apache.dubbo.remoting.zookeeper.ZookeeperTransporter;
 import org.apache.dubbo.samples.metadatareport.local.xml.api.DemoService;
@@ -47,7 +47,7 @@ public class MetadataLocalXmlProvider {
         ZookeeperClient zookeeperClient = ExtensionLoader.getExtensionLoader(ZookeeperTransporter.class).getExtension("curator").connect(new URL("zookeeper", "127.0.0.1", 2181));
 
         Thread.sleep(5000);
-        String data = zookeeperClient.getContent(ZkUtil.getNodePath(new MetadataIdentifier(DemoService.class.getName(), null, null, Constants.PROVIDER_SIDE, "metadatareport-local-xml-provider2")));
+        String data = zookeeperClient.getContent(ZkUtil.getNodePath(new MetadataIdentifier(DemoService.class.getName(), null, null, CommonConstants.PROVIDER_SIDE, "metadatareport-local-xml-provider2")));
         System.out.println("*********************************************************");
         System.out.println("Dubbo store metadata into special store(as zk,redis) when local xml:");
         System.out.println(data);

--- a/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-xml/src/main/java/org/apache/dubbo/samples/metadatareport/local/xml/ZkUtil.java
+++ b/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-xml/src/main/java/org/apache/dubbo/samples/metadatareport/local/xml/ZkUtil.java
@@ -18,8 +18,9 @@
  */
 package org.apache.dubbo.samples.metadatareport.local.xml;
 
-import org.apache.dubbo.common.Constants;
-import org.apache.dubbo.metadata.identifier.MetadataIdentifier;
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.metadata.report.identifier.KeyTypeEnum;
+import org.apache.dubbo.metadata.report.identifier.MetadataIdentifier;
 
 /**
  * 2018/11/8
@@ -27,13 +28,13 @@ import org.apache.dubbo.metadata.identifier.MetadataIdentifier;
 public class ZkUtil {
 
     static String toRootDir(String root) {
-        if (root.equals(Constants.PATH_SEPARATOR)) {
+        if (root.equals(CommonConstants.PATH_SEPARATOR)) {
             return root;
         }
-        return root + Constants.PATH_SEPARATOR;
+        return root + CommonConstants.PATH_SEPARATOR;
     }
 
     public static String getNodePath(MetadataIdentifier metadataIdentifier) {
-        return toRootDir("/dubbo3") + metadataIdentifier.getUniqueKey(MetadataIdentifier.KeyTypeEnum.PATH) + Constants.PATH_SEPARATOR + "service.data";
+        return toRootDir("/dubbo3") + metadataIdentifier.getUniqueKey(KeyTypeEnum.PATH) + CommonConstants.PATH_SEPARATOR + "service.data";
     }
 }

--- a/dubbo-samples-monitor/pom.xml
+++ b/dubbo-samples-monitor/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-multi-registry/pom.xml
+++ b/dubbo-samples-multi-registry/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-notify/pom.xml
+++ b/dubbo-samples-notify/pom.xml
@@ -32,8 +32,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-resilience4j/dubbo-samples-resilience4j-filter/pom.xml
+++ b/dubbo-samples-resilience4j/dubbo-samples-resilience4j-filter/pom.xml
@@ -32,8 +32,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-resilience4j/dubbo-samples-resilience4j-springboot2/pom.xml
+++ b/dubbo-samples-resilience4j/dubbo-samples-resilience4j-springboot2/pom.xml
@@ -33,8 +33,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-rest/pom.xml
+++ b/dubbo-samples-rest/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-scala/pom.xml
+++ b/dubbo-samples-scala/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-annotation/pom.xml
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-annotation/pom.xml
@@ -34,8 +34,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -212,6 +212,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-metadata-report-api</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
     </dependencies>
 

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-annotation/src/main/java/org/apache/dubbo/samples/simplified/annotation/SimpleRegistryAnnotationConsumer.java
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-annotation/src/main/java/org/apache/dubbo/samples/simplified/annotation/SimpleRegistryAnnotationConsumer.java
@@ -19,7 +19,7 @@
 
 package org.apache.dubbo.samples.simplified.annotation;
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.config.RegistryConfig;
@@ -80,7 +80,7 @@ public class SimpleRegistryAnnotationConsumer {
         System.out.println("simple contain 'application':" + urls.get(0).contains("application"));
         System.out.println("simple contain 'version':" + urls.get(0).contains("version"));
         System.out.println("simple contain 'group':" + urls.get(0).contains("group"));
-        System.out.println("simple contain 'specVersion(default)':" + urls.get(0).contains(Constants.RELEASE_KEY));
+        System.out.println("simple contain 'specVersion(default)':" + urls.get(0).contains(CommonConstants.RELEASE_KEY));
         System.out.println("*********************************************************");
     }
 }

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-annotation/src/main/java/org/apache/dubbo/samples/simplified/annotation/SimpleRegistryAnnotationProvider.java
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-annotation/src/main/java/org/apache/dubbo/samples/simplified/annotation/SimpleRegistryAnnotationProvider.java
@@ -20,7 +20,7 @@
 package org.apache.dubbo.samples.simplified.annotation;
 
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.config.ProviderConfig;
@@ -86,7 +86,7 @@ public class SimpleRegistryAnnotationProvider {
         System.out.println("simple contain 'timeout(default)':" + urls.get(0).contains("timeout"));
         System.out.println("simple contain 'version(default)':" + urls.get(0).contains("version"));
         System.out.println("simple contain 'group(default)':" + urls.get(0).contains("group"));
-        System.out.println("simple contain 'specVersion(default)':" + urls.get(0).contains(Constants.RELEASE_KEY));
+        System.out.println("simple contain 'specVersion(default)':" + urls.get(0).contains(CommonConstants.RELEASE_KEY));
         System.out.println("*********************************************************");
     }
 

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-annotation/src/main/java/org/apache/dubbo/samples/simplified/annotation/ZkUtil.java
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-annotation/src/main/java/org/apache/dubbo/samples/simplified/annotation/ZkUtil.java
@@ -18,7 +18,7 @@
  */
 package org.apache.dubbo.samples.simplified.annotation;
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.samples.simplified.annotation.api.AnnotationService;
 
@@ -32,11 +32,11 @@ public class ZkUtil {
 
     private static String toServicePath() {
         String name = AnnotationService.class.getName();
-        return toRootDir() + Constants.PATH_SEPARATOR + URL.encode(name);
+        return toRootDir() + CommonConstants.PATH_SEPARATOR + URL.encode(name);
     }
 
     private static String toCategoryPath(String side) {
-        return toServicePath() + Constants.PATH_SEPARATOR + side;
+        return toServicePath() + CommonConstants.PATH_SEPARATOR + side;
     }
 
     public static String toUrlPath(String side) {

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-nosimple/pom.xml
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-nosimple/pom.xml
@@ -32,8 +32,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -210,6 +210,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-metadata-report-api</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
     </dependencies>
 

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-nosimple/src/main/java/org/apache/dubbo/samples/simplified/registry/nosimple/NoSimpleRegistryConsumer.java
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-nosimple/src/main/java/org/apache/dubbo/samples/simplified/registry/nosimple/NoSimpleRegistryConsumer.java
@@ -19,7 +19,7 @@
 
 package org.apache.dubbo.samples.simplified.registry.nosimple;
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.remoting.zookeeper.ZookeeperClient;
@@ -65,7 +65,7 @@ public class NoSimpleRegistryConsumer {
         System.out.println("simple contain 'application':" + urls.get(0).contains("application"));
         System.out.println("simple contain 'version':" + urls.get(0).contains("version"));
         System.out.println("simple contain 'group':" + urls.get(0).contains("group"));
-        System.out.println("simple contain 'specVersion(default)':" + urls.get(0).contains(Constants.RELEASE_KEY));
+        System.out.println("simple contain 'specVersion(default)':" + urls.get(0).contains(CommonConstants.RELEASE_KEY));
         System.out.println("*********************************************************");
     }
 }

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-nosimple/src/main/java/org/apache/dubbo/samples/simplified/registry/nosimple/NoSimpleRegistryProvider.java
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-nosimple/src/main/java/org/apache/dubbo/samples/simplified/registry/nosimple/NoSimpleRegistryProvider.java
@@ -19,7 +19,7 @@
 
 package org.apache.dubbo.samples.simplified.registry.nosimple;
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.remoting.zookeeper.ZookeeperClient;
@@ -55,7 +55,7 @@ public class NoSimpleRegistryProvider {
         System.out.println("simple contain 'timeout(default)':" + urls.get(0).contains("timeout"));
         System.out.println("simple contain 'version(default)':" + urls.get(0).contains("version"));
         System.out.println("simple contain 'group(default)':" + urls.get(0).contains("group"));
-        System.out.println("simple contain 'specVersion(default)':" + urls.get(0).contains(Constants.RELEASE_KEY));
+        System.out.println("simple contain 'specVersion(default)':" + urls.get(0).contains(CommonConstants.RELEASE_KEY));
         System.out.println("*********************************************************");
     }
 

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-nosimple/src/main/java/org/apache/dubbo/samples/simplified/registry/nosimple/ZkUtil.java
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-nosimple/src/main/java/org/apache/dubbo/samples/simplified/registry/nosimple/ZkUtil.java
@@ -18,7 +18,7 @@
  */
 package org.apache.dubbo.samples.simplified.registry.nosimple;
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.samples.simplified.registry.nosimple.api.DemoService;
 
@@ -33,11 +33,11 @@ public class ZkUtil {
 
     private static String toServicePath() {
         String name = DemoService.class.getName();
-        return toRootDir() + Constants.PATH_SEPARATOR + URL.encode(name);
+        return toRootDir() + CommonConstants.PATH_SEPARATOR + URL.encode(name);
     }
 
     private static String toCategoryPath(String side) {
-        return toServicePath() + Constants.PATH_SEPARATOR + side;
+        return toServicePath() + CommonConstants.PATH_SEPARATOR + side;
     }
 
     public static String toUrlPath(String side) {

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-properties/pom.xml
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-properties/pom.xml
@@ -33,8 +33,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -211,6 +211,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-metadata-report-api</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
     </dependencies>
 

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-properties/src/main/java/org/apache/dubbo/samples/simplified/registry/nosimple/SimpleRegistryPropertiesConsumer.java
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-properties/src/main/java/org/apache/dubbo/samples/simplified/registry/nosimple/SimpleRegistryPropertiesConsumer.java
@@ -19,7 +19,7 @@
 
 package org.apache.dubbo.samples.simplified.registry.nosimple;
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.remoting.zookeeper.ZookeeperClient;
@@ -65,7 +65,7 @@ public class SimpleRegistryPropertiesConsumer {
         System.out.println("simple contain 'application':" + urls.get(0).contains("application"));
         System.out.println("simple contain 'version':" + urls.get(0).contains("version"));
         System.out.println("simple contain 'group':" + urls.get(0).contains("group"));
-        System.out.println("simple contain 'specVersion(default)':" + urls.get(0).contains(Constants.RELEASE_KEY));
+        System.out.println("simple contain 'specVersion(default)':" + urls.get(0).contains(CommonConstants.RELEASE_KEY));
         System.out.println("*********************************************************");
     }
 }

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-properties/src/main/java/org/apache/dubbo/samples/simplified/registry/nosimple/SimpleRegistryPropertiesProvider.java
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-properties/src/main/java/org/apache/dubbo/samples/simplified/registry/nosimple/SimpleRegistryPropertiesProvider.java
@@ -19,7 +19,7 @@
 
 package org.apache.dubbo.samples.simplified.registry.nosimple;
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.remoting.zookeeper.ZookeeperClient;
@@ -55,7 +55,7 @@ public class SimpleRegistryPropertiesProvider {
         System.out.println("simple contain 'timeout(default)':" + urls.get(0).contains("timeout"));
         System.out.println("simple contain 'version(default)':" + urls.get(0).contains("version"));
         System.out.println("simple contain 'group(default)':" + urls.get(0).contains("group"));
-        System.out.println("simple contain 'specVersion(default)':" + urls.get(0).contains(Constants.RELEASE_KEY));
+        System.out.println("simple contain 'specVersion(default)':" + urls.get(0).contains(CommonConstants.RELEASE_KEY));
         System.out.println("*********************************************************");
     }
 

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-properties/src/main/java/org/apache/dubbo/samples/simplified/registry/nosimple/ZkUtil.java
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-properties/src/main/java/org/apache/dubbo/samples/simplified/registry/nosimple/ZkUtil.java
@@ -18,7 +18,7 @@
  */
 package org.apache.dubbo.samples.simplified.registry.nosimple;
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.samples.simplified.registry.nosimple.api.DemoService;
 
@@ -33,11 +33,11 @@ public class ZkUtil {
 
     private static String toServicePath() {
         String name = DemoService.class.getName();
-        return toRootDir() + Constants.PATH_SEPARATOR + URL.encode(name);
+        return toRootDir() + CommonConstants.PATH_SEPARATOR + URL.encode(name);
     }
 
     private static String toCategoryPath(String side) {
-        return toServicePath() + Constants.PATH_SEPARATOR + side;
+        return toServicePath() + CommonConstants.PATH_SEPARATOR + side;
     }
 
     public static String toUrlPath(String side) {

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-xml/pom.xml
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-xml/pom.xml
@@ -32,8 +32,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -210,6 +210,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-metadata-report-api</artifactId>
+            <version>${dubbo.version}</version>
         </dependency>
     </dependencies>
 

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-xml/src/main/java/org/apache/dubbo/samples/simplified/registry/nosimple/SimpleRegistryXmlConsumer.java
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-xml/src/main/java/org/apache/dubbo/samples/simplified/registry/nosimple/SimpleRegistryXmlConsumer.java
@@ -19,7 +19,7 @@
 
 package org.apache.dubbo.samples.simplified.registry.nosimple;
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.remoting.zookeeper.ZookeeperClient;
@@ -65,7 +65,7 @@ public class SimpleRegistryXmlConsumer {
         System.out.println("simple contain 'application':" + urls.get(0).contains("application"));
         System.out.println("simple contain 'version':" + urls.get(0).contains("version"));
         System.out.println("simple contain 'group':" + urls.get(0).contains("group"));
-        System.out.println("simple contain 'specVersion(default)':" + urls.get(0).contains(Constants.RELEASE_KEY));
+        System.out.println("simple contain 'specVersion(default)':" + urls.get(0).contains(CommonConstants.RELEASE_KEY));
         System.out.println("*********************************************************");
     }
 }

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-xml/src/main/java/org/apache/dubbo/samples/simplified/registry/nosimple/SimpleRegistryXmlProvider.java
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-xml/src/main/java/org/apache/dubbo/samples/simplified/registry/nosimple/SimpleRegistryXmlProvider.java
@@ -19,7 +19,7 @@
 
 package org.apache.dubbo.samples.simplified.registry.nosimple;
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.remoting.zookeeper.ZookeeperClient;
@@ -55,7 +55,7 @@ public class SimpleRegistryXmlProvider {
         System.out.println("simple contain 'timeout(default)':" + urls.get(0).contains("timeout"));
         System.out.println("simple contain 'version(default)':" + urls.get(0).contains("version"));
         System.out.println("simple contain 'group(default)':" + urls.get(0).contains("group"));
-        System.out.println("simple contain 'specVersion(default)':" + urls.get(0).contains(Constants.RELEASE_KEY));
+        System.out.println("simple contain 'specVersion(default)':" + urls.get(0).contains(CommonConstants.RELEASE_KEY));
         System.out.println("*********************************************************");
     }
 

--- a/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-xml/src/main/java/org/apache/dubbo/samples/simplified/registry/nosimple/ZkUtil.java
+++ b/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-xml/src/main/java/org/apache/dubbo/samples/simplified/registry/nosimple/ZkUtil.java
@@ -18,7 +18,7 @@
  */
 package org.apache.dubbo.samples.simplified.registry.nosimple;
 
-import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.samples.simplified.registry.nosimple.api.DemoService;
 
@@ -33,11 +33,11 @@ public class ZkUtil {
 
     private static String toServicePath() {
         String name = DemoService.class.getName();
-        return toRootDir() + Constants.PATH_SEPARATOR + URL.encode(name);
+        return toRootDir() + CommonConstants.PATH_SEPARATOR + URL.encode(name);
     }
 
     private static String toCategoryPath(String side) {
-        return toServicePath() + Constants.PATH_SEPARATOR + side;
+        return toServicePath() + CommonConstants.PATH_SEPARATOR + side;
     }
 
     public static String toUrlPath(String side) {

--- a/dubbo-samples-spring-boot-hystrix/pom.xml
+++ b/dubbo-samples-spring-boot-hystrix/pom.xml
@@ -31,8 +31,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-spring-hystrix/pom.xml
+++ b/dubbo-samples-spring-hystrix/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-switch-serialization-thread/pom.xml
+++ b/dubbo-samples-switch-serialization-thread/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-thrift/pom.xml
+++ b/dubbo-samples-thrift/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-validation/pom.xml
+++ b/dubbo-samples-validation/pom.xml
@@ -30,8 +30,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-version/pom.xml
+++ b/dubbo-samples-version/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-zipkin/pom.xml
+++ b/dubbo-samples-zipkin/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/dubbo-samples-zookeeper/pom.xml
+++ b/dubbo-samples-zookeeper/pom.xml
@@ -29,8 +29,8 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
-        <dubbo.version>2.7.0</dubbo.version>
-        <dubbo.rpc.version>2.7.0</dubbo.rpc.version>
+        <dubbo.version>3.0.0-SNAPSHOT</dubbo.version>
+        <dubbo.rpc.version>3.0.0-SNAPSHOT</dubbo.rpc.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <curator.version>4.0.1</curator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>


### PR DESCRIPTION
## What is the purpose of the change

Make 3.x branch build successfully, see #313 

## Brief changelog

1. Update all `dubbo.version` and `dubbo.rpc.version` from `2.7.0-SNAPSHOT` to `3.0.0-SNAPSHOT`
2. Update from `org.apache.dubbo.common.Constants` to `org.apache.dubbo.common.constants.CommonConstants`
3. Update from `org.apache.dubbo.metadata.identifier.MetadataIdentifier` to `org.apache.dubbo.metadata.report.identifier.MetadataIdentifier`
4. Update from `org.apache.dubbo.metadata.identifier.MetadataIdentifier.KeyTypeEnum` to `org.apache.dubbo.metadata.report.identifier.KeyTypeEnum`