### PR TITLE
block test case if assert failed in dubbo-samples-async-simple

### DIFF
--- a/dubbo-samples-async/dubbo-samples-async-simple/src/test/java/org/apache/dubbo/samples/async/AsyncServiceIT.java
+++ b/dubbo-samples-async/dubbo-samples-async-simple/src/test/java/org/apache/dubbo/samples/async/AsyncServiceIT.java
@@ -29,6 +29,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {"classpath:/spring/async-consumer.xml"})
@@ -41,13 +42,16 @@ public class AsyncServiceIT {
         asyncService.sayHello("completable future");
         CompletableFuture<String> helloFuture = RpcContext.getContext().getCompletableFuture();
         CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Throwable> exceptionRef = new AtomicReference<>();
+        AtomicReference<String> retValueRef = new AtomicReference<>();
         helloFuture.whenComplete((retValue, exception) -> {
-            Assert.assertNull(exception);
-            Assert.assertEquals("hello, completable future", retValue);
+            exceptionRef.set(exception);
+            retValueRef.set(retValue);
             latch.countDown();
         });
-
         latch.await();
+        Assert.assertNull(exceptionRef.get());
+        Assert.assertEquals("hello, completable future", retValueRef.get());
     }
 
     @Test


### PR DESCRIPTION
# What is the purpose of the change
###### if     Assert.assertEquals("hello, completable future", retValue); is fail in helloFuture, the latch.countDown() wouldn't to execute, and the test case will be blocked, if try the assert and put countDown on the finally, the test will quit so quickly and the fail will not to be marked

## Brief changelog

use AtomicReference in the helloFuture to set the retValue and exception, and validate the value after latch count down

