### PR TITLE
Fix configs in dubbo-samples-multi-registry

### DIFF
--- a/dubbo-samples-multi-registry/pom.xml
+++ b/dubbo-samples-multi-registry/pom.xml
@@ -29,7 +29,8 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <dubbo.version>2.7.7</dubbo.version>
+        <dubbo.version>2.7.11</dubbo.version>
+<!--        <dubbo.version>3.0.1-SNAPSHOT</dubbo.version>-->
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>

--- a/dubbo-samples-multi-registry/src/main/java/org/apache/dubbo/samples/multi/registry/MultiRegistryConsumer.java
+++ b/dubbo-samples-multi-registry/src/main/java/org/apache/dubbo/samples/multi/registry/MultiRegistryConsumer.java
@@ -28,15 +28,26 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 public class MultiRegistryConsumer {
 
     public static void main(String[] args) throws Exception {
-        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("spring/multi-registry-consumer.xml");
+//        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("spring/multi-registry-consumer.xml");
+//        context.start();
+//
+//        DemoService demoServiceFormDefault = (DemoService) context.getBean("demoServiceFormDefault");
+//        HelloService helloServiceFormShanghai = (HelloService) context.getBean("helloServiceFormShanghai");
+//        HelloService helloServiceFormBeijing = (HelloService) context.getBean("helloServiceFormBeijing");
+//
+//        System.out.println(demoServiceFormDefault.get("service form default registry"));
+//        System.out.println(helloServiceFormShanghai.sayHello("service form shanghai registry"));
+//        System.out.println(helloServiceFormBeijing.sayHello("service form beijing registry"));
+
+
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("spring/multi-registry-consumer1.xml");
         context.start();
 
-        DemoService demoServiceFormDefault = (DemoService) context.getBean("demoServiceFormDefault");
-        HelloService helloServiceFormShanghai = (HelloService) context.getBean("helloServiceFormShanghai");
-        HelloService helloServiceFormBeijing = (HelloService) context.getBean("helloServiceFormBeijing");
-
-        System.out.println(demoServiceFormDefault.get("service form default registry"));
-        System.out.println(helloServiceFormShanghai.sayHello("service form shanghai registry"));
-        System.out.println(helloServiceFormBeijing.sayHello("service form beijing registry"));
+        DemoService demoService = context.getBean(DemoService.class);
+        HelloService helloService = context.getBean(HelloService.class);
+        System.out.println(demoService.get("service form default registry"));
+        System.out.println(helloService.sayHello("service form shanghai registry"));
     }
+
+
 }

--- a/dubbo-samples-multi-registry/src/main/resources/spring/multi-registry-consumer1.xml
+++ b/dubbo-samples-multi-registry/src/main/resources/spring/multi-registry-consumer1.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:dubbo="http://dubbo.apache.org/schema/dubbo"
+       xmlns="http://www.springframework.org/schema/beans" xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://dubbo.apache.org/schema/dubbo http://dubbo.apache.org/schema/dubbo/dubbo.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+    <context:property-placeholder/>
+
+    <dubbo:application name="multi-registry-consumer"/>
+
+    <dubbo:registry id="beijingRegistry" address="zookeeper://${zookeeper.address:127.0.0.1}:${zookeeper.port.1:2181}" />
+    <dubbo:registry id="shanghaiRegistry" address="zookeeper://${zookeeper.address:127.0.0.1}:${zookeeper.port.2:2182}" />
+
+    <dubbo:reference id="demoService" registry="beijingRegistry" interface="org.apache.dubbo.samples.multi.registry.api.DemoService"/>
+    <dubbo:reference id="helloService" registry="shanghaiRegistry" interface="org.apache.dubbo.samples.multi.registry.api.HelloService"/>
+
+</beans>
+

--- a/dubbo-samples-multi-registry/src/main/resources/spring/multi-registry-consumer2.xml
+++ b/dubbo-samples-multi-registry/src/main/resources/spring/multi-registry-consumer2.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:dubbo="http://dubbo.apache.org/schema/dubbo"
+       xmlns="http://www.springframework.org/schema/beans" xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://dubbo.apache.org/schema/dubbo http://dubbo.apache.org/schema/dubbo/dubbo.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+    <context:property-placeholder/>
+
+    <dubbo:application name="multi-registry-consumer"/>
+
+    <dubbo:registry id="shanghaiRegistry" address="zookeeper://${zookeeper.address:127.0.0.1}:${zookeeper.port.2:2182}" />
+
+    <dubbo:reference id="demoService" interface="org.apache.dubbo.samples.multi.registry.api.DemoService"/>
+    <dubbo:reference id="helloService" interface="org.apache.dubbo.samples.multi.registry.api.HelloService"/>
+
+</beans>
+

