### PR TITLE
add common multi registry sample except docker

### DIFF
--- a/dubbo-samples-multi-registry/src/main/java/org/apache/dubbo/samples/multi/registry/CommonMultiRegistryConsumer.java
+++ b/dubbo-samples-multi-registry/src/main/java/org/apache/dubbo/samples/multi/registry/CommonMultiRegistryConsumer.java
@@ -1,0 +1,35 @@
+/*
+ *
+ *   Licensed to the Apache Software Foundation (ASF) under one or more
+ *   contributor license agreements.  See the NOTICE file distributed with
+ *   this work for additional information regarding copyright ownership.
+ *   The ASF licenses this file to You under the Apache License, Version 2.0
+ *   (the "License"); you may not use this file except in compliance with
+ *   the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package org.apache.dubbo.samples.multi.registry;
+
+import org.apache.dubbo.samples.multi.registry.api.DemoService;
+import org.apache.dubbo.samples.multi.registry.api.HelloService;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+public class CommonMultiRegistryConsumer {
+    public static void main(String[] args) {
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("spring/common-multi-registry-consumer.xml");
+        context.start();
+
+        DemoService demoService = context.getBean(DemoService.class);
+        HelloService helloService = context.getBean(HelloService.class);
+        System.out.println(demoService.get("service form default registry"));
+        System.out.println(helloService.sayHello("service form shanghai registry"));
+    }
+}

--- a/dubbo-samples-multi-registry/src/main/java/org/apache/dubbo/samples/multi/registry/CommonMultiRegistryProvider.java
+++ b/dubbo-samples-multi-registry/src/main/java/org/apache/dubbo/samples/multi/registry/CommonMultiRegistryProvider.java
@@ -1,0 +1,36 @@
+/*
+ *
+ *   Licensed to the Apache Software Foundation (ASF) under one or more
+ *   contributor license agreements.  See the NOTICE file distributed with
+ *   this work for additional information regarding copyright ownership.
+ *   The ASF licenses this file to You under the Apache License, Version 2.0
+ *   (the "License"); you may not use this file except in compliance with
+ *   the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package org.apache.dubbo.samples.multi.registry;
+
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import java.util.concurrent.CountDownLatch;
+
+public class CommonMultiRegistryProvider {
+    public static void main(String[] args) throws Exception {
+        new EmbeddedZooKeeper(2181, false).start();
+        new EmbeddedZooKeeper(2182, false).start();
+
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("spring/common-multi-registry-provider.xml");
+        context.start();
+
+        System.out.println("dubbo service started");
+        new CountDownLatch(1).await();
+    }
+}

--- a/dubbo-samples-multi-registry/src/main/resources/spring/common-multi-registry-consumer.xml
+++ b/dubbo-samples-multi-registry/src/main/resources/spring/common-multi-registry-consumer.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:dubbo="http://dubbo.apache.org/schema/dubbo"
+       xmlns="http://www.springframework.org/schema/beans" xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://dubbo.apache.org/schema/dubbo http://dubbo.apache.org/schema/dubbo/dubbo.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+    <context:property-placeholder/>
+
+    <dubbo:application name="multi-registry-consumer"/>
+
+    <dubbo:registry id="beijingRegistry" address="zookeeper://${zookeeper.address.1:127.0.0.1}:${zookeeper.port:2181}" />
+    <dubbo:registry id="shanghaiRegistry" address="zookeeper://${zookeeper.address.2:127.0.0.1}:${zookeeper.port:2182}" />
+
+    <dubbo:reference id="demoService" registry="beijingRegistry" interface="org.apache.dubbo.samples.multi.registry.api.DemoService"/>
+    <dubbo:reference id="helloService" registry="shanghaiRegistry" interface="org.apache.dubbo.samples.multi.registry.api.HelloService"/>
+
+</beans>
+

--- a/dubbo-samples-multi-registry/src/main/resources/spring/common-multi-registry-provider.xml
+++ b/dubbo-samples-multi-registry/src/main/resources/spring/common-multi-registry-provider.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:dubbo="http://dubbo.apache.org/schema/dubbo"
+       xmlns="http://www.springframework.org/schema/beans" xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://dubbo.apache.org/schema/dubbo http://dubbo.apache.org/schema/dubbo/dubbo.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+    <context:property-placeholder/>
+
+    <dubbo:application name="multi-registry-provider"/>
+
+    <dubbo:registry id="beijingRegistry" address="zookeeper://${zookeeper.address.1:127.0.0.1}:${zookeeper.port:2181}" default="false"/>
+
+    <dubbo:registry id="shanghaiRegistry" address="zookeeper://${zookeeper.address.2:127.0.0.1}:${zookeeper.port:2182}" />
+
+    <dubbo:protocol name="dubbo" port="20880"/>
+
+    <bean id="helloService" class="org.apache.dubbo.samples.multi.registry.impl.HelloServiceImpl"/>
+    <bean id="demoService" class="org.apache.dubbo.samples.multi.registry.impl.DemoServiceImpl"/>
+
+    <dubbo:service interface="org.apache.dubbo.samples.multi.registry.api.HelloService" ref="helloService"
+                   registry="shanghaiRegistry,beijingRegistry"/>
+    <dubbo:service interface="org.apache.dubbo.samples.multi.registry.api.DemoService" ref="demoService"
+                   registry="shanghaiRegistry,beijingRegistry"/>
+
+</beans>


### PR DESCRIPTION
The original examples can only be run in the docker environment. If they are run locally, an error will be reported. An example of successful local execution is added.