### PR TITLE
Reference'id should equals getBean name

### DIFF
--- a/dubbo-samples-context/src/main/java/org/apache/dubbo/samples/context/ContextConsumer.java
+++ b/dubbo-samples-context/src/main/java/org/apache/dubbo/samples/context/ContextConsumer.java
@@ -26,7 +26,7 @@ public class ContextConsumer {
     public static void main(String[] args) {
         ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("spring/dubbo-context-consumer.xml");
         context.start();
-        ContextService contextService = context.getBean("contextService", ContextService.class);
+        ContextService contextService = context.getBean("demoService", ContextService.class);
 
         String hello = contextService.sayHello("world");
         System.out.println("result: " + hello);

--- a/dubbo-samples-context/src/main/java/org/apache/dubbo/samples/context/ContextConsumer.java
+++ b/dubbo-samples-context/src/main/java/org/apache/dubbo/samples/context/ContextConsumer.java
@@ -26,7 +26,7 @@ public class ContextConsumer {
     public static void main(String[] args) {
         ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("spring/dubbo-context-consumer.xml");
         context.start();
-        ContextService contextService = context.getBean("demoService", ContextService.class);
+        ContextService contextService = context.getBean("contextService", ContextService.class);
 
         String hello = contextService.sayHello("world");
         System.out.println("result: " + hello);

--- a/dubbo-samples-context/src/main/resources/spring/dubbo-context-consumer.xml
+++ b/dubbo-samples-context/src/main/resources/spring/dubbo-context-consumer.xml
@@ -32,6 +32,6 @@
 
     <!-- generate proxy for the remote service, then demoService can be used in the same way as the
     local regular interface -->
-    <dubbo:reference scope="remote" id="contextService" check="false" interface="org.apache.dubbo.samples.context.api.ContextService"/>
+    <dubbo:reference scope="remote" id="demoService" check="false" interface="org.apache.dubbo.samples.context.api.ContextService"/>
 
 </beans>


### PR DESCRIPTION
ContextConsumer.class
    ContextService contextService = context.getBean("**demoService**", ContextService.class);

dubbo-context-consumer.xml
    <dubbo:reference scope="remote" id="contextService" check="false" interface="org.apache.dubbo.samples.context.api.ContextService"/>


Exception in thread "main" org.springframework.beans.factory.NoSuchBeanDefinitionException: No bean named 'demoService' available
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.getBeanDefinition(DefaultListableBeanFactory.java:687)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getMergedLocalBeanDefinition(AbstractBeanFactory.java:1213)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:284)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202)
	at org.springframework.context.support.AbstractApplicationContext.getBean(AbstractApplicationContext.java:1086)
	at org.apache.dubbo.samples.context.ContextConsumer.main(ContextConsumer.java:29)

