### PR TITLE
fix dubbo-sample-configcenter-api module ExternalConfiguration

### DIFF
--- a/dubbo-samples-configcenter/dubbo-samples-configcenter-api/src/main/java/org/apache/dubbo/samples/server/Provider2.java
+++ b/dubbo-samples-configcenter/dubbo-samples-configcenter-api/src/main/java/org/apache/dubbo/samples/server/Provider2.java
@@ -71,7 +71,7 @@ public class Provider2 {
      */
     public static Map<String, String> getExternalConfiguration() {
         Map<String, String> dubboConfigurations = new HashMap<>();
-        dubboConfigurations.put("dubbo.registry.address", "zookeeper://" + zookeeperHost1 + ":" + zookeeperPort1);
+        dubboConfigurations.put("dubbo.registry.address", "zookeeper://" + zookeeperHost2 + ":" + zookeeperPort2);
         // you will need to add the config center address if you want to use the service governance features in 2.7,
         // e.g., overrides and routers, but notice it will not be used for gathering startup configurations.
         dubboConfigurations.put("dubbo.config-center.address", "zookeeper://" + zookeeperHost1 + ":" + zookeeperPort1);


### PR DESCRIPTION
fix dubbo-sample-configcenter-api module ExternalConfiguration

see more detail from #325 