### PR TITLE
[NPE] Fix the reference of demoService is null

### DIFF
--- a/dubbo-samples-spring-boot-hystrix/src/main/java/org/apache/dubbo/spring/boot/consumer/ConsumerApplication.java
+++ b/dubbo-samples-spring-boot-hystrix/src/main/java/org/apache/dubbo/spring/boot/consumer/ConsumerApplication.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.spring.boot.consumer;
 
 import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import org.apache.dubbo.config.annotation.DubboReference;
+import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
 import org.apache.dubbo.spring.boot.api.HelloService;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -28,6 +29,7 @@ import org.springframework.stereotype.Service;
 @SpringBootApplication
 @Service
 @EnableHystrix
+@EnableDubbo
 public class ConsumerApplication {
 
     @DubboReference(version = "1.0.0")

--- a/dubbo-samples-spring-boot-hystrix/src/main/java/org/apache/dubbo/spring/boot/consumer/ConsumerApplication.java
+++ b/dubbo-samples-spring-boot-hystrix/src/main/java/org/apache/dubbo/spring/boot/consumer/ConsumerApplication.java
@@ -46,6 +46,7 @@ public class ConsumerApplication {
 
     @HystrixCommand(fallbackMethod = "reliable")
     public String doSayHello(String name) {
+        // According to author's original purpose, the fallbackMethod is triggered by remote RpcException but not NPE of demoService.
         return demoService.sayHello(name);
     }
 


### PR DESCRIPTION
According to author's original purpose,  the `fallbackMethod` is triggered by remote RpcException but not NPE of `demoService`.

```java
    @HystrixCommand(fallbackMethod = "reliable")
    public String doSayHello(String name) {
        return demoService.sayHello(name);
    }

    public String reliable(String name) {
        return "hystrix fallback value";
    }
```