### PR TITLE
dubbo-samples-spring-boot-triple

### DIFF
--- a/dubbo-samples-spring-boot-triple/README.MD
+++ b/dubbo-samples-spring-boot-triple/README.MD
@@ -1,0 +1,10 @@
+## SpringBoot-Triple-Samples
+1. Run `org.apache.dubbo.sample.tri.TriApplication`
+- zookeeper.port=2181
+- provider.port=50052
+
+### tri --> tri
+2. Run `org.apache.dubbo.sample.tri.direct.TriDirectPbConsumerTest`\
+
+### grpc --> tri
+2. Run `org.apache.dubbo.sample.tri.direct.GrpcDirectPbConsumerTest`

--- a/dubbo-samples-spring-boot-triple/case-configuration.yml
+++ b/dubbo-samples-spring-boot-triple/case-configuration.yml
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  dubbo-samples-spring-boot-triple:
+    type: app
+    basedir: .
+    checkPorts:
+      - 2181
+      - 50052
+    mainClass: org.apache.dubbo.sample.tri.TriApplication
+
+  dubbo-samples-spring-boot-triple-test:
+    type: test
+    basedir: .
+    tests:
+      # tri-->tri
+      - "org.apache.dubbo.sample.tri/TriPbConsumerTest.class"
+      - "org.apache.dubbo.sample.tri/TriWrapConsumerTest.class"
+      - "org.apache.dubbo.sample.tri/TriGenericTest.class"
+      # grpc-->tri
+      - "org.apache.dubbo.sample.tri/grpc/Grpc*Test.class"
+      # tri-->grpc
+      - "org.apache.dubbo.sample.tri.grpc/TriGrpcDirectPbConsumerTest.class"
+    systemProps:
+      - zookeeper.host=dubbo-samples-spring-boot-triple
+      - zookeeper.port=2181
+      - provider.host=dubbo-samples-spring-boot-triple
+      - provider.port=50052
+    waitPortsBeforeRun:
+      - dubbo-samples-spring-boot-triple:2181
+      - dubbo-samples-spring-boot-triple:50052
+    depends_on:
+      - dubbo-samples-spring-boot-triple
+
+
+
+

--- a/dubbo-samples-spring-boot-triple/case-versions.conf
+++ b/dubbo-samples-spring-boot-triple/case-versions.conf
@@ -1,0 +1,24 @@
+#
+#
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Supported component versions of the test case
+
+# Spring app
+dubbo.version=3.*
+spring.version=4.*, 5.*
+spring-boot.version=2.*