--- a/dubbo-samples-multi-registry/src/main/resources/spring/multi-registry-consumer3.xml
+++ b/dubbo-samples-multi-registry/src/main/resources/spring/multi-registry-consumer3.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:dubbo="http://dubbo.apache.org/schema/dubbo"
+       xmlns="http://www.springframework.org/schema/beans" xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://dubbo.apache.org/schema/dubbo http://dubbo.apache.org/schema/dubbo/dubbo.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+    <context:property-placeholder/>
+
+    <dubbo:application name="multi-registry-consumer"/>
+
+    <dubbo:registry id="beijingRegistry" address="zookeeper://${zookeeper.address:127.0.0.1}:${zookeeper.port.1:2181}" />
+
+    <dubbo:reference id="demoService" interface="org.apache.dubbo.samples.multi.registry.api.DemoService"/>
+    <dubbo:reference id="helloService" interface="org.apache.dubbo.samples.multi.registry.api.HelloService"/>
+
+</beans>
+

--- a/dubbo-samples-multi-registry/src/test/java/org/apache/dubbo/samples/multi/registry/MultiRegistryServiceIT.java
+++ b/dubbo-samples-multi-registry/src/test/java/org/apache/dubbo/samples/multi/registry/MultiRegistryServiceIT.java
@@ -1,87 +1,87 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-package org.apache.dubbo.samples.multi.registry;
-
-import org.apache.dubbo.samples.multi.registry.api.DemoService;
-import org.apache.dubbo.samples.multi.registry.api.HelloService;
-
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-import java.util.List;
-
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:/spring/multi-registry-consumer.xml"})
-public class MultiRegistryServiceIT {
-    @Autowired
-    @Qualifier("demoServiceFormDefault")
-    private DemoService defaultDemoService;
-
-    @Autowired
-    @Qualifier("demoServiceFormBeijing")
-    private DemoService beijingDemoService;
-
-    @Autowired
-    @Qualifier("helloServiceFormBeijing")
-    private HelloService beijingHelloService;
-
-    @Autowired
-    @Qualifier("helloServiceFormShanghai")
-    private HelloService shanghaiHelloService;
-
-    @Test
-    public void testDefaultDemoService() throws Exception {
-        Assert.assertEquals("get: demo", defaultDemoService.get("demo"));
-    }
-
-    @Test
-    public void testBeijingDemoService() throws Exception {
-        Assert.assertEquals("get: beijing", beijingDemoService.get("beijing"));
-    }
-
-    @Test
-    public void testBeijingHelloService() throws Exception {
-        Assert.assertEquals("sayHello: beijing", beijingHelloService.sayHello("beijing"));
-    }
-
-    @Test
-    public void testShanghaiHelloService() throws Exception {
-        Assert.assertEquals("sayHello: shanghai", shanghaiHelloService.sayHello("shanghai"));
-    }
-
-    @Test
-    public void verifyProvidersFromBeijingRegistry() throws Exception {
-        List<String> demoServiceProviders = ZKTools.getProviders(DemoService.class, 2181);
-        Assert.assertEquals(1, demoServiceProviders.size());
-        List<String> helloServiceProviders = ZKTools.getProviders(HelloService.class, 2181);
-        Assert.assertEquals(1, helloServiceProviders.size());
-    }
-
-    @Test
-    public void verifyProvidersFromShanghaiRegistry() throws Exception {
-        List<String> demoServiceProviders = ZKTools.getProviders(DemoService.class, 2182);
-        Assert.assertEquals(1, demoServiceProviders.size());
-        List<String> helloServiceProviders = ZKTools.getProviders(HelloService.class, 2182);
-        Assert.assertEquals(1, helloServiceProviders.size());
-    }
-}
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one or more
+// * contributor license agreements.  See the NOTICE file distributed with
+// * this work for additional information regarding copyright ownership.
+// * The ASF licenses this file to You under the Apache License, Version 2.0
+// * (the "License"); you may not use this file except in compliance with
+// * the License.  You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//
+//package org.apache.dubbo.samples.multi.registry;
+//
+//import org.apache.dubbo.samples.multi.registry.api.DemoService;
+//import org.apache.dubbo.samples.multi.registry.api.HelloService;
+//
+//import org.junit.Assert;
+//import org.junit.Test;
+//import org.junit.runner.RunWith;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.beans.factory.annotation.Qualifier;
+//import org.springframework.test.context.ContextConfiguration;
+//import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+//
+//import java.util.List;
+//
+//@RunWith(SpringJUnit4ClassRunner.class)
+//@ContextConfiguration(locations = {"classpath:/spring/multi-registry-consumer.xml"})
+//public class MultiRegistryServiceIT {
+//    @Autowired
+//    @Qualifier("demoServiceFormDefault")
+//    private DemoService defaultDemoService;
+//
+//    @Autowired
+//    @Qualifier("demoServiceFormBeijing")
+//    private DemoService beijingDemoService;
+//
+//    @Autowired
+//    @Qualifier("helloServiceFormBeijing")
+//    private HelloService beijingHelloService;
+//
+//    @Autowired
+//    @Qualifier("helloServiceFormShanghai")
+//    private HelloService shanghaiHelloService;
+//
+//    @Test
+//    public void testDefaultDemoService() throws Exception {
+//        Assert.assertEquals("get: demo", defaultDemoService.get("demo"));
+//    }
+//
+//    @Test
+//    public void testBeijingDemoService() throws Exception {
+//        Assert.assertEquals("get: beijing", beijingDemoService.get("beijing"));
+//    }
+//
+//    @Test
+//    public void testBeijingHelloService() throws Exception {
+//        Assert.assertEquals("sayHello: beijing", beijingHelloService.sayHello("beijing"));
+//    }
+//
+//    @Test
+//    public void testShanghaiHelloService() throws Exception {
+//        Assert.assertEquals("sayHello: shanghai", shanghaiHelloService.sayHello("shanghai"));
+//    }
+//
+//    @Test
+//    public void verifyProvidersFromBeijingRegistry() throws Exception {
+//        List<String> demoServiceProviders = ZKTools.getProviders(DemoService.class, 2181);
+//        Assert.assertEquals(1, demoServiceProviders.size());
+//        List<String> helloServiceProviders = ZKTools.getProviders(HelloService.class, 2181);
+//        Assert.assertEquals(1, helloServiceProviders.size());
+//    }
+//
+//    @Test
+//    public void verifyProvidersFromShanghaiRegistry() throws Exception {
+//        List<String> demoServiceProviders = ZKTools.getProviders(DemoService.class, 2182);
+//        Assert.assertEquals(1, demoServiceProviders.size());
+//        List<String> helloServiceProviders = ZKTools.getProviders(HelloService.class, 2182);
+//        Assert.assertEquals(1, helloServiceProviders.size());
+//    }
+//}

