### PR TITLE
update dubbo.registry.address in dubbo-samples-kubernetes

### DIFF
--- a/dubbo-samples-kubernetes/README.md
+++ b/dubbo-samples-kubernetes/README.md
@@ -119,7 +119,7 @@ namespace、trustCerts 两个参数
 ```properties
 dubbo.application.name=dubbo-samples-apiserver-provider
 dubbo.application.metadataServicePort=20885
-dubbo.registry.address=kubernetes://DEFAULT_MASTER_HOST?registry-type=service&duplicate=false&namespace=dubbo-demo&trustCerts=true
+dubbo.registry.address=kubernetes://DEFAULT_MASTER_HOST:443?registry-type=service&duplicate=false&namespace=dubbo-demo&trustCerts=true
 dubbo.protocol.name=dubbo
 dubbo.protocol.port=20880
 dubbo.application.qosEnable=true


### PR DESCRIPTION
直接使用 dubbo.registry.address=kubernetes://kubernetes.default.svc.cluster.local:443?registry-type=service&duplicate=false&namespace=dubbo-demo&trustCerts=true   原来的DEFAULT_MASTER_HOST 容易造成误解，另外也缺少端口。
