### PR TITLE
Consumer getBean name should equals reference's id

### DIFF
--- a/dubbo-samples-context/src/main/java/org/apache/dubbo/samples/context/ContextConsumer.java
+++ b/dubbo-samples-context/src/main/java/org/apache/dubbo/samples/context/ContextConsumer.java
@@ -26,7 +26,7 @@ public class ContextConsumer {
     public static void main(String[] args) {
         ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("spring/dubbo-context-consumer.xml");
         context.start();
-        ContextService contextService = context.getBean("demoService", ContextService.class);
+        ContextService contextService = context.getBean("contextService", ContextService.class);
 
         String hello = contextService.sayHello("world");
         System.out.println("result: " + hello);


### PR DESCRIPTION
Exception in thread "main" org.springframework.beans.factory.NoSuchBeanDefinitionException: No bean named 'demoService' available
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.getBeanDefinition(DefaultListableBeanFactory.java:687)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getMergedLocalBeanDefinition(AbstractBeanFactory.java:1213)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:284)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202)
	at org.springframework.context.support.AbstractApplicationContext.getBean(AbstractApplicationContext.java:1086)
	at org.apache.dubbo.samples.context.ContextConsumer.main(ContextConsumer.java:29)

dubbo-context-consumer.xml
<dubbo:reference scope="remote" id="contextService" check="false" interface="org.apache.dubbo.samples.context.api.ContextService"/>

ContextConsumer.class 
ContextService contextService = context.getBean("demoService", ContextService.class);