--- a/dubbo-samples-spring-boot-triple/pom.xml
+++ b/dubbo-samples-spring-boot-triple/pom.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~  Licensed to the Apache Software Foundation (ASF) under one or more
+  ~  contributor license agreements.  See the NOTICE file distributed with
+  ~  this work for additional information regarding copyright ownership.
+  ~  The ASF licenses this file to You under the Apache License, Version 2.0
+  ~  (the "License"); you may not use this file except in compliance with
+  ~  the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>dubbo-samples-all</artifactId>
+        <groupId>org.apache.dubbo</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>dubbo-samples-spring-boot-triple</artifactId>
+
+    <properties>
+        <source.level>1.8</source.level>
+        <target.level>1.8</target.level>
+        <dubbo.version>3.0.4</dubbo.version>
+        <grpc.version>1.31.1</grpc.version>
+        <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
+        <maven-failsafe-plugin.version>2.21.0</maven-failsafe-plugin.version>
+        <spring-boot.version>2.3.0.RELEASE</spring-boot.version>
+        <protoc.version>3.7.1</protoc.version>
+        <dubbo.compiler.version>0.0.4-SNAPSHOT</dubbo.compiler.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Spring Boot -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <!-- Apache Dubbo  -->
+            <dependency>
+                <groupId>org.apache.dubbo</groupId>
+                <artifactId>dubbo-dependencies-bom</artifactId>
+                <version>${dubbo.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+<!--            <dependency>-->
+<!--                <groupId>org.apache.dubbo</groupId>-->
+<!--                <artifactId>dubbo</artifactId>-->
+<!--                <version>${dubbo.version}</version>-->
+<!--                <exclusions>-->
+<!--                    <exclusion>-->
+<!--                        <groupId>org.springframework</groupId>-->
+<!--                        <artifactId>spring</artifactId>-->
+<!--                    </exclusion>-->
+<!--                    <exclusion>-->
+<!--                        <groupId>javax.servlet</groupId>-->
+<!--                        <artifactId>servlet-api</artifactId>-->
+<!--                    </exclusion>-->
+<!--                    <exclusion>-->
+<!--                        <groupId>log4j</groupId>-->
+<!--                        <artifactId>log4j</artifactId>-->
+<!--                    </exclusion>-->
+<!--                </exclusions>-->
+<!--            </dependency>-->
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-spring-boot-starter</artifactId>
+            <version>${dubbo.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo</artifactId>
+            <version>${dubbo.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-dependencies-zookeeper</artifactId>
+            <version>${dubbo.version}</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+<!--            <version>3.14.0</version>-->
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-all</artifactId>
+            <version>${grpc.version}</version>
+<!--            <scope>test</scope>-->
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <!-- For jdk 11 above JavaEE annotation -->
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[1.11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
+    <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.6.1</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
+                    <pluginId>grpc-java</pluginId>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+                    <protocPlugins>
+                        <protocPlugin>
+                            <id>dubbo</id>
+                            <groupId>org.apache.dubbo</groupId>
+                            <artifactId>dubbo-compiler</artifactId>
+                            <version>${dubbo.compiler.version}</version>
+                            <mainClass>org.apache.dubbo.gen.dubbo.Dubbo3Generator</mainClass>
+                        </protocPlugin>
+                    </protocPlugins>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>test-compile</goal>
+                            <goal>compile-custom</goal>
+                            <goal>test-compile-custom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <source>${source.level}</source>
+                    <target>${target.level}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/dubbo-samples-spring-boot-triple/src/main/java/org/apache/dubbo/sample/tri/PbGreeterImpl.java
+++ b/dubbo-samples-spring-boot-triple/src/main/java/org/apache/dubbo/sample/tri/PbGreeterImpl.java
@@ -1,0 +1,76 @@
+package org.apache.dubbo.sample.tri;
+
+import org.apache.dubbo.common.stream.StreamObserver;
+import org.apache.dubbo.config.annotation.DubboService;
+import org.apache.dubbo.rpc.RpcContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@DubboService
+public class PbGreeterImpl implements PbGreeter {
+
+    public static final Map<String, Boolean> cancelResultMap = new HashMap<>();
+
+    @Override
+    public GreeterReply greetWithAttachment(GreeterRequest request) {
+        final String key = "user-attachment";
+        final String value = "hello," + RpcContext.getServerAttachment().getAttachment(key);
+        RpcContext.getServerContext().setObjectAttachment(key, value);
+        return GreeterReply.newBuilder().setMessage("hello," + request.getName()).build();
+    }
+
+    @Override
+    public GreeterReply greet(GreeterRequest request) {
+        System.out.println(request.getName());
+        return GreeterReply.newBuilder()
+                .setMessage(request.getName())
+                .build();
+    }
+
+    @Override
+    public GreeterReply greetException(GreeterRequest request) {
+        RpcContext.getServerContext().setAttachment("str", "str")
+                .setAttachment("integer", 1)
+                .setAttachment("raw", new byte[]{1, 2, 3, 4});
+        throw new RuntimeException("Biz Exception");
+    }
+
+    @Override
+    public StreamObserver<GreeterRequest> greetStream(StreamObserver<GreeterReply> replyStream) {
+        return new StreamObserver<GreeterRequest>() {
+            int n = 0;
+
+            @Override
+            public void onNext(GreeterRequest data) {
+                n++;
+                System.out.println(data.getName() + " " + n);
+                replyStream.onNext(GreeterReply.newBuilder()
+                        .setMessage(data.getName() + " " + n)
+                        .build());
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                throwable.printStackTrace();
+                replyStream.onError(new IllegalStateException("Stream err"));
+            }
+
+            @Override
+            public void onCompleted() {
+                System.out.println("[greetStream] onCompleted");
+                replyStream.onCompleted();
+            }
+        };
+    }
+
+    @Override
+    public void greetServerStream(GreeterRequest request, StreamObserver<GreeterReply> replyStream) {
+        for (int i = 0; i < 10; i++) {
+            replyStream.onNext(GreeterReply.newBuilder()
+                    .setMessage(request.getName() + "--" + i)
+                    .build());
+        }
+        replyStream.onCompleted();
+    }
+}

--- a/dubbo-samples-spring-boot-triple/src/main/java/org/apache/dubbo/sample/tri/TriApplication.java
+++ b/dubbo-samples-spring-boot-triple/src/main/java/org/apache/dubbo/sample/tri/TriApplication.java
@@ -1,0 +1,13 @@
+package org.apache.dubbo.sample.tri;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+
+@EnableAutoConfiguration
+public class TriApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(TriApplication.class,args);
+    }
+
+}

--- a/dubbo-samples-spring-boot-triple/src/main/proto/PbGreeter.proto
+++ b/dubbo-samples-spring-boot-triple/src/main/proto/PbGreeter.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+
+package org.apache.dubbo.sample.tri;
+
+service PbGreeter{
+  rpc greet(GreeterRequest) returns (GreeterReply);
+
+  rpc greetWithAttachment (GreeterRequest) returns (GreeterReply);
+
+  rpc greetException(GreeterRequest) returns (GreeterReply);
+
+  rpc greetStream(stream GreeterRequest) returns (stream GreeterReply);
+
+  rpc greetServerStream(GreeterRequest) returns (stream GreeterReply);
+}
+
+// The request message containing the user's name.
+message GreeterRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings
+message GreeterReply {
+  string message = 1;
+}

--- a/dubbo-samples-spring-boot-triple/src/main/resources/application.properties
+++ b/dubbo-samples-spring-boot-triple/src/main/resources/application.properties
@@ -1,0 +1,11 @@
+# Spring boot application
+spring.application.name=dubbo-auto-configuration-provider-demo
+# Base packages to scan Dubbo Component: @org.apache.dubbo.config.annotation.Service
+dubbo.scan.base-packages=org.apache.dubbo.sample.tri
+
+# Dubbo Protocol
+dubbo.protocol.name=tri
+dubbo.protocol.port=50052
+
+## Dubbo Registry
+dubbo.registry.address=N/A

--- a/dubbo-samples-spring-boot-triple/src/test/java/org/apache/dubbo/sample/tri/common/BasePbConsumerTest.java
+++ b/dubbo-samples-spring-boot-triple/src/test/java/org/apache/dubbo/sample/tri/common/BasePbConsumerTest.java
@@ -1,0 +1,103 @@
+package org.apache.dubbo.sample.tri.common;
+
+import org.apache.dubbo.common.stream.StreamObserver;
+import org.apache.dubbo.config.bootstrap.DubboBootstrap;
+import org.apache.dubbo.rpc.RpcContext;
+import org.apache.dubbo.rpc.RpcException;
+import org.apache.dubbo.sample.tri.GreeterReply;
+import org.apache.dubbo.sample.tri.GreeterRequest;
+import org.apache.dubbo.sample.tri.PbGreeter;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author earthchen
+ * @date 2021/9/9
+ **/
+public abstract class BasePbConsumerTest {
+
+    protected static PbGreeter delegate;
+
+    protected static DubboBootstrap appDubboBootstrap;
+
+    @Test
+    public void serverStream() throws InterruptedException {
+        int n = 10;
+        CountDownLatch latch = new CountDownLatch(n);
+        final GreeterRequest request = GreeterRequest.newBuilder()
+                .setName("request")
+                .build();
+        delegate.greetServerStream(request, new StdoutStreamObserver<GreeterReply>("sayGreeterServerStream") {
+            @Override
+            public void onNext(GreeterReply data) {
+                super.onNext(data);
+                latch.countDown();
+            }
+        });
+        Assert.assertTrue(latch.await(3, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void stream() throws InterruptedException {
+        int n = 10;
+        CountDownLatch latch = new CountDownLatch(n);
+        final GreeterRequest request = GreeterRequest.newBuilder()
+                .setName("stream request")
+                .build();
+        final StreamObserver<GreeterRequest> requestObserver = delegate.greetStream(new StdoutStreamObserver<GreeterReply>("sayGreeterStream") {
+            @Override
+            public void onNext(GreeterReply data) {
+                super.onNext(data);
+                latch.countDown();
+            }
+        });
+        for (int i = 0; i < n; i++) {
+            requestObserver.onNext(request);
+        }
+        requestObserver.onCompleted();
+        Assert.assertTrue(latch.await(3, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void unaryGreeter() {
+        final GreeterReply reply = delegate.greet(GreeterRequest.newBuilder()
+                .setName("name")
+                .build());
+        Assert.assertNotNull(reply);
+    }
+
+    @Test(expected = RpcException.class)
+    public void clientSendLargeSizeHeader() {
+        StringBuilder sb = new StringBuilder("a");
+        for (int j = 0; j < 15; j++) {
+            sb.append(sb);
+        }
+        sb.setLength(8000);
+        RpcContext.getClientAttachment().setObjectAttachment("large-size-meta", sb.toString());
+        delegate.greet(GreeterRequest.newBuilder().setName("meta").build());
+        RpcContext.getClientAttachment().clearAttachments();
+    }
+
+    @Test
+    public void attachmentTest() {
+        final String key = "user-attachment";
+        final String value = "attachment-value";
+        RpcContext.removeClientAttachment();
+        RpcContext.getClientAttachment().setAttachment(key, value);
+        GreeterReply reply = delegate.greetWithAttachment(GreeterRequest.newBuilder().setName("meta").build());
+        Assert.assertEquals("hello,meta",reply.getMessage());
+        final String returned = (String) RpcContext.getServerContext().getObjectAttachment(key);
+        Assert.assertEquals("hello," + value, returned);
+    }
+
+    @AfterClass
+    public static void alterTest() {
+        appDubboBootstrap.stop();
+        DubboBootstrap.reset();
+    }
+
+}

--- a/dubbo-samples-spring-boot-triple/src/test/java/org/apache/dubbo/sample/tri/common/EmbeddedZooKeeper.java
+++ b/dubbo-samples-spring-boot-triple/src/test/java/org/apache/dubbo/sample/tri/common/EmbeddedZooKeeper.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.sample.tri.common;
+
+import org.apache.zookeeper.server.ServerConfig;
+import org.apache.zookeeper.server.ZooKeeperServerMain;
+import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.util.ErrorHandler;
+import org.springframework.util.SocketUtils;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.util.Properties;
+import java.util.UUID;
+
+/**
+ * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
+ * <p>
+ * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
+ * <p>
+ * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
+ * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
+ *
+ * @author Patrick Peralta
+ * @author Mark Fisher
+ * @author David Turanski
+ */
+public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    /**
+     * Logger.
+     */
+    private static final Logger logger = LoggerFactory.getLogger(EmbeddedZooKeeper.class);
+
+    /**
+     * ZooKeeper client port. This will be determined dynamically upon startup.
+     */
+    private final int clientPort;
+
+    /**
+     * Whether to auto-start. Default is true.
+     */
+    private boolean autoStartup = true;
+
+    /**
+     * Lifecycle phase. Default is 0.
+     */
+    private int phase = 0;
+
+    /**
+     * Thread for running the ZooKeeper server.
+     */
+    private volatile Thread zkServerThread;
+
+    /**
+     * ZooKeeper server.
+     */
+    private volatile ZooKeeperServerMain zkServer;
+
+    /**
+     * {@link ErrorHandler} to be invoked if an Exception is thrown from the ZooKeeper server thread.
+     */
+    private ErrorHandler errorHandler;
+
+    private boolean daemon = true;
+
+    /**
+     * Construct an EmbeddedZooKeeper with a random port.
+     */
+    public EmbeddedZooKeeper() {
+        clientPort = SocketUtils.findAvailableTcpPort();
+    }
+
+    /**
+     * Construct an EmbeddedZooKeeper with the provided port.
+     *
+     * @param clientPort port for ZooKeeper server to bind to
+     */
+    public EmbeddedZooKeeper(int clientPort, boolean daemon) {
+        this.clientPort = clientPort;
+        this.daemon = daemon;
+    }
+
+    /**
+     * Returns the port that clients should use to connect to this embedded server.
+     *
+     * @return dynamically determined client port
+     */
+    public int getClientPort() {
+        return this.clientPort;
+    }
+
+    /**
+     * Specify whether to start automatically. Default is true.
+     *
+     * @param autoStartup whether to start automatically
+     */
+    public void setAutoStartup(boolean autoStartup) {
+        this.autoStartup = autoStartup;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isAutoStartup() {
+        return this.autoStartup;
+    }
+
+    /**
+     * Specify the lifecycle phase for the embedded server.
+     *
+     * @param phase the lifecycle phase
+     */
+    public void setPhase(int phase) {
+        this.phase = phase;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getPhase() {
+        return this.phase;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isRunning() {
+        return (zkServerThread != null);
+    }
+
+    /**
+     * Start the ZooKeeper server in a background thread.
+     * <p>
+     * Register an error handler via {@link #setErrorHandler} in order to handle
+     * any exceptions thrown during startup or execution.
+     */
+    @Override
+    public synchronized void start() {
+        if (zkServerThread == null) {
+            zkServerThread = new Thread(new ServerRunnable(), "ZooKeeper Server Starter");
+            zkServerThread.setDaemon(daemon);
+            zkServerThread.start();
+        }
+    }
+
+    /**
+     * Shutdown the ZooKeeper server.
+     */
+    @Override
+    public synchronized void stop() {
+        if (zkServerThread != null) {
+            // The shutdown method is protected...thus this hack to invoke it.
+            // This will log an exception on shutdown; see
+            // https://issues.apache.org/jira/browse/ZOOKEEPER-1873 for details.
+            try {
+                Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
+                shutdown.setAccessible(true);
+                shutdown.invoke(zkServer);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            // It is expected that the thread will exit after
+            // the server is shutdown; this will block until
+            // the shutdown is complete.
+            try {
+                zkServerThread.join(5000);
+                zkServerThread = null;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
+                // abandoning zk thread
+                zkServerThread = null;
+            }
+        }
+    }
+
+    /**
+     * Stop the server if running and invoke the callback when complete.
+     */
+    @Override
+    public void stop(Runnable callback) {
+        stop();
+        callback.run();
+    }
+
+    /**
+     * Provide an {@link ErrorHandler} to be invoked if an Exception is thrown from the ZooKeeper server thread. If none
+     * is provided, only error-level logging will occur.
+     *
+     * @param errorHandler the {@link ErrorHandler} to be invoked
+     */
+    public void setErrorHandler(ErrorHandler errorHandler) {
+        this.errorHandler = errorHandler;
+    }
+
+    /**
+     * Runnable implementation that starts the ZooKeeper server.
+     */
+    private class ServerRunnable implements Runnable {
+
+        @Override
+        public void run() {
+            try {
+                Properties properties = new Properties();
+                File file = new File(System.getProperty("java.io.tmpdir")
+                        + File.separator + UUID.randomUUID());
+                file.deleteOnExit();
+                properties.setProperty("dataDir", file.getAbsolutePath());
+                properties.setProperty("clientPort", String.valueOf(clientPort));
+
+                QuorumPeerConfig quorumPeerConfig = new QuorumPeerConfig();
+                quorumPeerConfig.parseProperties(properties);
+
+                zkServer = new ZooKeeperServerMain();
+                ServerConfig configuration = new ServerConfig();
+                configuration.readFrom(quorumPeerConfig);
+
+                zkServer.runFromConfig(configuration);
+            } catch (Exception e) {
+                if (errorHandler != null) {
+                    errorHandler.handleError(e);
+                } else {
+                    logger.error("Exception running embedded ZooKeeper", e);
+                }
+            }
+        }
+    }
+
+}

--- a/dubbo-samples-spring-boot-triple/src/test/java/org/apache/dubbo/sample/tri/common/StdoutStreamObserver.java
+++ b/dubbo-samples-spring-boot-triple/src/test/java/org/apache/dubbo/sample/tri/common/StdoutStreamObserver.java
@@ -1,0 +1,33 @@
+package org.apache.dubbo.sample.tri.common;
+
+import org.apache.dubbo.common.stream.StreamObserver;
+
+/**
+ * @author earthchen
+ * @date 2021/9/6
+ **/
+public class StdoutStreamObserver<T> implements StreamObserver<T>, io.grpc.stub.StreamObserver<T> {
+
+
+    private final String name;
+
+    public StdoutStreamObserver(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public void onNext(T data) {
+        System.out.println("[" + name + "] stream reply:" + data);
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        System.err.println("[" + name + "] Error:");
+        throwable.printStackTrace();
+    }
+
+    @Override
+    public void onCompleted() {
+        System.out.println("[" + name + "] stream done");
+    }
+}

--- a/dubbo-samples-spring-boot-triple/src/test/java/org/apache/dubbo/sample/tri/common/TriSampleConstants.java
+++ b/dubbo-samples-spring-boot-triple/src/test/java/org/apache/dubbo/sample/tri/common/TriSampleConstants.java
@@ -1,0 +1,54 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.dubbo.sample.tri.common;
+
+
+import org.apache.dubbo.common.constants.CommonConstants;
+
+import static org.apache.dubbo.common.constants.RegistryConstants.*;
+
+public class TriSampleConstants {
+
+    // macos 11 later the 50051 is occupied by system (pid=1!!!)
+    public static final int SERVER_PORT = Integer.parseInt(System.getProperty("provider.port",  "50052"));
+
+    public static final int DEFAULT_DUBBO_PORT = 20880;
+
+    public static final int CONSUMER_METADATA_SERVICE_PORT = 20881;
+
+    public static final String HOST = System.getProperty("provider.host", "127.0.0.1");
+
+    public static final String ZK_HOST = System.getProperty("zookeeper.host", "127.0.0.1");
+
+    public static final int ZK_PORT = Integer.parseInt(System.getProperty("zookeeper.port", "2181"));
+
+    public static final String ZK_ADDRESS = "zookeeper://" + ZK_HOST + ":" + ZK_PORT;
+
+    public static final String ZK_ADDRESS_MODE_INSTANCE = ZK_ADDRESS + "?" + REGISTER_MODE_KEY + "=" + DEFAULT_REGISTER_MODE_INSTANCE;
+
+    public static final String ZK_ADDRESS_MODE_INTERFACE = ZK_ADDRESS + "?" + REGISTER_MODE_KEY + "=" + DEFAULT_REGISTER_MODE_INTERFACE;
+
+    public static final String ZK_ADDRESS_MODE_ALL = ZK_ADDRESS + "?" + REGISTER_MODE_KEY + "=" + DEFAULT_REGISTER_MODE_ALL;
+
+    public static final String LOCAL_HOST = "localhost";
+
+    public static final String DEFAULT_ADDRESS = CommonConstants.TRIPLE + "://" + HOST + ":" + SERVER_PORT;
+
+    public static final String DEFAULT_MULTI_ADDRESS = CommonConstants.TRIPLE + "://" + HOST + ":" + SERVER_PORT + ";" + CommonConstants.TRIPLE + "://" + LOCAL_HOST + ":" + SERVER_PORT;
+
+}

--- a/dubbo-samples-spring-boot-triple/src/test/java/org/apache/dubbo/sample/tri/direct/GrpcDirectPbConsumerTest.java
+++ b/dubbo-samples-spring-boot-triple/src/test/java/org/apache/dubbo/sample/tri/direct/GrpcDirectPbConsumerTest.java
@@ -1,0 +1,105 @@
+package org.apache.dubbo.sample.tri.direct;
+
+import org.apache.dubbo.sample.tri.GreeterReply;
+import org.apache.dubbo.sample.tri.GreeterRequest;
+import org.apache.dubbo.sample.tri.PbGreeterGrpc;
+import org.apache.dubbo.sample.tri.common.StdoutStreamObserver;
+import org.apache.dubbo.sample.tri.common.TriSampleConstants;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.stub.MetadataUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class GrpcDirectPbConsumerTest {
+
+    private static PbGreeterGrpc.PbGreeterStub stub;
+    private static PbGreeterGrpc.PbGreeterBlockingStub blockingStub;
+
+    @BeforeClass
+    public static void init() {
+        final ManagedChannel channel = ManagedChannelBuilder.forAddress(TriSampleConstants.HOST, TriSampleConstants.SERVER_PORT)
+                .usePlaintext()
+                .build();
+        stub = PbGreeterGrpc.newStub(channel);
+        blockingStub = PbGreeterGrpc.newBlockingStub(channel);
+    }
+
+//    @Test
+//    public void clientSendLargeSizeHeader() throws InterruptedException {
+//        final Metadata.Key<String> key = Metadata.Key.of("large_size", Metadata.ASCII_STRING_MARSHALLER);
+//        StringBuilder sb = new StringBuilder("a");
+//        for (int j = 0; j < 15; j++) {
+//            sb.append(sb);
+//        }
+//        Metadata meta = new Metadata();
+//        meta.put(key, sb.toString());
+//        final PbGreeterGrpc.PbGreeterStub curStub = MetadataUtils.attachHeaders(GrpcDirectPbConsumerTest.stub, meta);
+//        curStub.greet(GreeterRequest.newBuilder().setName("metadata").build(), new StdoutStreamObserver<>("meta"));
+//        TimeUnit.SECONDS.sleep(1);
+//    }
+
+    @Test
+    public void serverStream() throws InterruptedException {
+        int n = 10;
+        CountDownLatch latch = new CountDownLatch(n);
+        final GreeterRequest request = GreeterRequest.newBuilder()
+                .setName("request")
+                .build();
+        stub.greetServerStream(request, new StdoutStreamObserver<GreeterReply>("grpc sayGreeterServerStream") {
+            @Override
+            public void onNext(GreeterReply data) {
+                super.onNext(data);
+                latch.countDown();
+            }
+        });
+        Assert.assertTrue(latch.await(3, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void stream() throws InterruptedException {
+        int n = 10;
+        CountDownLatch latch = new CountDownLatch(n);
+        final GreeterRequest request = GreeterRequest.newBuilder()
+                .setName("stream request")
+                .build();
+        final io.grpc.stub.StreamObserver<GreeterRequest> requestObserver = stub.greetStream(new StdoutStreamObserver<GreeterReply>("sayGreeterStream") {
+            @Override
+            public void onNext(GreeterReply data) {
+                super.onNext(data);
+                latch.countDown();
+            }
+        });
+        for (int i = 0; i < n; i++) {
+            requestObserver.onNext(request);
+        }
+        requestObserver.onCompleted();
+        Assert.assertTrue(latch.await(3, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void unaryGreeter() {
+        final GreeterReply reply = blockingStub.greet(GreeterRequest.newBuilder()
+                .setName("name")
+                .build());
+        Assert.assertNotNull(reply);
+    }
+
+    @Test
+    public void attachmentTest() {
+        final Metadata.Key<String> key = Metadata.Key.of("large_size", Metadata.ASCII_STRING_MARSHALLER);
+        Metadata meta = new Metadata();
+        meta.put(key, "test");
+        final PbGreeterGrpc.PbGreeterBlockingStub curStub = MetadataUtils.attachHeaders(GrpcDirectPbConsumerTest.blockingStub, meta);
+        GreeterReply reply = curStub.greetWithAttachment(GreeterRequest.newBuilder().setName("meta").build());
+        Assert.assertEquals("hello,meta", reply.getMessage());
+    }
+
+}
+

--- a/dubbo-samples-spring-boot-triple/src/test/java/org/apache/dubbo/sample/tri/direct/TriDirectPbConsumerTest.java
+++ b/dubbo-samples-spring-boot-triple/src/test/java/org/apache/dubbo/sample/tri/direct/TriDirectPbConsumerTest.java
@@ -1,0 +1,33 @@
+package org.apache.dubbo.sample.tri.direct;
+
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.config.ReferenceConfig;
+import org.apache.dubbo.config.bootstrap.DubboBootstrap;
+import org.apache.dubbo.sample.tri.common.BasePbConsumerTest;
+import org.apache.dubbo.sample.tri.PbGreeter;
+import org.apache.dubbo.sample.tri.common.TriSampleConstants;
+import org.junit.BeforeClass;
+
+public class TriDirectPbConsumerTest extends BasePbConsumerTest {
+
+    @BeforeClass
+    public static void init() {
+        ReferenceConfig<PbGreeter> ref = new ReferenceConfig<>();
+        ref.setInterface(PbGreeter.class);
+        ref.setCheck(false);
+        ref.setUrl(TriSampleConstants.DEFAULT_ADDRESS);
+        ref.setProtocol(CommonConstants.TRIPLE);
+        ref.setLazy(true);
+        ref.setTimeout(3000);
+
+        DubboBootstrap bootstrap = DubboBootstrap.getInstance();
+        ApplicationConfig applicationConfig = new ApplicationConfig(TriDirectPbConsumerTest.class.getName());
+        applicationConfig.setMetadataServicePort(TriSampleConstants.CONSUMER_METADATA_SERVICE_PORT);
+        bootstrap.application(applicationConfig)
+                .reference(ref)
+                .start();
+        delegate = ref.get();
+        appDubboBootstrap = bootstrap;
+    }
+}

--- a/dubbo-samples-spring-boot-triple/src/test/java/org/apache/dubbo/sample/tri/zk/TriZkConsumerTest.java
+++ b/dubbo-samples-spring-boot-triple/src/test/java/org/apache/dubbo/sample/tri/zk/TriZkConsumerTest.java
@@ -1,0 +1,35 @@
+package org.apache.dubbo.sample.tri.zk;
+
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.config.ReferenceConfig;
+import org.apache.dubbo.config.RegistryConfig;
+import org.apache.dubbo.config.bootstrap.DubboBootstrap;
+import org.apache.dubbo.sample.tri.common.BasePbConsumerTest;
+import org.apache.dubbo.sample.tri.PbGreeter;
+import org.apache.dubbo.sample.tri.common.TriSampleConstants;
+import org.junit.BeforeClass;
+
+public class TriZkConsumerTest extends BasePbConsumerTest {
+
+    @BeforeClass
+    public static void init() {
+        ReferenceConfig<PbGreeter> ref = new ReferenceConfig<>();
+        ref.setInterface(PbGreeter.class);
+        ref.setCheck(false);
+        ref.setProtocol(CommonConstants.TRIPLE);
+        ref.setLazy(true);
+        ref.setTimeout(10000);
+
+        DubboBootstrap bootstrap = DubboBootstrap.getInstance();
+        ApplicationConfig applicationConfig = new ApplicationConfig(TriZkConsumerTest.class.getName());
+        applicationConfig.setMetadataServicePort(TriSampleConstants.CONSUMER_METADATA_SERVICE_PORT);
+        bootstrap.application(applicationConfig)
+                .registry(new RegistryConfig(TriSampleConstants.ZK_ADDRESS_MODE_INSTANCE))
+                .reference(ref)
+                .start();
+        delegate = ref.get();
+        appDubboBootstrap=bootstrap;
+    }
+
+}


### PR DESCRIPTION
## 说明
关联Issues [#dubbo9149](https://github.com/apache/dubbo/issues/9149)

净的springboot+triple+proto示例，为grpc+proto人员迁移至dubbo3 triple体系，提供兼容思路

## SpringBoot-Triple-Samples
1. Run `org.apache.dubbo.sample.tri.TriApplication`
- zookeeper.port=2181
- provider.port=50052

### tri --> tri
2. Run `org.apache.dubbo.sample.tri.direct.TriDirectPbConsumerTest`\

### grpc --> tri
2. Run `org.apache.dubbo.sample.tri.direct.GrpcDirectPbConsumerTest`