### PR TITLE
Disable snapshot update

### DIFF
--- a/.github/workflows/dubbo-2.yml
+++ b/.github/workflows/dubbo-2.yml
@@ -17,7 +17,7 @@ env:
   FORK_COUNT: 2
   FAIL_FAST: 0
   SHOW_ERROR_DETAIL: 1
-  BUILD_OPTS: --batch-mode --no-transfer-progress --settings ${{github.workspace}}/.mvn/settings.xml
+  BUILD_OPTS: --batch-mode --no-snapshot-updates --no-transfer-progress --settings ${{github.workspace}}/.mvn/settings.xml
     -Dmaven.wagon.http.retryHandler.count=3 clean package dependency:copy-dependencies -DskipTests
   #multi-version size limit
   VERSIONS_LIMIT: 4
@@ -98,7 +98,7 @@ jobs:
       - name: Build dubbo
         if: steps.dubbocache.outputs.cache-hit != 'true'
         run: |
-          ./mvnw --batch-mode --no-transfer-progress  clean install -Dmaven.test.skip=true -Dmaven.test.skip.exec=true
+          ./mvnw --batch-mode --no-snapshot-updates --no-transfer-progress  clean install -Dmaven.test.skip=true -Dmaven.test.skip.exec=true
 
   prepare_test:
     runs-on: ubuntu-latest

--- a/.github/workflows/dubbo-3.yml
+++ b/.github/workflows/dubbo-3.yml
@@ -17,7 +17,7 @@ env:
   FORK_COUNT: 2
   FAIL_FAST: 0
   SHOW_ERROR_DETAIL: 1
-  BUILD_OPTS: --batch-mode --no-transfer-progress --settings ${{github.workspace}}/.mvn/settings.xml
+  BUILD_OPTS: --batch-mode --no-snapshot-updates --no-transfer-progress --settings ${{github.workspace}}/.mvn/settings.xml
     -Dmaven.wagon.http.retryHandler.count=3 clean package dependency:copy-dependencies -DskipTests
   #multi-version size limit
   VERSIONS_LIMIT: 4
@@ -98,7 +98,7 @@ jobs:
       - name: Build dubbo
         if: steps.dubbocache.outputs.cache-hit != 'true'
         run: |
-          ./mvnw --batch-mode --no-transfer-progress  clean install -Dmaven.test.skip=true -Dmaven.test.skip.exec=true
+          ./mvnw --batch-mode --no-snapshot-updates --no-transfer-progress  clean install -Dmaven.test.skip=true -Dmaven.test.skip.exec=true
 
   prepare_test:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-dubbo-2.yml
+++ b/.github/workflows/nightly-dubbo-2.yml
@@ -17,7 +17,7 @@ env:
   FORK_COUNT: 1
   FAIL_FAST: 0
   SHOW_ERROR_DETAIL: 1
-  BUILD_OPTS: --batch-mode --no-transfer-progress --settings ${{github.workspace}}/.mvn/settings.xml
+  BUILD_OPTS: --batch-mode --no-snapshot-updates --no-transfer-progress --settings ${{github.workspace}}/.mvn/settings.xml
     -Dmaven.wagon.http.retryHandler.count=3 clean package dependency:copy-dependencies -DskipTests
   #multi-version size limit
   VERSIONS_LIMIT: 12
@@ -101,7 +101,7 @@ jobs:
       - name: Build dubbo
         if: steps.dubbocache.outputs.cache-hit != 'true'
         run: |
-          ./mvnw --batch-mode --no-transfer-progress  clean install -Dmaven.test.skip=true -Dmaven.test.skip.exec=true
+          ./mvnw --batch-mode --no-snapshot-updates --no-transfer-progress  clean install -Dmaven.test.skip=true -Dmaven.test.skip.exec=true
 
   prepare_test:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-dubbo-3.yml
+++ b/.github/workflows/nightly-dubbo-3.yml
@@ -17,7 +17,7 @@ env:
   FORK_COUNT: 1
   FAIL_FAST: 0
   SHOW_ERROR_DETAIL: 1
-  BUILD_OPTS: --batch-mode --no-transfer-progress --settings ${{github.workspace}}/.mvn/settings.xml
+  BUILD_OPTS: --batch-mode --no-snapshot-updates --no-transfer-progress --settings ${{github.workspace}}/.mvn/settings.xml
     -Dmaven.wagon.http.retryHandler.count=3 clean package dependency:copy-dependencies -DskipTests
   #multi-version size limit
   VERSIONS_LIMIT: 12
@@ -100,7 +100,7 @@ jobs:
       - name: Build dubbo
         if: steps.dubbocache.outputs.cache-hit != 'true'
         run: |
-          ./mvnw --batch-mode --no-transfer-progress  clean install -Dmaven.test.skip=true -Dmaven.test.skip.exec=true
+          ./mvnw --batch-mode --no-snapshot-updates --no-transfer-progress  clean install -Dmaven.test.skip=true -Dmaven.test.skip.exec=true
 
   prepare_test:
     runs-on: ubuntu-latest

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -44,7 +44,7 @@ if [ "$MVN_OPTS" != "" ]; then
 fi
 
 if [ "$BUILD_OPTS" == "" ]; then
-  BUILD_OPTS="$MVN_OPTS --batch-mode --no-transfer-progress clean package dependency:copy-dependencies -DskipTests"
+  BUILD_OPTS="$MVN_OPTS --batch-mode --no-snapshot-updates --no-transfer-progress clean package dependency:copy-dependencies -DskipTests"
 fi
 export BUILD_OPTS=$BUILD_OPTS
 echo "BUILD_OPTS: $BUILD_OPTS"


### PR DESCRIPTION
Add `--no-snapshot-updates` to `mvn` command line , avoid unexpected snapshot jar updates.