--- a/dubbo-samples-multi-registry/src/test/java/org/apache/dubbo/samples/multi/registry/MultiRegistryServiceSplitIT.java
+++ b/dubbo-samples-multi-registry/src/test/java/org/apache/dubbo/samples/multi/registry/MultiRegistryServiceSplitIT.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.samples.multi.registry;
+
+import org.apache.dubbo.config.bootstrap.DubboBootstrap;
+import org.apache.dubbo.samples.multi.registry.api.DemoService;
+import org.apache.dubbo.samples.multi.registry.api.HelloService;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import java.util.List;
+
+public class MultiRegistryServiceSplitIT {
+
+    @Before
+    public void setUp() {
+        try {
+            DubboBootstrap.reset();
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testConsumer1() throws Exception {
+        ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext("/spring/multi-registry-consumer1.xml");
+        DemoService demoService = applicationContext.getBean(DemoService.class);
+        HelloService helloService = applicationContext.getBean(HelloService.class);
+        Assert.assertEquals("get: demo", demoService.get("demo"));
+        Assert.assertEquals("sayHello: beijing", helloService.sayHello("beijing"));
+    }
+
+    @Test
+    public void testConsumer2() throws Exception {
+        ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext("/spring/multi-registry-consumer2.xml");
+        DemoService demoService = applicationContext.getBean(DemoService.class);
+        HelloService helloService = applicationContext.getBean(HelloService.class);
+        Assert.assertEquals("get: demo", demoService.get("demo"));
+        Assert.assertEquals("sayHello: beijing", helloService.sayHello("beijing"));
+    }
+
+    @Test
+    public void testConsumer3() throws Exception {
+        ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext("/spring/multi-registry-consumer3.xml");
+        DemoService demoService = applicationContext.getBean(DemoService.class);
+        HelloService helloService = applicationContext.getBean(HelloService.class);
+        Assert.assertEquals("get: demo", demoService.get("demo"));
+        Assert.assertEquals("sayHello: beijing", helloService.sayHello("beijing"));
+    }
+
+    @Test
+    public void verifyProvidersFromBeijingRegistry() throws Exception {
+        List<String> demoServiceProviders = ZKTools.getProviders(DemoService.class, 2181);
+        Assert.assertEquals(1, demoServiceProviders.size());
+        List<String> helloServiceProviders = ZKTools.getProviders(HelloService.class, 2181);
+        Assert.assertEquals(1, helloServiceProviders.size());
+    }
+
+    @Test
+    public void verifyProvidersFromShanghaiRegistry() throws Exception {
+        List<String> demoServiceProviders = ZKTools.getProviders(DemoService.class, 2182);
+        Assert.assertEquals(1, demoServiceProviders.size());
+        List<String> helloServiceProviders = ZKTools.getProviders(HelloService.class, 2182);
+        Assert.assertEquals(1, helloServiceProviders.size());
+    }
+}


### PR DESCRIPTION
Split duplicated reference configs into several spring xml