### PR TITLE
🎨 add to prefer serialization test

### DIFF
--- a/.github/workflows/dubbo-3_1.yml
+++ b/.github/workflows/dubbo-3_1.yml
@@ -17,7 +17,7 @@ env:
   FORK_COUNT: 2
   FAIL_FAST: 0
   SHOW_ERROR_DETAIL: 1
-  BUILD_OPTS: --batch-mode --no-snapshot-updates --no-transfer-progress --settings ${{github.workspace}}/.mvn/settings.xml
+  BUILD_OPTS: --batch-mode --no-snapshot-updates --no-transfer-progress
     -Dmaven.wagon.http.retryHandler.count=3 clean package dependency:copy-dependencies -DskipTests
   #multi-version size limit
   VERSIONS_LIMIT: 4

--- a/.github/workflows/dubbo-3_1.yml
+++ b/.github/workflows/dubbo-3_1.yml
@@ -17,7 +17,7 @@ env:
   FORK_COUNT: 2
   FAIL_FAST: 0
   SHOW_ERROR_DETAIL: 1
-  BUILD_OPTS: --batch-mode --no-snapshot-updates --no-transfer-progress
+  BUILD_OPTS: --batch-mode --no-snapshot-updates --no-transfer-progress --settings ${{github.workspace}}/.mvn/settings.xml
     -Dmaven.wagon.http.retryHandler.count=3 clean package dependency:copy-dependencies -DskipTests
   #multi-version size limit
   VERSIONS_LIMIT: 4

--- a/.github/workflows/dubbo-3_2.yml
+++ b/.github/workflows/dubbo-3_2.yml
@@ -17,7 +17,7 @@ env:
   FORK_COUNT: 2
   FAIL_FAST: 0
   SHOW_ERROR_DETAIL: 1
-  BUILD_OPTS: --batch-mode --no-snapshot-updates --no-transfer-progress --settings ${{github.workspace}}/.mvn/settings.xml
+  BUILD_OPTS: --batch-mode --no-snapshot-updates --no-transfer-progress
     -Dmaven.wagon.http.retryHandler.count=3 clean package dependency:copy-dependencies -DskipTests
   #multi-version size limit
   VERSIONS_LIMIT: 4

--- a/.github/workflows/dubbo-3_2.yml
+++ b/.github/workflows/dubbo-3_2.yml
@@ -17,7 +17,7 @@ env:
   FORK_COUNT: 2
   FAIL_FAST: 0
   SHOW_ERROR_DETAIL: 1
-  BUILD_OPTS: --batch-mode --no-snapshot-updates --no-transfer-progress
+  BUILD_OPTS: --batch-mode --no-snapshot-updates --no-transfer-progress --settings ${{github.workspace}}/.mvn/settings.xml
     -Dmaven.wagon.http.retryHandler.count=3 clean package dependency:copy-dependencies -DskipTests
   #multi-version size limit
   VERSIONS_LIMIT: 4

--- a/.github/workflows/nightly-dubbo-3.yml
+++ b/.github/workflows/nightly-dubbo-3.yml
@@ -17,7 +17,7 @@ env:
   FORK_COUNT: 1
   FAIL_FAST: 0
   SHOW_ERROR_DETAIL: 1
-  BUILD_OPTS: --batch-mode --no-snapshot-updates --no-transfer-progress
+  BUILD_OPTS: --batch-mode --no-snapshot-updates --no-transfer-progress --settings ${{github.workspace}}/.mvn/settings.xml
     -Dmaven.wagon.http.retryHandler.count=3 clean package dependency:copy-dependencies -DskipTests
   #multi-version size limit
   VERSIONS_LIMIT: 12

--- a/.github/workflows/nightly-dubbo-3.yml
+++ b/.github/workflows/nightly-dubbo-3.yml
@@ -17,7 +17,7 @@ env:
   FORK_COUNT: 1
   FAIL_FAST: 0
   SHOW_ERROR_DETAIL: 1
-  BUILD_OPTS: --batch-mode --no-snapshot-updates --no-transfer-progress --settings ${{github.workspace}}/.mvn/settings.xml
+  BUILD_OPTS: --batch-mode --no-snapshot-updates --no-transfer-progress
     -Dmaven.wagon.http.retryHandler.count=3 clean package dependency:copy-dependencies -DskipTests
   #multi-version size limit
   VERSIONS_LIMIT: 12

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,20 @@
 # maven ignore
 target/
 *.jar
-!.mvn/wrapper/*
 *.war
 *.zip
 *.tar
 *.tar.gz
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+.mvn/wrapper/maven-wrapper.jar
 
 # eclipse ignore
 .settings/

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-s .mvn/settings.xml

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,0 @@
--s .mvn/settings.xml

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -32,7 +32,6 @@
                 </repository>
             </repositories>
         </profile>
-
     </profiles>
 
     <activeProfiles>

--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2007-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.net.*;
+import java.io.*;
+import java.nio.channels.*;
+import java.util.Properties;
+
+public class MavenWrapperDownloader {
+
+    private static final String WRAPPER_VERSION = "0.5.6";
+    /**
+     * Default URL to download the maven-wrapper.jar from, if no 'downloadUrl' is provided.
+     */
+    private static final String DEFAULT_DOWNLOAD_URL = "https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/"
+        + WRAPPER_VERSION + "/maven-wrapper-" + WRAPPER_VERSION + ".jar";
+
+    /**
+     * Path to the maven-wrapper.properties file, which might contain a downloadUrl property to
+     * use instead of the default one.
+     */
+    private static final String MAVEN_WRAPPER_PROPERTIES_PATH =
+            ".mvn/wrapper/maven-wrapper.properties";
+
+    /**
+     * Path where the maven-wrapper.jar will be saved to.
+     */
+    private static final String MAVEN_WRAPPER_JAR_PATH =
+            ".mvn/wrapper/maven-wrapper.jar";
+
+    /**
+     * Name of the property which should be used to override the default download url for the wrapper.
+     */
+    private static final String PROPERTY_NAME_WRAPPER_URL = "wrapperUrl";
+
+    public static void main(String args[]) {
+        System.out.println("- Downloader started");
+        File baseDirectory = new File(args[0]);
+        System.out.println("- Using base directory: " + baseDirectory.getAbsolutePath());
+
+        // If the maven-wrapper.properties exists, read it and check if it contains a custom
+        // wrapperUrl parameter.
+        File mavenWrapperPropertyFile = new File(baseDirectory, MAVEN_WRAPPER_PROPERTIES_PATH);
+        String url = DEFAULT_DOWNLOAD_URL;
+        if(mavenWrapperPropertyFile.exists()) {
+            FileInputStream mavenWrapperPropertyFileInputStream = null;
+            try {
+                mavenWrapperPropertyFileInputStream = new FileInputStream(mavenWrapperPropertyFile);
+                Properties mavenWrapperProperties = new Properties();
+                mavenWrapperProperties.load(mavenWrapperPropertyFileInputStream);
+                url = mavenWrapperProperties.getProperty(PROPERTY_NAME_WRAPPER_URL, url);
+            } catch (IOException e) {
+                System.out.println("- ERROR loading '" + MAVEN_WRAPPER_PROPERTIES_PATH + "'");
+            } finally {
+                try {
+                    if(mavenWrapperPropertyFileInputStream != null) {
+                        mavenWrapperPropertyFileInputStream.close();
+                    }
+                } catch (IOException e) {
+                    // Ignore ...
+                }
+            }
+        }
+        System.out.println("- Downloading from: " + url);
+
+        File outputFile = new File(baseDirectory.getAbsolutePath(), MAVEN_WRAPPER_JAR_PATH);
+        if(!outputFile.getParentFile().exists()) {
+            if(!outputFile.getParentFile().mkdirs()) {
+                System.out.println(
+                        "- ERROR creating output directory '" + outputFile.getParentFile().getAbsolutePath() + "'");
+            }
+        }
+        System.out.println("- Downloading to: " + outputFile.getAbsolutePath());
+        try {
+            downloadFileFromURL(url, outputFile);
+            System.out.println("Done");
+            System.exit(0);
+        } catch (Throwable e) {
+            System.out.println("- Error downloading");
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    private static void downloadFileFromURL(String urlString, File destination) throws Exception {
+        if (System.getenv("MVNW_USERNAME") != null && System.getenv("MVNW_PASSWORD") != null) {
+            String username = System.getenv("MVNW_USERNAME");
+            char[] password = System.getenv("MVNW_PASSWORD").toCharArray();
+            Authenticator.setDefault(new Authenticator() {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication() {
+                    return new PasswordAuthentication(username, password);
+                }
+            });
+        }
+        URL website = new URL(urlString);
+        ReadableByteChannel rbc;
+        rbc = Channels.newChannel(website.openStream());
+        FileOutputStream fos = new FileOutputStream(destination);
+        fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
+        fos.close();
+        rbc.close();
+    }
+
+}

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,2 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.6.1/apache-maven-3.6.1-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/dubbo-maven-address-plugin/pom.xml
+++ b/dubbo-maven-address-plugin/pom.xml
@@ -25,6 +25,8 @@
     <version>1.0-SNAPSHOT</version>
     <artifactId>dubbo-maven-address-plugin</artifactId>
     <packaging>maven-plugin</packaging>
+    <name>Dubbo Maven Address Plugin</name>
+    <description>Dubbo Maven Address Plugin</description>
 
     <properties>
         <maven-plugin.version>3.6.0</maven-plugin.version>

--- a/dubbo-samples-annotation/pom.xml
+++ b/dubbo-samples-annotation/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-annotation</artifactId>
+    <name>Dubbo Samples Annotation</name>
+    <description>Dubbo Samples Annotation</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-api/pom.xml
+++ b/dubbo-samples-api/pom.xml
@@ -25,6 +25,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-api</artifactId>
+    <name>Dubbo Samples Api</name>
+    <description>Dubbo Samples Api</description>
 
     <properties>
         <spring.version>4.3.16.RELEASE</spring.version>

--- a/dubbo-samples-async/dubbo-samples-async-generated-future/pom.xml
+++ b/dubbo-samples-async/dubbo-samples-async-generated-future/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-async-generated-future</artifactId>
+    <name>Dubbo Samples Async Generated Future</name>
+    <description>Dubbo Samples Async Generated Future</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-async/dubbo-samples-async-onerror/pom.xml
+++ b/dubbo-samples-async/dubbo-samples-async-onerror/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-async-onerror</artifactId>
+    <name>Dubbo Samples Async Onerror</name>
+    <description>Dubbo Samples Async Onerror</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-async/dubbo-samples-async-original-future/pom.xml
+++ b/dubbo-samples-async/dubbo-samples-async-original-future/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-async-original-future</artifactId>
+    <name>Dubbo Samples Async Original Future</name>
+    <description>Dubbo Samples Async Original Future</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-async/dubbo-samples-async-provider/pom.xml
+++ b/dubbo-samples-async/dubbo-samples-async-provider/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-async-provider</artifactId>
+    <name>Dubbo Samples Async Provider</name>
+    <description>Dubbo Samples Async Provider</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-async/dubbo-samples-async-simple/pom.xml
+++ b/dubbo-samples-async/dubbo-samples-async-simple/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-async-simple</artifactId>
+    <name>Dubbo Samples Async Simple</name>
+    <description>Dubbo Samples Async Simple</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-async/pom.xml
+++ b/dubbo-samples-async/pom.xml
@@ -25,6 +25,8 @@
     <packaging>pom</packaging>
 
     <artifactId>dubbo-samples-async</artifactId>
+    <name>Dubbo Samples Async</name>
+    <description>Dubbo Samples Async</description>
 
     <modules>
         <module>dubbo-samples-async-simple</module>

--- a/dubbo-samples-attachment/pom.xml
+++ b/dubbo-samples-attachment/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-attachment</artifactId>
+    <name>Dubbo Samples Attachment</name>
+    <description>Dubbo Samples Attachment</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-autowire/pom.xml
+++ b/dubbo-samples-autowire/pom.xml
@@ -26,6 +26,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-autowire</artifactId>
+    <name>Dubbo Samples Autowire</name>
+    <description>Dubbo Samples Autowire</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-basic/pom.xml
+++ b/dubbo-samples-basic/pom.xml
@@ -24,6 +24,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-basic</artifactId>
+    <name>Dubbo Samples Basic</name>
+    <description>Dubbo Samples Basic</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-boundary-test/dubbo-samples-empty-protection-nacos/pom.xml
+++ b/dubbo-samples-boundary-test/dubbo-samples-empty-protection-nacos/pom.xml
@@ -26,6 +26,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-empty-protection-nacos</artifactId>
+    <name>Dubbo Samples Empty Protection Nacos</name>
+    <description>Dubbo Samples Empty Protection Nacos</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-boundary-test/dubbo-samples-empty-protection/pom.xml
+++ b/dubbo-samples-boundary-test/dubbo-samples-empty-protection/pom.xml
@@ -26,6 +26,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-empty-protection</artifactId>
+    <name>Dubbo Samples Empty Protection</name>
+    <description>Dubbo Samples Empty Protection</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-boundary-test/dubbo-samples-hibernate/pom.xml
+++ b/dubbo-samples-boundary-test/dubbo-samples-hibernate/pom.xml
@@ -28,8 +28,8 @@
     <groupId>org.apache.dubbo.samples.boundary.hibernate</groupId>
     <artifactId>dubbo-samples-hibernate</artifactId>
     <version>1.0-SNAPSHOT</version>
-    <name>dubbo-samples-hibernate</name>
-    <url>http://maven.apache.org</url>
+    <name>Dubbo Samples Hibernate</name>
+    <description>Dubbo Samples Hibernate</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-boundary-test/dubbo-samples-mybatis/pom.xml
+++ b/dubbo-samples-boundary-test/dubbo-samples-mybatis/pom.xml
@@ -28,8 +28,8 @@
     <groupId>org.apache.dubbo.samples.boundary</groupId>
     <artifactId>dubbo-samples-mybatis</artifactId>
     <version>1.0-SNAPSHOT</version>
-    <name>dubbo-samples-mybatis</name>
-    <url>http://maven.apache.org</url>
+    <name>Dubbo Samples Mybatis</name>
+    <description>Dubbo Samples Mybatis</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-boundary-test/dubbo-samples-nacos-merge/dubbo-samples-nacos-merge-api/pom.xml
+++ b/dubbo-samples-boundary-test/dubbo-samples-nacos-merge/dubbo-samples-nacos-merge-api/pom.xml
@@ -27,4 +27,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-nacos-merge-api</artifactId>
+    <name>Dubbo Samples Nacos Merge Api</name>
+    <description>Dubbo Samples Nacos Merge Api</description>
 </project>

--- a/dubbo-samples-boundary-test/dubbo-samples-nacos-merge/dubbo-samples-nacos-merge-consumer/pom.xml
+++ b/dubbo-samples-boundary-test/dubbo-samples-nacos-merge/dubbo-samples-nacos-merge-consumer/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-nacos-merge-consumer</artifactId>
+    <name>Dubbo Samples Nacos Merge Consumer</name>
+    <description>Dubbo Samples Nacos Merge Consumer</description>
 
     <dependencies>
         <dependency>

--- a/dubbo-samples-boundary-test/dubbo-samples-nacos-merge/dubbo-samples-nacos-merge-provider1/pom.xml
+++ b/dubbo-samples-boundary-test/dubbo-samples-nacos-merge/dubbo-samples-nacos-merge-provider1/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-nacos-merge-provider1</artifactId>
+    <name>Dubbo Samples Nacos Merge Provider1</name>
+    <description>Dubbo Samples Nacos Merge Provider1</description>
 
     <dependencies>
         <dependency>

--- a/dubbo-samples-boundary-test/dubbo-samples-nacos-merge/dubbo-samples-nacos-merge-provider2/pom.xml
+++ b/dubbo-samples-boundary-test/dubbo-samples-nacos-merge/dubbo-samples-nacos-merge-provider2/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-nacos-merge-provider2</artifactId>
+    <name>Dubbo Samples Nacos Merge Provider2</name>
+    <description>Dubbo Samples Nacos Merge Provider2</description>
 
     <dependencies>
         <dependency>

--- a/dubbo-samples-boundary-test/dubbo-samples-nacos-merge/pom.xml
+++ b/dubbo-samples-boundary-test/dubbo-samples-nacos-merge/pom.xml
@@ -32,6 +32,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-nacos-merge</artifactId>
+    <name>Dubbo Samples Nacos Merge</name>
+    <description>Dubbo Samples Nacos Merge</description>
+
     <properties>
         <dubbo.version>3.1.1</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>

--- a/dubbo-samples-boundary-test/dubbo-samples-port-unification-netty3/pom.xml
+++ b/dubbo-samples-boundary-test/dubbo-samples-port-unification-netty3/pom.xml
@@ -25,6 +25,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-port-unification-netty3</artifactId>
+    <name>Dubbo Samples Port Unification Netty 3</name>
+    <description>Dubbo Samples Port Unification Netty 3</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/dubbo-samples-boundary-test/dubbo-samples-router-chain-switch/pom.xml
+++ b/dubbo-samples-boundary-test/dubbo-samples-router-chain-switch/pom.xml
@@ -26,6 +26,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-router-chain-switch</artifactId>
+    <name>Dubbo Samples Router Chain Switch</name>
+    <description>Dubbo Samples Router Chain Switch</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/dubbo-samples-boundary-test/dubbo-samples-sd-group/dubbo-samples-sd-group-api/pom.xml
+++ b/dubbo-samples-boundary-test/dubbo-samples-sd-group/dubbo-samples-sd-group-api/pom.xml
@@ -27,4 +27,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-sd-group-api</artifactId>
+    <name>Dubbo Samples Sd Group Api</name>
+    <description>Dubbo Samples Sd Group Api</description>
 </project>

--- a/dubbo-samples-boundary-test/dubbo-samples-sd-group/dubbo-samples-sd-group-consumer/pom.xml
+++ b/dubbo-samples-boundary-test/dubbo-samples-sd-group/dubbo-samples-sd-group-consumer/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-sd-group-consumer</artifactId>
+    <name>Dubbo Samples Sd Group Consumer</name>
+    <description>Dubbo Samples Sd Group Consumer</description>
 
     <dependencies>
         <dependency>

--- a/dubbo-samples-boundary-test/dubbo-samples-sd-group/dubbo-samples-sd-group-provider1/pom.xml
+++ b/dubbo-samples-boundary-test/dubbo-samples-sd-group/dubbo-samples-sd-group-provider1/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-sd-group-provider1</artifactId>
+    <name>Dubbo Samples Sd Group Provider1</name>
+    <description>Dubbo Samples Sd Group Provider1</description>
 
     <dependencies>
         <dependency>

--- a/dubbo-samples-boundary-test/dubbo-samples-sd-group/dubbo-samples-sd-group-provider2/pom.xml
+++ b/dubbo-samples-boundary-test/dubbo-samples-sd-group/dubbo-samples-sd-group-provider2/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-sd-group-provider2</artifactId>
+    <name>Dubbo Samples Sd Group Provider2</name>
+    <description>Dubbo Samples Sd Group Provider2</description>
 
     <dependencies>
         <dependency>

--- a/dubbo-samples-boundary-test/dubbo-samples-sd-group/pom.xml
+++ b/dubbo-samples-boundary-test/dubbo-samples-sd-group/pom.xml
@@ -32,6 +32,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-sd-group</artifactId>
+    <name>Dubbo Samples Sd Group</name>
+    <description>Dubbo Samples Sd Group</description>
+
     <properties>
         <dubbo.version>3.1.1</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>

--- a/dubbo-samples-boundary-test/dubbo-samples-sd-merge/dubbo-samples-sd-merge-api/pom.xml
+++ b/dubbo-samples-boundary-test/dubbo-samples-sd-merge/dubbo-samples-sd-merge-api/pom.xml
@@ -27,4 +27,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-sd-merge-api</artifactId>
+    <name>Dubbo Samples Sd Merge Api</name>
+    <description>Dubbo Samples Sd Merge Api</description>
 </project>

--- a/dubbo-samples-boundary-test/dubbo-samples-sd-merge/dubbo-samples-sd-merge-consumer/pom.xml
+++ b/dubbo-samples-boundary-test/dubbo-samples-sd-merge/dubbo-samples-sd-merge-consumer/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-sd-merge-consumer</artifactId>
+    <name>Dubbo Samples Sd Merge Consumer</name>
+    <description>Dubbo Samples Sd Merge Consumer</description>
 
     <dependencies>
         <dependency>

--- a/dubbo-samples-boundary-test/dubbo-samples-sd-merge/dubbo-samples-sd-merge-provider1/pom.xml
+++ b/dubbo-samples-boundary-test/dubbo-samples-sd-merge/dubbo-samples-sd-merge-provider1/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-sd-merge-provider1</artifactId>
+    <name>Dubbo Samples Sd Merge Provider1</name>
+    <description>Dubbo Samples Sd Merge Provider1</description>
 
     <dependencies>
         <dependency>

--- a/dubbo-samples-boundary-test/dubbo-samples-sd-merge/dubbo-samples-sd-merge-provider2/pom.xml
+++ b/dubbo-samples-boundary-test/dubbo-samples-sd-merge/dubbo-samples-sd-merge-provider2/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-sd-merge-provider2</artifactId>
+    <name>Dubbo Samples Sd Merge Provider2</name>
+    <description>Dubbo Samples Sd Merge Provider2</description>
 
     <dependencies>
         <dependency>

--- a/dubbo-samples-boundary-test/dubbo-samples-sd-merge/pom.xml
+++ b/dubbo-samples-boundary-test/dubbo-samples-sd-merge/pom.xml
@@ -32,6 +32,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-sd-merge</artifactId>
+    <name>Dubbo Samples Sd Merge</name>
+    <description>Dubbo Samples Sd Merge</description>
+
     <properties>
         <dubbo.version>3.1.1</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>

--- a/dubbo-samples-boundary-test/dubbo-samples-sd-version/pom.xml
+++ b/dubbo-samples-boundary-test/dubbo-samples-sd-version/pom.xml
@@ -25,6 +25,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-sd-version</artifactId>
+    <name>Dubbo Samples Sd Version</name>
+    <description>Dubbo Samples Sd Version</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-boundary-test/pom.xml
+++ b/dubbo-samples-boundary-test/pom.xml
@@ -23,6 +23,8 @@
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <artifactId>dubbo-samples-boundary-test</artifactId>
+    <name>Dubbo Samples Boundary Test</name>
+    <description>Dubbo Samples Boundary Test</description>
 
     <modules>
         <module>dubbo-samples-mybatis</module>

--- a/dubbo-samples-cache/pom.xml
+++ b/dubbo-samples-cache/pom.xml
@@ -24,6 +24,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-cache</artifactId>
+    <name>Dubbo Samples Cache</name>
+    <description>Dubbo Samples Cache</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-callback/pom.xml
+++ b/dubbo-samples-callback/pom.xml
@@ -24,6 +24,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-callback</artifactId>
+    <name>Dubbo Samples Callback</name>
+    <description>Dubbo Samples Callback</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-chain/dubbo-samples-chain-api/pom.xml
+++ b/dubbo-samples-chain/dubbo-samples-chain-api/pom.xml
@@ -30,5 +30,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-chain-api</artifactId>
+    <name>Dubbo Samples Chain Api</name>
+    <description>Dubbo Samples Chain Api</description>
 
 </project>

--- a/dubbo-samples-chain/dubbo-samples-chain-backend/pom.xml
+++ b/dubbo-samples-chain/dubbo-samples-chain-backend/pom.xml
@@ -30,6 +30,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-chain-backend</artifactId>
+    <name>Dubbo Samples Chain Backend</name>
+    <description>Dubbo Samples Chain Backend</description>
 
     <dependencies>
         <dependency>

--- a/dubbo-samples-chain/dubbo-samples-chain-front/pom.xml
+++ b/dubbo-samples-chain/dubbo-samples-chain-front/pom.xml
@@ -30,6 +30,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-chain-front</artifactId>
+    <name>Dubbo Samples Chain Front</name>
+    <description>Dubbo Samples Chain Front</description>
 
     <dependencies>
         <dependency>

--- a/dubbo-samples-chain/dubbo-samples-chain-middle/pom.xml
+++ b/dubbo-samples-chain/dubbo-samples-chain-middle/pom.xml
@@ -21,14 +21,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.dubbo</groupId>
         <artifactId>dubbo-samples-chain</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>dubbo-samples-chain-middle</artifactId>
+    <name>Dubbo Samples Chain Middle</name>
+    <description>Dubbo Samples Chain Middle</description>
 
     <dependencies>
         <dependency>

--- a/dubbo-samples-chain/pom.xml
+++ b/dubbo-samples-chain/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <artifactId>dubbo-samples-chain</artifactId>
+    <name>Dubbo Samples Chain</name>
+    <description>Dubbo Samples Chain</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-cloud-native/dubbo-call-sc/dubbo-sc-api/pom.xml
+++ b/dubbo-samples-cloud-native/dubbo-call-sc/dubbo-sc-api/pom.xml
@@ -24,9 +24,9 @@
     </parent>
     <artifactId>dubbo-sc-api</artifactId>
     <packaging>jar</packaging>
-    <name>${project.artifactId}</name>
+    <name>Dubbo Sc Api</name>
     <description>The demo module of dubbo project</description>
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 </project>

--- a/dubbo-samples-cloud-native/dubbo-call-sc/dubbo-sc-consumer/pom.xml
+++ b/dubbo-samples-cloud-native/dubbo-call-sc/dubbo-sc-consumer/pom.xml
@@ -25,10 +25,10 @@
     </parent>
     <artifactId>dubbo-sc-consumer</artifactId>
     <packaging>jar</packaging>
-    <name>${project.artifactId}</name>
+    <name>Dubbo Sc Consumer</name>
     <description>The demo consumer module of dubbo project</description>
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
     <dependencies>
         <dependency>

--- a/dubbo-samples-cloud-native/dubbo-call-sc/dubbo-sc-provider/pom.xml
+++ b/dubbo-samples-cloud-native/dubbo-call-sc/dubbo-sc-provider/pom.xml
@@ -20,15 +20,17 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.dubbo</groupId>
         <artifactId>dubbo-call-sc</artifactId>
         <version>1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-sc-provider</artifactId>
+    <name>Dubbo Sc Provider</name>
+    <description>Dubbo Sc Provider</description>
 
     <properties>
         <spring-cloud-starter-consul.version>1.3.0.RELEASE</spring-cloud-starter-consul.version>

--- a/dubbo-samples-cloud-native/dubbo-call-sc/pom.xml
+++ b/dubbo-samples-cloud-native/dubbo-call-sc/pom.xml
@@ -25,6 +25,8 @@
     <groupId>org.apache.dubbo</groupId>
     <artifactId>dubbo-call-sc</artifactId>
     <version>1.0-SNAPSHOT</version>
+    <name>Dubbo Call Sc</name>
+    <description>Dubbo Call Sc</description>
 
     <modules>
         <module>dubbo-sc-provider</module>
@@ -33,7 +35,7 @@
     </modules>
 
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>

--- a/dubbo-samples-cloud-native/dubbo-call-scdubbo/dubbo-scdubbo-api/pom.xml
+++ b/dubbo-samples-cloud-native/dubbo-call-scdubbo/dubbo-scdubbo-api/pom.xml
@@ -24,9 +24,9 @@
     </parent>
     <artifactId>dubbo-scdubbo-api</artifactId>
     <packaging>jar</packaging>
-    <name>${project.artifactId}</name>
+    <name>Dubbo Scdubbo Api</name>
     <description>The demo module of dubbo project</description>
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 </project>

--- a/dubbo-samples-cloud-native/dubbo-call-scdubbo/dubbo-scdubbo-consumer/pom.xml
+++ b/dubbo-samples-cloud-native/dubbo-call-scdubbo/dubbo-scdubbo-consumer/pom.xml
@@ -25,10 +25,10 @@
     </parent>
     <artifactId>dubbo-scdubbo-consumer</artifactId>
     <packaging>jar</packaging>
-    <name>${project.artifactId}</name>
+    <name>Dubbo Scdubbo Consumer</name>
     <description>The demo consumer module of dubbo project</description>
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
     <dependencies>
         <dependency>

--- a/dubbo-samples-cloud-native/dubbo-call-scdubbo/dubbo-scdubbo-provider/pom.xml
+++ b/dubbo-samples-cloud-native/dubbo-call-scdubbo/dubbo-scdubbo-provider/pom.xml
@@ -20,15 +20,17 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.dubbo</groupId>
         <artifactId>dubbo-call-scdubbo</artifactId>
         <version>1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-scdubbo-provider</artifactId>
+    <name>Dubbo Scdubbo Provider</name>
+    <description>Dubbo Scdubbo Provider</description>
 
     <dependencyManagement>
         <dependencies>

--- a/dubbo-samples-cloud-native/dubbo-call-scdubbo/dubbo-scdubbo-provider2/pom.xml
+++ b/dubbo-samples-cloud-native/dubbo-call-scdubbo/dubbo-scdubbo-provider2/pom.xml
@@ -25,10 +25,11 @@
     </parent>
     <artifactId>dubbo-scdubbo-provider2</artifactId>
     <packaging>jar</packaging>
-    <name>${project.artifactId}</name>
-    <description>The demo provider module of dubbo project</description>
+    <name>Dubbo Scdubbo Provider2</name>
+    <description>Dubbo Scdubbo Provider2</description>
+
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
         <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
     </properties>
 

--- a/dubbo-samples-cloud-native/dubbo-call-scdubbo/pom.xml
+++ b/dubbo-samples-cloud-native/dubbo-call-scdubbo/pom.xml
@@ -26,6 +26,8 @@
     <groupId>org.apache.dubbo</groupId>
     <artifactId>dubbo-call-scdubbo</artifactId>
     <version>1.0-SNAPSHOT</version>
+    <name>Dubbo Call Scdubbo</name>
+    <description>Dubbo Call Scdubbo</description>
 
     <modules>
         <module>dubbo-scdubbo-api</module>
@@ -35,7 +37,7 @@
     </modules>
 
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
         <spring-boot-maven-plugin.version>2.6.4</spring-boot-maven-plugin.version>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>

--- a/dubbo-samples-cloud-native/dubbo-demo-servicediscovery-xml/pom.xml
+++ b/dubbo-samples-cloud-native/dubbo-demo-servicediscovery-xml/pom.xml
@@ -26,6 +26,8 @@
     <groupId>org.apache.dubbo</groupId>
     <artifactId>dubbo-demo-servicediscovery-xml</artifactId>
     <version>1.0-SNAPSHOT</version>
+    <name>Dubbo Demo Service Discovery Xml</name>
+    <description>Dubbo Demo Service Discovery Xml</description>
 
     <modules>
         <module>servicediscovery-api</module>
@@ -34,7 +36,7 @@
     </modules>
 
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
         <spring-boot-maven-plugin.version>2.6.4</spring-boot-maven-plugin.version>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>

--- a/dubbo-samples-cloud-native/dubbo-demo-servicediscovery-xml/servicediscovery-api/pom.xml
+++ b/dubbo-samples-cloud-native/dubbo-demo-servicediscovery-xml/servicediscovery-api/pom.xml
@@ -24,9 +24,9 @@
     </parent>
     <artifactId>servicediscovery-api</artifactId>
     <packaging>jar</packaging>
-    <name>${project.artifactId}</name>
-    <description>The demo module of dubbo project</description>
+    <name>Service Discovery Api</name>
+    <description>Service Discovery Api</description>
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 </project>

--- a/dubbo-samples-cloud-native/dubbo-demo-servicediscovery-xml/servicediscovery-consumer/pom.xml
+++ b/dubbo-samples-cloud-native/dubbo-demo-servicediscovery-xml/servicediscovery-consumer/pom.xml
@@ -25,10 +25,10 @@
     </parent>
     <artifactId>servicediscovery-consumer</artifactId>
     <packaging>jar</packaging>
-    <name>${project.artifactId}</name>
-    <description>The demo consumer module of dubbo project</description>
+    <name>Service Discovery Consumer</name>
+    <description>Service Discovery Consumer</description>
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
     <dependencies>
         <dependency>

--- a/dubbo-samples-cloud-native/dubbo-demo-servicediscovery-xml/servicediscovery-provider/pom.xml
+++ b/dubbo-samples-cloud-native/dubbo-demo-servicediscovery-xml/servicediscovery-provider/pom.xml
@@ -25,10 +25,10 @@
     </parent>
     <artifactId>servicediscovery-provider</artifactId>
     <packaging>jar</packaging>
-    <name>${project.artifactId}</name>
-    <description>The demo provider module of dubbo project</description>
+    <name>Service Discovery Provider</name>
+    <description>Service Discovery Provider</description>
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
         <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
     </properties>
 

--- a/dubbo-samples-cloud-native/dubbo-servicediscovery-migration/dubbo-servicediscovery-migration-api/pom.xml
+++ b/dubbo-samples-cloud-native/dubbo-servicediscovery-migration/dubbo-servicediscovery-migration-api/pom.xml
@@ -29,10 +29,11 @@
     <artifactId>dubbo-servicediscovery-migration-api</artifactId>
 
     <packaging>jar</packaging>
-    <name>${project.artifactId}</name>
+    <name>Dubbo Service Discovery Migration Api</name>
+    <description>Dubbo Service Discovery Migration Api</description>
 
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
 </project>

--- a/dubbo-samples-cloud-native/dubbo-servicediscovery-migration/dubbo-servicediscovery-migration-consumer/pom.xml
+++ b/dubbo-samples-cloud-native/dubbo-servicediscovery-migration/dubbo-servicediscovery-migration-consumer/pom.xml
@@ -29,10 +29,11 @@
     <artifactId>dubbo-servicediscovery-migration-consumer</artifactId>
 
     <packaging>jar</packaging>
-    <name>${project.artifactId}</name>
+    <name>Dubbo Service Discovery Migration Consumer</name>
+    <description>Dubbo Service Discovery Migration Consumer</description>
 
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>

--- a/dubbo-samples-cloud-native/dubbo-servicediscovery-migration/dubbo-servicediscovery-migration-provider1/pom.xml
+++ b/dubbo-samples-cloud-native/dubbo-servicediscovery-migration/dubbo-servicediscovery-migration-provider1/pom.xml
@@ -29,10 +29,11 @@
     <artifactId>dubbo-servicediscovery-migration-provider1</artifactId>
 
     <packaging>jar</packaging>
-    <name>${project.artifactId}</name>
+    <name>Dubbo Service Discovery Migration Provider1</name>
+    <description>Dubbo Service Discovery Migration Provider1</description>
 
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>

--- a/dubbo-samples-cloud-native/dubbo-servicediscovery-migration/dubbo-servicediscovery-migration-provider2/pom.xml
+++ b/dubbo-samples-cloud-native/dubbo-servicediscovery-migration/dubbo-servicediscovery-migration-provider2/pom.xml
@@ -29,10 +29,11 @@
     <artifactId>dubbo-servicediscovery-migration-provider2</artifactId>
 
     <packaging>jar</packaging>
-    <name>${project.artifactId}</name>
+    <name>Dubbo Service Discovery Migration Provider2</name>
+    <description>Dubbo Service Discovery Migration Provider2</description>
 
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>

--- a/dubbo-samples-cloud-native/dubbo-servicediscovery-migration/pom.xml
+++ b/dubbo-samples-cloud-native/dubbo-servicediscovery-migration/pom.xml
@@ -25,6 +25,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-servicediscovery-migration</artifactId>
+    <name>Dubbo Service Discovery Migration</name>
+    <description>Dubbo Service Discovery Migration</description>
 
     <modules>
         <module>dubbo-servicediscovery-migration-api</module>

--- a/dubbo-samples-cloud-native/pom.xml
+++ b/dubbo-samples-cloud-native/pom.xml
@@ -21,7 +21,7 @@
     <artifactId>dubbo-samples-cloud-native</artifactId>
 
     <packaging>pom</packaging>
-    <name>${project.artifactId}</name>
+    <name>Dubbo Samples Cloud Native</name>
     <description>The cloud native demo module of dubbo project</description>
 
     <modules>

--- a/dubbo-samples-cloud-native/sc-call-dubbo/pom.xml
+++ b/dubbo-samples-cloud-native/sc-call-dubbo/pom.xml
@@ -25,6 +25,8 @@
     <groupId>org.apache.dubbo</groupId>
     <artifactId>sc-call-dubbo</artifactId>
     <version>1.0-SNAPSHOT</version>
+    <name>Sc Call Dubbo</name>
+    <description>Sc Call Dubbo</description>
 
     <modules>
         <module>sc-dubbo-api</module>
@@ -33,7 +35,7 @@
     </modules>
 
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
         <spring-boot-maven-plugin.version>2.6.4</spring-boot-maven-plugin.version>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>

--- a/dubbo-samples-cloud-native/sc-call-dubbo/sc-dubbo-api/pom.xml
+++ b/dubbo-samples-cloud-native/sc-call-dubbo/sc-dubbo-api/pom.xml
@@ -24,9 +24,9 @@
     </parent>
     <artifactId>sc-dubbo-api</artifactId>
     <packaging>jar</packaging>
-    <name>${project.artifactId}</name>
-    <description>The demo module of dubbo project</description>
+    <name>Sc Dubbo Api</name>
+    <description>Sc Dubbo Api</description>
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 </project>

--- a/dubbo-samples-cloud-native/sc-call-dubbo/sc-dubbo-consumer/pom.xml
+++ b/dubbo-samples-cloud-native/sc-call-dubbo/sc-dubbo-consumer/pom.xml
@@ -29,6 +29,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>sc-dubbo-consumer</artifactId>
+    <name>Sc Dubbo Consumer</name>
+    <description>Sc Dubbo Consumer</description>
 
     <dependencyManagement>
         <dependencies>

--- a/dubbo-samples-cloud-native/sc-call-dubbo/sc-dubbo-provider/pom.xml
+++ b/dubbo-samples-cloud-native/sc-call-dubbo/sc-dubbo-provider/pom.xml
@@ -29,11 +29,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
         <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
     </properties>
 
     <artifactId>sc-dubbo-provider</artifactId>
+    <name>Sc Dubbo Provider</name>
+    <description>Sc Dubbo Provider</description>
 
     <dependencies>
         <dependency>

--- a/dubbo-samples-cloud-native/servicediscovery-transfer/pom.xml
+++ b/dubbo-samples-cloud-native/servicediscovery-transfer/pom.xml
@@ -25,7 +25,8 @@
     <groupId>org.apache.dubbo</groupId>
     <artifactId>servicediscovery-transfer</artifactId>
     <version>1.0-SNAPSHOT</version>
-
+    <name>Service Discovery Transfer</name>
+    <description>Service Discovery Transfer</description>
 
     <modules>
         <module>servicediscovery-transfer-api</module>
@@ -36,7 +37,7 @@
     </modules>
 
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
         <spring-boot-maven-plugin.version>2.6.4</spring-boot-maven-plugin.version>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>

--- a/dubbo-samples-cloud-native/servicediscovery-transfer/servicediscovery-transfer-api/pom.xml
+++ b/dubbo-samples-cloud-native/servicediscovery-transfer/servicediscovery-transfer-api/pom.xml
@@ -24,9 +24,9 @@
     </parent>
     <artifactId>servicediscovery-transfer-api</artifactId>
     <packaging>jar</packaging>
-    <name>${project.artifactId}</name>
-    <description>The demo module of dubbo project</description>
+    <name>Service Discovery Transfer Api</name>
+    <description>Service Discovery Transfer Api</description>
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 </project>

--- a/dubbo-samples-cloud-native/servicediscovery-transfer/servicediscovery-transfer-consumer-old/pom.xml
+++ b/dubbo-samples-cloud-native/servicediscovery-transfer/servicediscovery-transfer-consumer-old/pom.xml
@@ -24,10 +24,10 @@
     </parent>
     <artifactId>servicediscovery-transfer-consumer-old</artifactId>
     <packaging>jar</packaging>
-    <name>${project.artifactId}</name>
-    <description>The demo consumer module of dubbo project</description>
+    <name>Service Discovery Transfer Consumer Old</name>
+    <description>Service Discovery Transfer Consumer Old</description>
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
     <dependencies>
         <dependency>

--- a/dubbo-samples-cloud-native/servicediscovery-transfer/servicediscovery-transfer-consumer/pom.xml
+++ b/dubbo-samples-cloud-native/servicediscovery-transfer/servicediscovery-transfer-consumer/pom.xml
@@ -25,10 +25,10 @@
     </parent>
     <artifactId>servicediscovery-transfer-consumer</artifactId>
     <packaging>jar</packaging>
-    <name>${project.artifactId}</name>
-    <description>The demo consumer module of dubbo project</description>
+    <name>Service Discovery Transfer Consumer</name>
+    <description>Service Discovery Transfer Consumer</description>
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
     <dependencies>
         <dependency>

--- a/dubbo-samples-cloud-native/servicediscovery-transfer/servicediscovery-transfer-provider-instance/pom.xml
+++ b/dubbo-samples-cloud-native/servicediscovery-transfer/servicediscovery-transfer-provider-instance/pom.xml
@@ -25,10 +25,10 @@
     </parent>
     <artifactId>servicediscovery-transfer-provider-instance</artifactId>
     <packaging>jar</packaging>
-    <name>${project.artifactId}</name>
-    <description>The demo provider module of dubbo project</description>
+    <name>Service Discovery Transfer Provider Instance</name>
+    <description>Service Discovery Transfer Provider Instance</description>
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
         <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
     </properties>
 

--- a/dubbo-samples-cloud-native/servicediscovery-transfer/servicediscovery-transfer-provider/pom.xml
+++ b/dubbo-samples-cloud-native/servicediscovery-transfer/servicediscovery-transfer-provider/pom.xml
@@ -25,10 +25,10 @@
     </parent>
     <artifactId>servicediscovery-transfer-provider</artifactId>
     <packaging>jar</packaging>
-    <name>${project.artifactId}</name>
-    <description>The demo provider module of dubbo project</description>
+    <name>Service Discovery Transfer Provider</name>
+    <description>Service Discovery Transfer Provider</description>
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
         <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
     </properties>
 

--- a/dubbo-samples-compatible/pom.xml
+++ b/dubbo-samples-compatible/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-compatible</artifactId>
+    <name>Dubbo Samples Compatible</name>
+    <description>Dubbo Samples Compatible</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-configcenter/dubbo-samples-configcenter-annotation/pom.xml
+++ b/dubbo-samples-configcenter/dubbo-samples-configcenter-annotation/pom.xml
@@ -27,7 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-configcenter-annotation</artifactId>
-
+    <name>Dubbo Samples Config Center Annotation</name>
+    <description>Dubbo Samples Config Center Annotation</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-configcenter/dubbo-samples-configcenter-api/pom.xml
+++ b/dubbo-samples-configcenter/dubbo-samples-configcenter-api/pom.xml
@@ -25,6 +25,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-configcenter-api</artifactId>
+    <name>Dubbo Samples Config Center Api</name>
+    <description>Dubbo Samples Config Center Api</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-configcenter/dubbo-samples-configcenter-apollo/pom.xml
+++ b/dubbo-samples-configcenter/dubbo-samples-configcenter-apollo/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-configcenter-apollo</artifactId>
+    <name>Dubbo Samples Config Center Apollo</name>
+    <description>Dubbo Samples Config Center Apollo</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-configcenter/dubbo-samples-configcenter-apollo/pom.xml
+++ b/dubbo-samples-configcenter/dubbo-samples-configcenter-apollo/pom.xml
@@ -133,6 +133,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <configuration>
                     <source>${source.level}</source>
                     <target>${target.level}</target>

--- a/dubbo-samples-configcenter/dubbo-samples-configcenter-externalconfiguration/pom.xml
+++ b/dubbo-samples-configcenter/dubbo-samples-configcenter-externalconfiguration/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-configcenter-externalconfiguration</artifactId>
+    <name>Dubbo Samples Config Center External Configuration</name>
+    <description>Dubbo Samples Config Center External Configuration</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-configcenter/dubbo-samples-configcenter-multi-registries/pom.xml
+++ b/dubbo-samples-configcenter/dubbo-samples-configcenter-multi-registries/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-configcenter-multi-registries</artifactId>
+    <name>Dubbo Samples Config Center Multi Registries</name>
+    <description>Dubbo Samples Config Center Multi Registries</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-configcenter/dubbo-samples-configcenter-multiprotocol/pom.xml
+++ b/dubbo-samples-configcenter/dubbo-samples-configcenter-multiprotocol/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-configcenter-multiprotocol</artifactId>
+    <name>Dubbo Samples Config Center Multi Protocol</name>
+    <description>Dubbo Samples Config Center Multi Protocol</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-configcenter/dubbo-samples-configcenter-xml/pom.xml
+++ b/dubbo-samples-configcenter/dubbo-samples-configcenter-xml/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-configcenter-xml</artifactId>
+    <name>Dubbo Samples Config Center Multi Xml</name>
+    <description>Dubbo Samples Config Center Multi Xml</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-configcenter/pom.xml
+++ b/dubbo-samples-configcenter/pom.xml
@@ -39,6 +39,8 @@
 
 
     <artifactId>dubbo-samples-configcenter</artifactId>
+    <name>Dubbo Samples Config Center</name>
+    <description>Dubbo Samples Config Center</description>
 
     <repositories>
         <repository>

--- a/dubbo-samples-consul/pom.xml
+++ b/dubbo-samples-consul/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-consul</artifactId>
+    <name>Dubbo Samples Consul</name>
+    <description>Dubbo Samples Consul</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-context/pom.xml
+++ b/dubbo-samples-context/pom.xml
@@ -24,6 +24,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-context</artifactId>
+    <name>Dubbo Samples Context</name>
+    <description>Dubbo Samples Context</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-default-config/pom.xml
+++ b/dubbo-samples-default-config/pom.xml
@@ -25,6 +25,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-default-config</artifactId>
+    <name>Dubbo Samples Default Config</name>
+    <description>Dubbo Samples Default Config</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-direct/pom.xml
+++ b/dubbo-samples-direct/pom.xml
@@ -24,6 +24,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-direct</artifactId>
+    <name>Dubbo Samples Direct</name>
+    <description>Dubbo Samples Direct</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-docker/pom.xml
+++ b/dubbo-samples-docker/pom.xml
@@ -24,6 +24,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-docker</artifactId>
+    <name>Dubbo Samples Docker</name>
+    <description>Dubbo Samples Docker</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-echo/pom.xml
+++ b/dubbo-samples-echo/pom.xml
@@ -25,6 +25,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-echo</artifactId>
+    <name>Dubbo Samples Echo</name>
+    <description>Dubbo Samples Echo</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-edas/dubbo-samples-edas-consumer/pom.xml
+++ b/dubbo-samples-edas/dubbo-samples-edas-consumer/pom.xml
@@ -104,6 +104,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/dubbo-samples-edas/dubbo-samples-edas-consumer/pom.xml
+++ b/dubbo-samples-edas/dubbo-samples-edas-consumer/pom.xml
@@ -19,14 +19,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>dubbo-samples-edas</artifactId>
         <groupId>org.apache.dubbo</groupId>
         <version>1.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-edas-consumer</artifactId>
+    <name>Dubbo Samples Edas Consumer</name>
+    <description>Dubbo Samples Edas Consumer</description>
 
     <properties>
         <spring-boot.version>2.1.1.RELEASE</spring-boot.version>

--- a/dubbo-samples-edas/dubbo-samples-edas-provider/pom.xml
+++ b/dubbo-samples-edas/dubbo-samples-edas-provider/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-edas-provider</artifactId>
+    <name>Dubbo Samples Edas Provider</name>
+    <description>Dubbo Samples Edas Provider</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-edas/dubbo-samples-edas-provider/pom.xml
+++ b/dubbo-samples-edas/dubbo-samples-edas-provider/pom.xml
@@ -174,6 +174,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/dubbo-samples-edas/pom.xml
+++ b/dubbo-samples-edas/pom.xml
@@ -28,6 +28,8 @@
     <packaging>pom</packaging>
 
     <artifactId>dubbo-samples-edas</artifactId>
+    <name>Dubbo Samples Edas</name>
+    <description>Dubbo Samples Edas</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-environment-keys/pom.xml
+++ b/dubbo-samples-environment-keys/pom.xml
@@ -24,6 +24,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-environment-keys</artifactId>
+    <name>Dubbo Samples Environment Keys</name>
+    <description>Dubbo Samples Environment Keys</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-gateway/pom.xml
+++ b/dubbo-samples-gateway/pom.xml
@@ -26,6 +26,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-gateway</artifactId>
+    <name>Dubbo Samples Gateway</name>
+    <description>Dubbo Samples Gateway</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-generic/dubbo-samples-generic-call/dubbo-samples-generic-call-api/pom.xml
+++ b/dubbo-samples-generic/dubbo-samples-generic-call/dubbo-samples-generic-call-api/pom.xml
@@ -29,6 +29,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-generic-call-api</artifactId>
-
+    <name>Dubbo Samples Generic Call Api</name>
+    <description>Dubbo Samples Generic Call Api</description>
 
 </project>

--- a/dubbo-samples-generic/dubbo-samples-generic-call/dubbo-samples-generic-call-consumer/pom.xml
+++ b/dubbo-samples-generic/dubbo-samples-generic-call/dubbo-samples-generic-call-consumer/pom.xml
@@ -29,6 +29,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-generic-call-consumer</artifactId>
+    <name>Dubbo Samples Generic Call Consumer</name>
+    <description>Dubbo Samples Generic Call Consumer</description>
 
     <dependencies>
         <dependency>

--- a/dubbo-samples-generic/dubbo-samples-generic-call/dubbo-samples-generic-call-provider/pom.xml
+++ b/dubbo-samples-generic/dubbo-samples-generic-call/dubbo-samples-generic-call-provider/pom.xml
@@ -29,6 +29,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-generic-call-provider</artifactId>
+    <name>Dubbo Samples Generic Call Provider</name>
+    <description>Dubbo Samples Generic Call Provider</description>
 
     <dependencies>
         <dependency>

--- a/dubbo-samples-generic/dubbo-samples-generic-call/pom.xml
+++ b/dubbo-samples-generic/dubbo-samples-generic-call/pom.xml
@@ -29,6 +29,8 @@
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <artifactId>dubbo-samples-generic-call</artifactId>
+    <name>Dubbo Samples Generic Call</name>
+    <description>Dubbo Samples Generic Call</description>
 
     <properties>
         <source.level>1.8</source.level>
@@ -36,7 +38,6 @@
         <dubbo.version>3.0.7</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
-        <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     </properties>
 
     <modules>

--- a/dubbo-samples-generic/dubbo-samples-generic-impl/dubbo-samples-generic-impl-api/pom.xml
+++ b/dubbo-samples-generic/dubbo-samples-generic-impl/dubbo-samples-generic-impl-api/pom.xml
@@ -30,4 +30,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-generic-impl-api</artifactId>
+    <name>Dubbo Samples Generic Impl Api</name>
+    <description>Dubbo Samples Generic Impl Api</description>
 </project>

--- a/dubbo-samples-generic/dubbo-samples-generic-impl/dubbo-samples-generic-impl-consumer/pom.xml
+++ b/dubbo-samples-generic/dubbo-samples-generic-impl/dubbo-samples-generic-impl-consumer/pom.xml
@@ -29,6 +29,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-generic-impl-consumer</artifactId>
+    <name>Dubbo Samples Generic Impl Consumer</name>
+    <description>Dubbo Samples Generic Impl Consumer</description>
 
     <dependencies>
         <dependency>

--- a/dubbo-samples-generic/dubbo-samples-generic-impl/dubbo-samples-generic-impl-provider/pom.xml
+++ b/dubbo-samples-generic/dubbo-samples-generic-impl/dubbo-samples-generic-impl-provider/pom.xml
@@ -29,6 +29,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-generic-impl-provider</artifactId>
+    <name>Dubbo Samples Generic Impl Provider</name>
+    <description>Dubbo Samples Generic Impl Provider</description>
 
     <dependencies>
         <dependency>

--- a/dubbo-samples-generic/dubbo-samples-generic-impl/pom.xml
+++ b/dubbo-samples-generic/dubbo-samples-generic-impl/pom.xml
@@ -29,6 +29,8 @@
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <artifactId>dubbo-samples-generic-impl</artifactId>
+    <name>Dubbo Samples Generic Impl</name>
+    <description>Dubbo Samples Generic Impl</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-generic/dubbo-samples-generic-type/pom.xml
+++ b/dubbo-samples-generic/dubbo-samples-generic-type/pom.xml
@@ -29,6 +29,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-generic-type</artifactId>
+    <name>Dubbo Samples Generic Type</name>
+    <description>Dubbo Samples Generic Type</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-generic/pom.xml
+++ b/dubbo-samples-generic/pom.xml
@@ -29,6 +29,8 @@
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <artifactId>dubbo-samples-generic</artifactId>
+    <name>Dubbo Samples Generic</name>
+    <description>Dubbo Samples Generic</description>
 
     <modules>
         <module>dubbo-samples-generic-call</module>

--- a/dubbo-samples-governance/dubbo-samples-applevel-override/pom.xml
+++ b/dubbo-samples-governance/dubbo-samples-applevel-override/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-applevel-override</artifactId>
+    <name>Dubbo Samples App Level Override</name>
+    <description>Dubbo Samples App Level Override</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-governance/dubbo-samples-configconditionrouter/pom.xml
+++ b/dubbo-samples-governance/dubbo-samples-configconditionrouter/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-configconditionrouter</artifactId>
+    <name>Dubbo Samples Config Condition Router</name>
+    <description>Dubbo Samples Config Condition Router</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-governance/dubbo-samples-meshrule-router/pom.xml
+++ b/dubbo-samples-governance/dubbo-samples-meshrule-router/pom.xml
@@ -27,6 +27,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-meshrule-router</artifactId>
+    <name>Dubbo Samples Mesh Rule Router</name>
+    <description>Dubbo Samples Mesh Rule Router</description>
+
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>

--- a/dubbo-samples-governance/dubbo-samples-servicelevel-override/pom.xml
+++ b/dubbo-samples-governance/dubbo-samples-servicelevel-override/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-servicelevel-override</artifactId>
+    <name>Dubbo Samples Service Level Override</name>
+    <description>Dubbo Samples Service Level Override</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-governance/dubbo-samples-tagrouter/pom.xml
+++ b/dubbo-samples-governance/dubbo-samples-tagrouter/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-tagrouter</artifactId>
+    <name>Dubbo Samples Tag Router</name>
+    <description>Dubbo Samples Tag Router</description>
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>

--- a/dubbo-samples-governance/pom.xml
+++ b/dubbo-samples-governance/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <artifactId>dubbo-samples-governance</artifactId>
+    <name>Dubbo Samples Governance</name>
+    <description>Dubbo Samples Governance</description>
 
     <modules>
         <module>dubbo-samples-applevel-override</module>

--- a/dubbo-samples-group/pom.xml
+++ b/dubbo-samples-group/pom.xml
@@ -25,6 +25,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-group</artifactId>
+    <name>Dubbo Samples Group</name>
+    <description>Dubbo Samples Group</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-grpc/dubbo-samples-original/pom.xml
+++ b/dubbo-samples-grpc/dubbo-samples-original/pom.xml
@@ -198,6 +198,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/dubbo-samples-grpc/dubbo-samples-reactor/pom.xml
+++ b/dubbo-samples-grpc/dubbo-samples-reactor/pom.xml
@@ -186,6 +186,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/dubbo-samples-grpc/dubbo-samples-rxjava/pom.xml
+++ b/dubbo-samples-grpc/dubbo-samples-rxjava/pom.xml
@@ -193,6 +193,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/dubbo-samples-grpc/dubbo-samples-ssl/dubbo-samples-grpc-ssl-consumer/pom.xml
+++ b/dubbo-samples-grpc/dubbo-samples-ssl/dubbo-samples-grpc-ssl-consumer/pom.xml
@@ -35,7 +35,7 @@
         <jib-maven-plugin.version>1.2.0</jib-maven-plugin.version>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
         <maven-failsafe-plugin.version>2.21.0</maven-failsafe-plugin.version>
-        <image.name>${artifactId}:${dubbo.version}</image.name>
+        <image.name>${project.artifactId}:${dubbo.version}</image.name>
         <java-image.name>openjdk:8</java-image.name>
         <dubbo.port>20880</dubbo.port>
         <zookeeper.port>2181</zookeeper.port>
@@ -200,6 +200,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>
@@ -217,6 +218,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
                 <configuration>
                     <executable>true</executable>
                     <mainClass>org.apache.dubbo.samples.basic.SslBasicConsumer</mainClass>

--- a/dubbo-samples-grpc/dubbo-samples-ssl/dubbo-samples-grpc-ssl-provider/pom.xml
+++ b/dubbo-samples-grpc/dubbo-samples-ssl/dubbo-samples-grpc-ssl-provider/pom.xml
@@ -35,7 +35,7 @@
         <jib-maven-plugin.version>1.2.0</jib-maven-plugin.version>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
         <maven-failsafe-plugin.version>2.21.0</maven-failsafe-plugin.version>
-        <image.name>${artifactId}:${dubbo.version}</image.name>
+        <image.name>${project.artifactId}:${dubbo.version}</image.name>
         <java-image.name>openjdk:8</java-image.name>
         <dubbo.port>20880</dubbo.port>
         <zookeeper.port>2181</zookeeper.port>
@@ -200,6 +200,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>
@@ -218,6 +219,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
                 <configuration>
                     <executable>true</executable>
                     <mainClass>org.apache.dubbo.samples.basic.SslBasicProvider</mainClass>

--- a/dubbo-samples-grpc/pom.xml
+++ b/dubbo-samples-grpc/pom.xml
@@ -24,6 +24,8 @@
     <version>1.0-SNAPSHOT</version>
     <artifactId>dubbo-samples-grpc</artifactId>
     <packaging>pom</packaging>
+    <name>Dubbo Samples Grpc</name>
+    <description>Dubbo Samples Grpc</description>
 
     <modules>
         <module>dubbo-samples-original</module>

--- a/dubbo-samples-http/pom.xml
+++ b/dubbo-samples-http/pom.xml
@@ -25,6 +25,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-http</artifactId>
+    <name>Dubbo Samples Http</name>
+    <description>Dubbo Samples Http</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-jetty/pom.xml
+++ b/dubbo-samples-jetty/pom.xml
@@ -23,9 +23,8 @@
   <artifactId>dubbo-samples-jetty</artifactId>
   <version>1.0-SNAPSHOT</version>
 
-  <name>dubbo-samples-jetty</name>
-  <!-- FIXME change it to the project's website -->
-  <url>http://www.example.com</url>
+  <name>Dubbo Samples Jetty</name>
+  <description>Dubbo Samples Jetty</description>
 
   <properties>
     <source.level>1.8</source.level>

--- a/dubbo-samples-kubernetes/pom.xml
+++ b/dubbo-samples-kubernetes/pom.xml
@@ -32,6 +32,8 @@
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <artifactId>dubbo-samples-kubernetes</artifactId>
+    <name>Dubbo Samples Kubernetes</name>
+    <description>Dubbo Samples Kubernetes</description>
 
     <repositories>
         <repository>

--- a/dubbo-samples-local/pom.xml
+++ b/dubbo-samples-local/pom.xml
@@ -24,6 +24,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-local</artifactId>
+    <name>Dubbo Samples Local</name>
+    <description>Dubbo Samples Local</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-merge/pom.xml
+++ b/dubbo-samples-merge/pom.xml
@@ -19,6 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.dubbo</groupId>
     <packaging>pom</packaging>
     <version>1.0-SNAPSHOT</version>
@@ -29,9 +30,10 @@
         <module>dubbo-samples-merge-consumer</module>
     </modules>
 
-    <modelVersion>4.0.0</modelVersion>
-
     <artifactId>dubbo-samples-merge</artifactId>
+    <name>Dubbo Samples Merge</name>
+    <description>Dubbo Samples Merge</description>
+
     <properties>
         <dubbo.version>3.0.7</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>

--- a/dubbo-samples-mesh-k8s/pom.xml
+++ b/dubbo-samples-mesh-k8s/pom.xml
@@ -20,6 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.dubbo</groupId>
     <version>1.0-SNAPSHOT</version>
     <modules>
@@ -27,9 +28,10 @@
         <module>dubbo-samples-mesh-provider</module>
     </modules>
 
-    <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <artifactId>dubbo-samples-mesh-k8s</artifactId>
+    <name>Dubbo Samples Mesh k8s</name>
+    <description>Dubbo Samples Mesh k8s</description>
 
     <repositories>
         <repository>

--- a/dubbo-samples-metadata-report/pom.xml
+++ b/dubbo-samples-metadata-report/pom.xml
@@ -27,6 +27,9 @@
 
     <artifactId>dubbo-samples-metadata-report</artifactId>
     <packaging>pom</packaging>
+    <name>Dubbo Samples Metadata Report</name>
+    <description>Dubbo Samples Metadata Report</description>
+
     <modules>
         <module>dubbo-samples-metadata-report-configcenter</module>
         <module>dubbo-samples-metadata-report-local-annotation</module>

--- a/dubbo-samples-metrics/pom.xml
+++ b/dubbo-samples-metrics/pom.xml
@@ -26,6 +26,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-metrics</artifactId>
+    <name>Dubbo Samples Metrics</name>
+    <description>Dubbo Samples Metrics</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-migration/pom.xml
+++ b/dubbo-samples-migration/pom.xml
@@ -25,6 +25,8 @@
     <artifactId>dubbo-samples-migration</artifactId>
     <packaging>pom</packaging>
     <version>1.0-SNAPSHOT</version>
+    <name>Dubbo Samples Migration</name>
+    <description>Dubbo Samples Migration</description>
     
     <modules>
         <module>dubbo-samples-migration-api</module>

--- a/dubbo-samples-mock/pom.xml
+++ b/dubbo-samples-mock/pom.xml
@@ -26,6 +26,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-mock</artifactId>
+    <name>Dubbo Samples Mock</name>
+    <description>Dubbo Samples Mock</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-monitor/pom.xml
+++ b/dubbo-samples-monitor/pom.xml
@@ -25,6 +25,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-monitor</artifactId>
+    <name>Dubbo Samples Monitor</name>
+    <description>Dubbo Samples Monitor</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-multi-registry/pom.xml
+++ b/dubbo-samples-multi-registry/pom.xml
@@ -25,6 +25,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-multi-registry</artifactId>
+    <name>Dubbo Samples Multi Registry</name>
+    <description>Dubbo Samples Multi Registry</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-nacos/pom.xml
+++ b/dubbo-samples-nacos/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <artifactId>dubbo-samples-nacos</artifactId>
+    <name>Dubbo Samples Nacos</name>
+    <description>Dubbo Samples Nacos</description>
 
     <modules>
         <module>dubbo-samples-nacos-override</module>

--- a/dubbo-samples-notify/pom.xml
+++ b/dubbo-samples-notify/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-notify</artifactId>
+    <name>Dubbo Samples Notify</name>
+    <description>Dubbo Samples Notify</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-perf/pom.xml
+++ b/dubbo-samples-perf/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <artifactId>dubbo-samples-perf</artifactId>
+    <name>Dubbo Samples Perf</name>
+    <description>Dubbo Samples Perf</description>
 
     <modules>
         <module>registry</module>

--- a/dubbo-samples-port-unification/pom.xml
+++ b/dubbo-samples-port-unification/pom.xml
@@ -25,6 +25,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-port-unification</artifactId>
+    <name>Dubbo Samples Port Unification</name>
+    <description>Dubbo Samples Port Unification</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/dubbo-samples-protobuf-json/pom.xml
+++ b/dubbo-samples-protobuf-json/pom.xml
@@ -25,6 +25,9 @@
 
     <artifactId>dubbo-samples-protobuf-json</artifactId>
     <packaging>pom</packaging>
+    <name>Dubbo Samples Protobuf Json</name>
+    <description>Dubbo Samples Protobuf Json</description>
+
     <modules>
         <module>protobuf-json-serialization-api</module>
         <module>protobuf-json-serialization-demo</module>

--- a/dubbo-samples-protobuf/pom.xml
+++ b/dubbo-samples-protobuf/pom.xml
@@ -14,14 +14,15 @@
   See the License for the specific language governing permissions and
   limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.dubbo</groupId>
     <version>1.0-SNAPSHOT</version>
     <artifactId>dubbo-samples-protobuf</artifactId>
 
     <packaging>pom</packaging>
-    <name>${project.artifactId}</name>
+    <name>Dubbo Samples Protobuf</name>
     <description>The protobuf demo module of dubbo project</description>
 
     <properties>
@@ -140,6 +141,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/dubbo-samples-protobuf/pom.xml
+++ b/dubbo-samples-protobuf/pom.xml
@@ -28,7 +28,7 @@
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
         <compiler.version>0.0.2</compiler.version>
         <dubbo.version>2.7.13</dubbo.version>
         <spring.version>4.3.16.RELEASE</spring.version>

--- a/dubbo-samples-protobuf/protobuf-consumer/pom.xml
+++ b/dubbo-samples-protobuf/protobuf-consumer/pom.xml
@@ -27,7 +27,7 @@
     <name>${project.artifactId}</name>
     <description>The demo consumer module of dubbo project</description>
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
         <junit.version>4.12</junit.version>
     </properties>
 

--- a/dubbo-samples-protobuf/protobuf-provider/pom.xml
+++ b/dubbo-samples-protobuf/protobuf-provider/pom.xml
@@ -28,7 +28,7 @@
     <name>${project.artifactId}</name>
     <description>The demo provider module of dubbo project</description>
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
         <junit.version>4.12</junit.version>
     </properties>
 

--- a/dubbo-samples-protostuff/pom.xml
+++ b/dubbo-samples-protostuff/pom.xml
@@ -25,7 +25,8 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-samples-protostuff</artifactId>
-    <name>dubbo-samples-protostuff</name>
+    <name>Dubbo Samples Protostuff</name>
+    <description>Dubbo Samples Protostuff</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/dubbo-samples-resilience4j/dubbo-samples-resilience4j-filter/pom.xml
+++ b/dubbo-samples-resilience4j/dubbo-samples-resilience4j-filter/pom.xml
@@ -201,10 +201,6 @@
             <artifactId>slf4j-simple</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.github.resilience4j</groupId>
             <artifactId>resilience4j-circuitbreaker</artifactId>
             <version>${resilience4j.version}</version>

--- a/dubbo-samples-resilience4j/dubbo-samples-resilience4j-springboot2/pom.xml
+++ b/dubbo-samples-resilience4j/dubbo-samples-resilience4j-springboot2/pom.xml
@@ -202,10 +202,6 @@
             <artifactId>slf4j-simple</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.github.resilience4j</groupId>
             <artifactId>resilience4j-circuitbreaker</artifactId>
             <version>${resilience4j.version}</version>

--- a/dubbo-samples-resilience4j/pom.xml
+++ b/dubbo-samples-resilience4j/pom.xml
@@ -28,6 +28,9 @@
 
     <artifactId>dubbo-samples-resilience4j</artifactId>
     <packaging>pom</packaging>
+    <name>Dubbo Samples Resilience4j</name>
+    <description>Dubbo Samples Resilience4j</description>
+
     <modules>
         <module>dubbo-samples-resilience4j-filter</module>
         <module>dubbo-samples-resilience4j-springboot2</module>

--- a/dubbo-samples-rest/pom.xml
+++ b/dubbo-samples-rest/pom.xml
@@ -1,4 +1,4 @@
- <?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -25,6 +25,8 @@
     <modelVersion>4.0.0</modelVersion>
     <packaging>war</packaging>
     <artifactId>dubbo-samples-rest</artifactId>
+    <name>Dubbo Samples Rest</name>
+    <description>Dubbo Samples Rest</description>
 
     <properties>
         <source.level>1.8</source.level>
@@ -131,10 +133,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>

--- a/dubbo-samples-rocketmq/pom.xml
+++ b/dubbo-samples-rocketmq/pom.xml
@@ -14,14 +14,15 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
         xmlns="http://maven.apache.org/POM/4.0.0">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.apache.dubbo</groupId>
+    <parent>
+        <groupId>org.apache.dubbo</groupId>
+        <artifactId>dubbo-samples-all</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
     <artifactId>dubbo-samples-rocketmq</artifactId>
-    <version>1.0-SNAPSHOT</version>
     <name>Dubbo Samples Rocketmq</name>
     <description>Dubbo Samples Rocketmq</description>
     <properties>
-        <source.level>1.8</source.level>
-        <target.level>1.8</target.level>
         <spring.version>4.3.16.RELEASE</spring.version>
         <dubbo.version>3.0.7</dubbo.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -68,25 +69,5 @@
             <artifactId>dubbo-registry-nameservice</artifactId>
             <version>1.0.3-SNAPSHOT</version>
         </dependency>
-
     </dependencies>
-
-
-    <repositories>
-        <repository>
-            <id>apache.snapshots.https</id>
-            <name>Apache Development Snapshot Repository</name>
-            <url>https://repository.apache.org/content/repositories/snapshots</url>
-            <layout>default</layout>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-            </snapshots>
-        </repository>
-    </repositories>
-
-
 </project>

--- a/dubbo-samples-rocketmq/pom.xml
+++ b/dubbo-samples-rocketmq/pom.xml
@@ -17,7 +17,8 @@
     <groupId>org.apache.dubbo</groupId>
     <artifactId>dubbo-samples-rocketmq</artifactId>
     <version>1.0-SNAPSHOT</version>
-    <name>dubbo-samples-rocketmq</name>
+    <name>Dubbo Samples Rocketmq</name>
+    <description>Dubbo Samples Rocketmq</description>
     <properties>
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
@@ -73,15 +74,16 @@
 
     <repositories>
         <repository>
-            <id>mvnrepository</id>
-            <name>mvnrepository</name>
-            <url>https://repository.apache.org</url>
+            <id>apache.snapshots.https</id>
+            <name>Apache Development Snapshot Repository</name>
+            <url>https://repository.apache.org/content/repositories/snapshots</url>
             <layout>default</layout>
             <releases>
-                <enabled>true</enabled>
+                <enabled>false</enabled>
             </releases>
             <snapshots>
                 <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
             </snapshots>
         </repository>
     </repositories>

--- a/dubbo-samples-scala/pom.xml
+++ b/dubbo-samples-scala/pom.xml
@@ -25,6 +25,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-scala</artifactId>
+    <name>Dubbo Samples Scala</name>
+    <description>Dubbo Samples Scala</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-sentinel/pom.xml
+++ b/dubbo-samples-sentinel/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-sentinel</artifactId>
+    <name>Dubbo Samples Sentinel</name>
+    <description>Dubbo Samples Sentinel</description>
 
     <properties>
         <source.level>1.8</source.level>
@@ -144,6 +146,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>2.4.1</version>
+                <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/dubbo-samples-serialization/dubbo-samples-prefer-serialization/case-configuration.yml
+++ b/dubbo-samples-serialization/dubbo-samples-prefer-serialization/case-configuration.yml
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from: app-builtin-zookeeper.yml
+
+props:
+  project_name: dubbo-samples-prefer-serialization
+  main_class: org.apache.dubbo.samples.prefer.serialization.DubboProvider
+  zookeeper_port: 2181
+  dubbo_port: 20880
+

--- a/dubbo-samples-serialization/dubbo-samples-prefer-serialization/case-versions.conf
+++ b/dubbo-samples-serialization/dubbo-samples-prefer-serialization/case-versions.conf
@@ -1,0 +1,24 @@
+#
+#
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+
+# Supported component versions of the test case
+
+# Spring app
+dubbo.version=2.7*, 3.*
+spring.version=4.*, 5.*

--- a/dubbo-samples-serialization/dubbo-samples-prefer-serialization/case-versions.conf
+++ b/dubbo-samples-serialization/dubbo-samples-prefer-serialization/case-versions.conf
@@ -20,5 +20,5 @@
 # Supported component versions of the test case
 
 # Spring app
-dubbo.version=2.7*, 3.*
+dubbo.version=[ >=3.2.0 ]
 spring.version=4.*, 5.*

--- a/dubbo-samples-serialization/dubbo-samples-prefer-serialization/pom.xml
+++ b/dubbo-samples-serialization/dubbo-samples-prefer-serialization/pom.xml
@@ -2,8 +2,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>dubbo-samples-serialization</artifactId>
         <groupId>org.apache.dubbo</groupId>
+        <artifactId>dubbo-samples-serialization</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>
 
@@ -14,9 +14,11 @@
     <description>Dubbo Samples Prefer Serialization</description>
 
     <properties>
-        <dubbo.version>3.1.3-SNAPSHOT</dubbo.version>
+<!--        <dubbo.version>3.1.3-SNAPSHOT</dubbo.version>-->
+        <dubbo.version>3.2.0-beta.2-SNAPSHOT</dubbo.version>
         <junit.version>4.12</junit.version>
-        <spring.version>4.3.16.RELEASE</spring.version>
+<!--        <spring.version>4.3.16.RELEASE</spring.version>-->
+        <spring.version>5.3.24</spring.version>
     </properties>
 
     <dependencyManagement>

--- a/dubbo-samples-serialization/dubbo-samples-prefer-serialization/pom.xml
+++ b/dubbo-samples-serialization/dubbo-samples-prefer-serialization/pom.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -14,11 +30,10 @@
     <description>Dubbo Samples Prefer Serialization</description>
 
     <properties>
-<!--        <dubbo.version>3.1.3-SNAPSHOT</dubbo.version>-->
         <dubbo.version>3.2.0-beta.2-SNAPSHOT</dubbo.version>
-        <junit.version>4.12</junit.version>
-<!--        <spring.version>4.3.16.RELEASE</spring.version>-->
-        <spring.version>5.3.24</spring.version>
+        <junit.version>4.13.1</junit.version>
+        <spring.version>4.3.16.RELEASE</spring.version>
+        <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
     </properties>
 
     <dependencyManagement>
@@ -46,7 +61,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
-                <version>1.7.25</version>
+                <version>${slf4j-log4j12.version}</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>

--- a/dubbo-samples-serialization/dubbo-samples-prefer-serialization/pom.xml
+++ b/dubbo-samples-serialization/dubbo-samples-prefer-serialization/pom.xml
@@ -1,0 +1,78 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>dubbo-samples-serialization</artifactId>
+        <groupId>org.apache.dubbo</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>dubbo-samples-prefer-serialization</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Dubbo Samples Prefer Serialization</name>
+    <description>Dubbo Samples Prefer Serialization</description>
+
+    <properties>
+        <dubbo.version>3.1.3-SNAPSHOT</dubbo.version>
+        <junit.version>4.12</junit.version>
+        <spring.version>4.3.16.RELEASE</spring.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-framework-bom</artifactId>
+                <version>${spring.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.dubbo</groupId>
+                <artifactId>dubbo-bom</artifactId>
+                <version>${dubbo.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.dubbo</groupId>
+                <artifactId>dubbo-dependencies-zookeeper</artifactId>
+                <version>${dubbo.version}</version>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>1.7.25</version>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-dependencies-zookeeper</artifactId>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/java/org/apache/dubbo/samples/prefer/serialization/DubboConsumer.java
+++ b/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/java/org/apache/dubbo/samples/prefer/serialization/DubboConsumer.java
@@ -21,6 +21,8 @@ package org.apache.dubbo.samples.prefer.serialization;
 import org.apache.dubbo.samples.prefer.serialization.api.DemoService;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
+import java.util.concurrent.locks.LockSupport;
+
 public class DubboConsumer {
 
     public static void main(String[] args) {

--- a/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/java/org/apache/dubbo/samples/prefer/serialization/DubboConsumer.java
+++ b/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/java/org/apache/dubbo/samples/prefer/serialization/DubboConsumer.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.samples.prefer.serialization;
+
+
+import org.apache.dubbo.samples.prefer.serialization.api.DemoService;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+public class DubboConsumer {
+
+    public static void main(String[] args) {
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("spring/dubbo-demo-consumer.xml");
+        context.start();
+        DemoService demoService = context.getBean("demoService", DemoService.class);
+        String hello = demoService.sayHello("world");
+        System.out.println(hello);
+    }
+}

--- a/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/java/org/apache/dubbo/samples/prefer/serialization/DubboProvider.java
+++ b/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/java/org/apache/dubbo/samples/prefer/serialization/DubboProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.samples.prefer.serialization;
+
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import java.util.concurrent.CountDownLatch;
+
+public class DubboProvider {
+
+    public static void main(String[] args) throws Exception {
+        System.out.println("Java serialization is unsafe. Dubbo Team do not recommend anyone to use it." +
+                "If you still want to use it, please follow [JEP 290](https://openjdk.java.net/jeps/290)" +
+                "to set serialization filter to prevent deserialization leak.");
+
+        new EmbeddedZooKeeper(2181, false).start();
+
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("spring/dubbo-demo-provider.xml");
+        context.start();
+
+        System.out.println("dubbo service started");
+        new CountDownLatch(1).await();
+    }
+}

--- a/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/java/org/apache/dubbo/samples/prefer/serialization/DubboProvider.java
+++ b/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/java/org/apache/dubbo/samples/prefer/serialization/DubboProvider.java
@@ -20,6 +20,7 @@ package org.apache.dubbo.samples.prefer.serialization;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.locks.LockSupport;
 
 public class DubboProvider {
 
@@ -30,10 +31,10 @@ public class DubboProvider {
 
         new EmbeddedZooKeeper(2181, false).start();
 
-        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("spring/dubbo-demo-provider.xml");
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("classpath:spring/dubbo-demo-provider.xml");
         context.start();
 
         System.out.println("dubbo service started");
-        new CountDownLatch(1).await();
+        LockSupport.park();
     }
 }

--- a/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/java/org/apache/dubbo/samples/prefer/serialization/EmbeddedZooKeeper.java
+++ b/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/java/org/apache/dubbo/samples/prefer/serialization/EmbeddedZooKeeper.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.samples.prefer.serialization;
+
+import org.apache.zookeeper.server.ServerConfig;
+import org.apache.zookeeper.server.ZooKeeperServerMain;
+import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.util.ErrorHandler;
+import org.springframework.util.SocketUtils;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.util.Properties;
+import java.util.UUID;
+
+/**
+ * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
+ *
+ * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
+ *
+ * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
+ * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
+ *
+ * @author Patrick Peralta
+ * @author Mark Fisher
+ * @author David Turanski
+ */
+public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    /**
+     * Logger.
+     */
+    private static final Logger logger = LoggerFactory.getLogger(EmbeddedZooKeeper.class);
+
+    /**
+     * ZooKeeper client port. This will be determined dynamically upon startup.
+     */
+    private final int clientPort;
+
+    /**
+     * Whether to auto-start. Default is true.
+     */
+    private boolean autoStartup = true;
+
+    /**
+     * Lifecycle phase. Default is 0.
+     */
+    private int phase = 0;
+
+    /**
+     * Thread for running the ZooKeeper server.
+     */
+    private volatile Thread zkServerThread;
+
+    /**
+     * ZooKeeper server.
+     */
+    private volatile ZooKeeperServerMain zkServer;
+
+    /**
+     * {@link ErrorHandler} to be invoked if an Exception is thrown from the ZooKeeper server thread.
+     */
+    private ErrorHandler errorHandler;
+
+    private boolean daemon = true;
+
+    /**
+     * Construct an EmbeddedZooKeeper with a random port.
+     */
+    public EmbeddedZooKeeper() {
+        clientPort = SocketUtils.findAvailableTcpPort();
+    }
+
+    /**
+     * Construct an EmbeddedZooKeeper with the provided port.
+     *
+     * @param clientPort  port for ZooKeeper server to bind to
+     */
+    public EmbeddedZooKeeper(int clientPort, boolean daemon) {
+        this.clientPort = clientPort;
+        this.daemon = daemon;
+    }
+
+    /**
+     * Returns the port that clients should use to connect to this embedded server.
+     *
+     * @return dynamically determined client port
+     */
+    public int getClientPort() {
+        return this.clientPort;
+    }
+
+    /**
+     * Specify whether to start automatically. Default is true.
+     *
+     * @param autoStartup whether to start automatically
+     */
+    public void setAutoStartup(boolean autoStartup) {
+        this.autoStartup = autoStartup;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isAutoStartup() {
+        return this.autoStartup;
+    }
+
+    /**
+     * Specify the lifecycle phase for the embedded server.
+     *
+     * @param phase the lifecycle phase
+     */
+    public void setPhase(int phase) {
+        this.phase = phase;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getPhase() {
+        return this.phase;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isRunning() {
+        return (zkServerThread != null);
+    }
+
+    /**
+     * Start the ZooKeeper server in a background thread.
+     * <p>
+     * Register an error handler via {@link #setErrorHandler} in order to handle
+     * any exceptions thrown during startup or execution.
+     */
+    @Override
+    public synchronized void start() {
+        if (zkServerThread == null) {
+            zkServerThread = new Thread(new ServerRunnable(), "ZooKeeper Server Starter");
+            zkServerThread.setDaemon(daemon);
+            zkServerThread.start();
+        }
+    }
+
+    /**
+     * Shutdown the ZooKeeper server.
+     */
+    @Override
+    public synchronized void stop() {
+        if (zkServerThread != null) {
+            // The shutdown method is protected...thus this hack to invoke it.
+            // This will log an exception on shutdown; see
+            // https://issues.apache.org/jira/browse/ZOOKEEPER-1873 for details.
+            try {
+                Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
+                shutdown.setAccessible(true);
+                shutdown.invoke(zkServer);
+            }
+
+            catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            // It is expected that the thread will exit after
+            // the server is shutdown; this will block until
+            // the shutdown is complete.
+            try {
+                zkServerThread.join(5000);
+                zkServerThread = null;
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
+                // abandoning zk thread
+                zkServerThread = null;
+            }
+        }
+    }
+
+    /**
+     * Stop the server if running and invoke the callback when complete.
+     */
+    @Override
+    public void stop(Runnable callback) {
+        stop();
+        callback.run();
+    }
+
+    /**
+     * Provide an {@link ErrorHandler} to be invoked if an Exception is thrown from the ZooKeeper server thread. If none
+     * is provided, only error-level logging will occur.
+     *
+     * @param errorHandler the {@link ErrorHandler} to be invoked
+     */
+    public void setErrorHandler(ErrorHandler errorHandler) {
+        this.errorHandler = errorHandler;
+    }
+
+    /**
+     * Runnable implementation that starts the ZooKeeper server.
+     */
+    private class ServerRunnable implements Runnable {
+
+        @Override
+        public void run() {
+            try {
+                Properties properties = new Properties();
+                File file = new File(System.getProperty("java.io.tmpdir")
+                    + File.separator + UUID.randomUUID());
+                file.deleteOnExit();
+                properties.setProperty("dataDir", file.getAbsolutePath());
+                properties.setProperty("clientPort", String.valueOf(clientPort));
+
+                QuorumPeerConfig quorumPeerConfig = new QuorumPeerConfig();
+                quorumPeerConfig.parseProperties(properties);
+
+                zkServer = new ZooKeeperServerMain();
+                ServerConfig configuration = new ServerConfig();
+                configuration.readFrom(quorumPeerConfig);
+
+                zkServer.runFromConfig(configuration);
+            }
+            catch (Exception e) {
+                if (errorHandler != null) {
+                    errorHandler.handleError(e);
+                }
+                else {
+                    logger.error("Exception running embedded ZooKeeper", e);
+                }
+            }
+        }
+    }
+
+}

--- a/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/java/org/apache/dubbo/samples/prefer/serialization/api/DemoService.java
+++ b/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/java/org/apache/dubbo/samples/prefer/serialization/api/DemoService.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.samples.prefer.serialization.api;
+
+public interface DemoService {
+    String sayHello(String name);
+}

--- a/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/java/org/apache/dubbo/samples/prefer/serialization/impl/DemoServiceImpl.java
+++ b/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/java/org/apache/dubbo/samples/prefer/serialization/impl/DemoServiceImpl.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.samples.prefer.serialization.impl;
+
+import org.apache.dubbo.rpc.RpcContext;
+import org.apache.dubbo.samples.prefer.serialization.api.DemoService;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public class DemoServiceImpl implements DemoService {
+
+    @Override
+    public String sayHello(String name) {
+        System.out.println("[" + new SimpleDateFormat("HH:mm:ss").format(new Date()) + "] Hello " + name +
+                ", request from consumer: " + RpcContext.getContext().getRemoteAddress());
+        return "Hello " + name + ", response from provider: " + RpcContext.getContext().getLocalAddress();
+    }
+}

--- a/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/resources/log4j.properties
+++ b/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/resources/log4j.properties
@@ -1,0 +1,26 @@
+#
+#
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#
+
+###set log levels###
+log4j.rootLogger=info, stdout
+###output to the console###
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d{dd/MM/yy hh:mm:ss:sss z}] %t %5p %c{2}: %m%n

--- a/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/resources/spring/dubbo-demo-consumer.xml
+++ b/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/resources/spring/dubbo-demo-consumer.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:dubbo="http://dubbo.apache.org/schema/dubbo"
+       xmlns="http://www.springframework.org/schema/beans" xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://dubbo.apache.org/schema/dubbo http://dubbo.apache.org/schema/dubbo/dubbo.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+    <context:property-placeholder/>
+
+    <dubbo:application name="demo-prefer-serialization-consumer"/>
+
+    <dubbo:registry address="zookeeper://${zookeeper.address:127.0.0.1}:2181"/>
+
+    <dubbo:reference id="demoService" check="true" interface="org.apache.dubbo.samples.prefer.serialization.api.DemoService"/>
+
+</beans>

--- a/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/resources/spring/dubbo-demo-consumer.xml
+++ b/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/resources/spring/dubbo-demo-consumer.xml
@@ -27,6 +27,6 @@
 
     <dubbo:registry address="zookeeper://${zookeeper.address:127.0.0.1}:2181"/>
 
-    <dubbo:reference id="demoService" check="true" interface="org.apache.dubbo.samples.prefer.serialization.api.DemoService"/>
+    <dubbo:reference id="demoService" check="true" interface="org.apache.dubbo.samples.prefer.serialization.api.DemoService" />
 
 </beans>

--- a/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/resources/spring/dubbo-demo-provider.xml
+++ b/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/resources/spring/dubbo-demo-provider.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:dubbo="http://dubbo.apache.org/schema/dubbo"
+       xmlns="http://www.springframework.org/schema/beans" xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://dubbo.apache.org/schema/dubbo http://dubbo.apache.org/schema/dubbo/dubbo.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+    <context:property-placeholder/>
+
+    <dubbo:application name="demo-prefer-serialization-provider"/>
+
+    <dubbo:registry address="zookeeper://${zookeeper.address:127.0.0.1}:2181"/>
+
+    <dubbo:provider token="true"/>
+
+    <bean id="demoService" class="org.apache.dubbo.samples.prefer.serialization.impl.DemoServiceImpl"/>
+
+    <dubbo:service interface="org.apache.dubbo.samples.prefer.serialization.api.DemoService" ref="demoService"
+                   serialization="java"/>
+
+</beans>

--- a/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/resources/spring/dubbo-demo-provider.xml
+++ b/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/main/resources/spring/dubbo-demo-provider.xml
@@ -18,9 +18,11 @@
 
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:dubbo="http://dubbo.apache.org/schema/dubbo"
-       xmlns="http://www.springframework.org/schema/beans" xmlns:context="http://www.springframework.org/schema/context"
+       xmlns="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://dubbo.apache.org/schema/dubbo http://dubbo.apache.org/schema/dubbo/dubbo.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+       http://dubbo.apache.org/schema/dubbo http://dubbo.apache.org/schema/dubbo/dubbo.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
     <context:property-placeholder/>
 
     <dubbo:application name="demo-prefer-serialization-provider"/>
@@ -31,7 +33,6 @@
 
     <bean id="demoService" class="org.apache.dubbo.samples.prefer.serialization.impl.DemoServiceImpl"/>
 
-    <dubbo:service interface="org.apache.dubbo.samples.prefer.serialization.api.DemoService" ref="demoService"
-                   serialization="java"/>
+    <dubbo:service interface="org.apache.dubbo.samples.prefer.serialization.api.DemoService" ref="demoService" prefer-serialization="fastjson"/>
 
 </beans>

--- a/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/test/java/org/apache/dubbo/samples/prefer/serialization/DemoServiceIT.java
+++ b/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/test/java/org/apache/dubbo/samples/prefer/serialization/DemoServiceIT.java
@@ -35,7 +35,7 @@ public class DemoServiceIT {
     private DemoService service;
 
     @Test
-    public void testGreeting() throws Exception {
+    public void testSayHello() throws Exception {
         Assert.assertTrue(service.sayHello("dubbo").startsWith("Hello dubbo"));
     }
 }

--- a/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/test/java/org/apache/dubbo/samples/prefer/serialization/DemoServiceIT.java
+++ b/dubbo-samples-serialization/dubbo-samples-prefer-serialization/src/test/java/org/apache/dubbo/samples/prefer/serialization/DemoServiceIT.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.samples.prefer.serialization;
+
+
+import org.apache.dubbo.samples.prefer.serialization.api.DemoService;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = "classpath*:spring/dubbo-demo-consumer.xml")
+public class DemoServiceIT {
+    @Autowired
+    @Qualifier("demoService")
+    private DemoService service;
+
+    @Test
+    public void testGreeting() throws Exception {
+        Assert.assertTrue(service.sayHello("dubbo").startsWith("Hello dubbo"));
+    }
+}

--- a/dubbo-samples-serialization/dubbo-samples-serialization-java/pom.xml
+++ b/dubbo-samples-serialization/dubbo-samples-serialization-java/pom.xml
@@ -19,14 +19,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>dubbo-samples-serialization</artifactId>
         <groupId>org.apache.dubbo</groupId>
         <version>1.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-serialization-java</artifactId>
+    <name>Dubbo Samples Serialization Java</name>
+    <description>Dubbo Samples Serialization Java</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-serialization/pom.xml
+++ b/dubbo-samples-serialization/pom.xml
@@ -19,17 +19,22 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>dubbo-samples-all</artifactId>
         <groupId>org.apache.dubbo</groupId>
         <version>1.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-serialization</artifactId>
     <packaging>pom</packaging>
+
+    <name>Dubbo Samples Serialization</name>
+    <description>Dubbo Samples Serialization</description>
+
     <modules>
         <module>dubbo-samples-serialization-java</module>
+        <module>dubbo-samples-prefer-serialization</module>
     </modules>
 
 

--- a/dubbo-samples-simplified-registry/pom.xml
+++ b/dubbo-samples-simplified-registry/pom.xml
@@ -25,7 +25,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <modelVersion>4.0.0</modelVersion>
+    <artifactId>dubbo-samples-simplified-registry</artifactId>
     <packaging>pom</packaging>
+    <name>Dubbo Samples Simplified Registry</name>
+    <description>Dubbo Samples Simplified Registry</description>
 
     <modules>
         <module>dubbo-samples-simplified-registry-xml</module>
@@ -33,8 +36,6 @@
         <module>dubbo-samples-simplified-registry-annotation</module>
         <module>dubbo-samples-simplified-registry-nosimple</module>
     </modules>
-
-    <artifactId>dubbo-samples-simplified-registry</artifactId>
 
 
 

--- a/dubbo-samples-spi-compatible/pom.xml
+++ b/dubbo-samples-spi-compatible/pom.xml
@@ -24,6 +24,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-spi-compatible</artifactId>
+    <name>Dubbo Samples Spi Compatible</name>
+    <description>Dubbo Samples Spi Compatible</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-spring-boot-hystrix/pom.xml
+++ b/dubbo-samples-spring-boot-hystrix/pom.xml
@@ -25,7 +25,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-spring-boot-hystrix</artifactId>
-
+    <name>Dubbo Samples Spring Boot Hystrix</name>
+    <description>Dubbo Samples Spring Boot Hystrix</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-spring-boot/dubbo-samples-spring-boot-interface/pom.xml
+++ b/dubbo-samples-spring-boot/dubbo-samples-spring-boot-interface/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
 </project>

--- a/dubbo-samples-spring-boot/pom.xml
+++ b/dubbo-samples-spring-boot/pom.xml
@@ -25,6 +25,8 @@
     <version>1.0-SNAPSHOT</version>
     <artifactId>dubbo-samples-spring-boot</artifactId>
     <packaging>pom</packaging>
+    <name>Dubbo Samples Spring Boot</name>
+    <description>Dubbo Samples Spring Boot</description>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/dubbo-samples-spring-hystrix/pom.xml
+++ b/dubbo-samples-spring-hystrix/pom.xml
@@ -25,6 +25,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-spring-hystrix</artifactId>
+    <name>Dubbo Samples Spring Hystrix</name>
+    <description>Dubbo Samples Spring Hystrix</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-ssl/dubbo-samples-ssl-consumer/pom.xml
+++ b/dubbo-samples-ssl/dubbo-samples-ssl-consumer/pom.xml
@@ -90,6 +90,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
                 <configuration>
                     <executable>true</executable>
                     <mainClass>org.apache.dubbo.samples.basic.SslBasicConsumer</mainClass>

--- a/dubbo-samples-ssl/dubbo-samples-ssl-provider/pom.xml
+++ b/dubbo-samples-ssl/dubbo-samples-ssl-provider/pom.xml
@@ -92,6 +92,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
                 <configuration>
                     <executable>true</executable>
                     <mainClass>org.apache.dubbo.samples.basic.SslBasicProvider</mainClass>

--- a/dubbo-samples-ssl/pom.xml
+++ b/dubbo-samples-ssl/pom.xml
@@ -25,6 +25,8 @@
 
     <packaging>pom</packaging>
     <artifactId>dubbo-samples-ssl</artifactId>
+    <name>Dubbo Samples ssl</name>
+    <description>Dubbo Samples ssl</description>
 
    <modules>
        <module>dubbo-samples-ssl-provider</module>
@@ -35,6 +37,7 @@
         <dubbo.version>3.0.7</dubbo.version>
         <junit.version>4.12</junit.version>
         <spring.version>4.3.16.RELEASE</spring.version>
+        <spring-boot.version>2.1.1.RELEASE</spring-boot.version>
     </properties>
 
     <dependencyManagement>

--- a/dubbo-samples-stub/pom.xml
+++ b/dubbo-samples-stub/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-stub</artifactId>
+    <name>Dubbo Samples Stub</name>
+    <description>Dubbo Samples Stub</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-switch-serialization-thread/pom.xml
+++ b/dubbo-samples-switch-serialization-thread/pom.xml
@@ -24,6 +24,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-switch-serialization-thread</artifactId>
+    <name>Dubbo Samples Switch Serialization Thread</name>
+    <description>Dubbo Samples Switch Serialization Thread</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-tengine/dubbo-samples-tengine-interface/pom.xml
+++ b/dubbo-samples-tengine/dubbo-samples-tengine-interface/pom.xml
@@ -29,7 +29,7 @@
     <name>${project.artifactId}</name>
     <description>The demo module of tengine dubbo</description>
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
     <build>
     <plugins>

--- a/dubbo-samples-tengine/dubbo-samples-tengine-provider/pom.xml
+++ b/dubbo-samples-tengine/dubbo-samples-tengine-provider/pom.xml
@@ -30,7 +30,7 @@
     <name>${project.artifactId}</name>
     <description>The demo provider module of dubbo tengine</description>
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
         <dubbo.version>3.0.7</dubbo.version>
     </properties>
 

--- a/dubbo-samples-tengine/dubbo-samples-tengine-provider/pom.xml
+++ b/dubbo-samples-tengine/dubbo-samples-tengine-provider/pom.xml
@@ -33,7 +33,7 @@
         <skip_maven_deploy>true</skip_maven_deploy>
         <dubbo.version>3.0.7</dubbo.version>
     </properties>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.apache.dubbo.sample</groupId>
@@ -59,7 +59,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
     <build>
         <finalName>dubbo-demo-provider</finalName>
         <plugins>
@@ -78,6 +78,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/dubbo-samples-tengine/pom.xml
+++ b/dubbo-samples-tengine/pom.xml
@@ -21,7 +21,7 @@
     <artifactId>dubbo-samples-tengine</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <name>${project.artifactId}</name>
+    <name>Dubbo Samples Tengine</name>
     <description>The demo module of tengine dubbo</description>
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>

--- a/dubbo-samples-tengine/pom.xml
+++ b/dubbo-samples-tengine/pom.xml
@@ -24,7 +24,7 @@
     <name>Dubbo Samples Tengine</name>
     <description>The demo module of tengine dubbo</description>
     <properties>
-        <skip_maven_deploy>true</skip_maven_deploy>
+        <maven.deploy.skip>true</maven.deploy.skip>
         <dubbo.version>3.0.7</dubbo.version>
         <spring-boot.version>2.1.5.RELEASE</spring-boot.version>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>

--- a/dubbo-samples-thrift/pom.xml
+++ b/dubbo-samples-thrift/pom.xml
@@ -31,6 +31,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-thrift</artifactId>
+    <name>Dubbo Samples Thrift</name>
+    <description>Dubbo Samples Thrift</description>
 
     <properties>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>

--- a/dubbo-samples-transaction/pom.xml
+++ b/dubbo-samples-transaction/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-transaction</artifactId>
+    <name>Dubbo Samples Transaction</name>
+    <description>Dubbo Samples Transaction</description>
 
     <properties>
         <source.level>1.8</source.level>
@@ -147,6 +149,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>2.4.1</version>
+                <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/dubbo-samples-triple-reactor/pom.xml
+++ b/dubbo-samples-triple-reactor/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-triple-reactor</artifactId>
+    <name>Dubbo Samples Triple Reactor</name>
+    <description>Dubbo Samples Triple Reactor</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-triple/pom.xml
+++ b/dubbo-samples-triple/pom.xml
@@ -27,6 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-triple</artifactId>
+    <name>Dubbo Samples Triple</name>
+    <description>Dubbo Samples Triple</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-validation/pom.xml
+++ b/dubbo-samples-validation/pom.xml
@@ -25,6 +25,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-validation</artifactId>
+    <name>Dubbo Samples Validation</name>
+    <description>Dubbo Samples Validation</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-version/pom.xml
+++ b/dubbo-samples-version/pom.xml
@@ -25,6 +25,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-version</artifactId>
+    <name>Dubbo Samples Version</name>
+    <description>Dubbo Samples Version</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/dubbo-samples-webservice/pom.xml
+++ b/dubbo-samples-webservice/pom.xml
@@ -30,6 +30,8 @@
 
     <packaging>pom</packaging>
     <artifactId>dubbo-samples-webservice</artifactId>
+    <name>Dubbo Samples Webservice</name>
+    <description>Dubbo Samples Webservice</description>
 
     <properties>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>

--- a/dubbo-samples-xds/dubbo-samples-xds-consumer/pom.xml
+++ b/dubbo-samples-xds/dubbo-samples-xds-consumer/pom.xml
@@ -184,6 +184,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>
@@ -195,16 +196,20 @@
                                 </filter>
                             </filters>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>org.apache.dubbo.samples.ConsumerBootstrap</mainClass>
                                 </transformer>
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                    <resource>META-INF/dubbo/internal/org.apache.dubbo.registry.client.ServiceDiscoveryFactory</resource>
+                                    <resource>
+                                        META-INF/dubbo/internal/org.apache.dubbo.registry.client.ServiceDiscoveryFactory
+                                    </resource>
                                 </transformer>
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                    <resource>META-INF/dubbo/internal/org.apache.dubbo.registry.RegistryFactory</resource>
+                                    <resource>META-INF/dubbo/internal/org.apache.dubbo.registry.RegistryFactory
+                                    </resource>
                                 </transformer>
                             </transformers>
                         </configuration>

--- a/dubbo-samples-xds/dubbo-samples-xds-provider/pom.xml
+++ b/dubbo-samples-xds/dubbo-samples-xds-provider/pom.xml
@@ -176,6 +176,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>2.4.1</version>
+                <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/dubbo-samples-xds/pom.xml
+++ b/dubbo-samples-xds/pom.xml
@@ -31,6 +31,8 @@
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <artifactId>dubbo-samples-xds</artifactId>
+    <name>Dubbo Samples XDS</name>
+    <description>Dubbo Samples XDS</description>
 
     <repositories>
         <repository>

--- a/dubbo-samples-zipkin/pom.xml
+++ b/dubbo-samples-zipkin/pom.xml
@@ -24,6 +24,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-zipkin</artifactId>
+    <name>Dubbo Samples Zipkin</name>
+    <description>Dubbo Samples Zipkin</description>
 
     <properties>
         <source.level>1.8</source.level>
@@ -139,12 +141,6 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.8.5</version>
         </dependency>
     </dependencies>
 

--- a/dubbo-samples-zookeeper/pom.xml
+++ b/dubbo-samples-zookeeper/pom.xml
@@ -24,6 +24,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-samples-zookeeper</artifactId>
+    <name>Dubbo Samples Zookeeper</name>
+    <description>Dubbo Samples Zookeeper</description>
 
     <properties>
         <source.level>1.8</source.level>

--- a/mvnw
+++ b/mvnw
@@ -19,7 +19,7 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Maven2 Start Up Batch script
+# Maven Start Up Batch script
 #
 # Required ENV vars:
 # ------------------
@@ -114,7 +114,6 @@ if $mingw ; then
     M2_HOME="`(cd "$M2_HOME"; pwd)`"
   [ -n "$JAVA_HOME" ] &&
     JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
-  # TODO classpath?
 fi
 
 if [ -z "$JAVA_HOME" ]; then
@@ -212,7 +211,11 @@ else
     if [ "$MVNW_VERBOSE" = true ]; then
       echo "Couldn't find .mvn/wrapper/maven-wrapper.jar, downloading it ..."
     fi
-    jarUrl="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.4.2/maven-wrapper-0.4.2.jar"
+    if [ -n "$MVNW_REPOURL" ]; then
+      jarUrl="$MVNW_REPOURL/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
+    else
+      jarUrl="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
+    fi
     while IFS="=" read key value; do
       case "$key" in (wrapperUrl) jarUrl="$value"; break ;;
       esac
@@ -221,22 +224,38 @@ else
       echo "Downloading from: $jarUrl"
     fi
     wrapperJarPath="$BASE_DIR/.mvn/wrapper/maven-wrapper.jar"
+    if $cygwin; then
+      wrapperJarPath=`cygpath --path --windows "$wrapperJarPath"`
+    fi
 
     if command -v wget > /dev/null; then
         if [ "$MVNW_VERBOSE" = true ]; then
           echo "Found wget ... using wget"
         fi
-        wget "$jarUrl" -O "$wrapperJarPath"
+        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+            wget "$jarUrl" -O "$wrapperJarPath"
+        else
+            wget --http-user=$MVNW_USERNAME --http-password=$MVNW_PASSWORD "$jarUrl" -O "$wrapperJarPath"
+        fi
     elif command -v curl > /dev/null; then
         if [ "$MVNW_VERBOSE" = true ]; then
           echo "Found curl ... using curl"
         fi
-        curl -o "$wrapperJarPath" "$jarUrl"
+        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+            curl -o "$wrapperJarPath" "$jarUrl" -f
+        else
+            curl --user $MVNW_USERNAME:$MVNW_PASSWORD -o "$wrapperJarPath" "$jarUrl" -f
+        fi
+
     else
         if [ "$MVNW_VERBOSE" = true ]; then
           echo "Falling back to using Java to download"
         fi
         javaClass="$BASE_DIR/.mvn/wrapper/MavenWrapperDownloader.java"
+        # For Cygwin, switch paths to Windows format before running javac
+        if $cygwin; then
+          javaClass=`cygpath --path --windows "$javaClass"`
+        fi
         if [ -e "$javaClass" ]; then
             if [ ! -e "$BASE_DIR/.mvn/wrapper/MavenWrapperDownloader.class" ]; then
                 if [ "$MVNW_VERBOSE" = true ]; then
@@ -276,6 +295,11 @@ if $cygwin; then
   [ -n "$MAVEN_PROJECTBASEDIR" ] &&
     MAVEN_PROJECTBASEDIR=`cygpath --path --windows "$MAVEN_PROJECTBASEDIR"`
 fi
+
+# Provide a "standardized" way to retrieve the CLI args that will
+# work with both Windows and non-Windows executions.
+MAVEN_CMD_LINE_ARGS="$MAVEN_CONFIG $@"
+export MAVEN_CMD_LINE_ARGS
 
 WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -18,7 +18,7 @@
 @REM ----------------------------------------------------------------------------
 
 @REM ----------------------------------------------------------------------------
-@REM Maven2 Start Up Batch script
+@REM Maven Start Up Batch script
 @REM
 @REM Required ENV vars:
 @REM JAVA_HOME - location of a JDK home dir
@@ -26,7 +26,7 @@
 @REM Optional ENV vars
 @REM M2_HOME - location of maven2's installed home dir
 @REM MAVEN_BATCH_ECHO - set to 'on' to enable the echoing of the batch commands
-@REM MAVEN_BATCH_PAUSE - set to 'on' to wait for a key stroke before ending
+@REM MAVEN_BATCH_PAUSE - set to 'on' to wait for a keystroke before ending
 @REM MAVEN_OPTS - parameters passed to the Java VM when running Maven
 @REM     e.g. to debug Maven itself, use
 @REM set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
@@ -37,7 +37,7 @@
 @echo off
 @REM set title of command window
 title %0
-@REM enable echoing my setting MAVEN_BATCH_ECHO to 'on'
+@REM enable echoing by setting MAVEN_BATCH_ECHO to 'on'
 @if "%MAVEN_BATCH_ECHO%" == "on"  echo %MAVEN_BATCH_ECHO%
 
 @REM set %HOME% to equivalent of $HOME
@@ -120,22 +120,43 @@ SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
 set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
 set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
-set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.4.2/maven-wrapper-0.4.2.jar"
-FOR /F "tokens=1,2 delims==" %%A IN (%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties) DO (
-	IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B 
+set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
+
+FOR /F "tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
+    IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B
 )
 
 @REM Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
 @REM This allows using the maven wrapper in projects that prohibit checking in binary data.
 if exist %WRAPPER_JAR% (
-    echo Found %WRAPPER_JAR%
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Found %WRAPPER_JAR%
+    )
 ) else (
-    echo Couldn't find %WRAPPER_JAR%, downloading it ...
-	echo Downloading from: %DOWNLOAD_URL%
-    powershell -Command "(New-Object Net.WebClient).DownloadFile('%DOWNLOAD_URL%', '%WRAPPER_JAR%')"
-    echo Finished downloading %WRAPPER_JAR%
+    if not "%MVNW_REPOURL%" == "" (
+        SET DOWNLOAD_URL="%MVNW_REPOURL%/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
+    )
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Couldn't find %WRAPPER_JAR%, downloading it ...
+        echo Downloading from: %DOWNLOAD_URL%
+    )
+
+    powershell -Command "&{"^
+		"$webclient = new-object System.Net.WebClient;"^
+		"if (-not ([string]::IsNullOrEmpty('%MVNW_USERNAME%') -and [string]::IsNullOrEmpty('%MVNW_PASSWORD%'))) {"^
+		"$webclient.Credentials = new-object System.Net.NetworkCredential('%MVNW_USERNAME%', '%MVNW_PASSWORD%');"^
+		"}"^
+		"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $webclient.DownloadFile('%DOWNLOAD_URL%', '%WRAPPER_JAR%')"^
+		"}"
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Finished downloading %WRAPPER_JAR%
+    )
 )
 @REM End of extension
+
+@REM Provide a "standardized" way to retrieve the CLI args that will
+@REM work with both Windows and non-Windows executions.
+set MAVEN_CMD_LINE_ARGS=%*
 
 %MAVEN_JAVA_EXE% %JVM_CONFIG_MAVEN_PROPS% %MAVEN_OPTS% %MAVEN_DEBUG_OPTS% -classpath %WRAPPER_JAR% "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %*
 if ERRORLEVEL 1 goto error

--- a/pom.xml
+++ b/pom.xml
@@ -14,13 +14,29 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.apache.dubbo</groupId>
     <artifactId>dubbo-samples-all</artifactId>
     <packaging>pom</packaging>
     <version>1.0-SNAPSHOT</version>
+    <name>Dubbo Samples All</name>
+    <description>Dubbo Samples All</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.version>1.8</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven.compiler.encoding>UTF-8</maven.compiler.encoding>
+        <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
+        <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
+    </properties>
+
     <modules>
         <module>dubbo-maven-address-plugin</module>
         <module>dubbo-samples-annotation</module>
@@ -94,6 +110,48 @@
         <module>dubbo-samples-rocketmq</module>
         <module>dubbo-samples-port-unification</module>
     </modules>
+
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>jdk9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>${java.version}</maven.compiler.release>
+            </properties>
+        </profile>
+        <profile>
+            <id>javax.annotation</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>${javax.annotation-api.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -23,13 +23,13 @@
     <artifactId>dubbo-samples-all</artifactId>
     <packaging>pom</packaging>
     <version>1.0-SNAPSHOT</version>
-    <name>Dubbo Samples All</name>
-    <description>Dubbo Samples All</description>
+    <name>Dubbo Samples</name>
+    <description>Dubbo Samples</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>1.8</java.version>
+        <java.version>8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.encoding>UTF-8</maven.compiler.encoding>


### PR DESCRIPTION
- 增加 prefer serialization 序列化的集成测试功能
- maven wrapper 基于takari maven wrapper 重新生成了一份，使用了最新的 maven 版本，原因是因为行业内目前大部分都是基于 takari maven wrapper，takari maven wrapper 是 apache maven wrapper 的一种增强。takari maven wrapper 兼容 apache wrapper 且 takari maven wrapper 正在合并到上游的 apache wrapper。
- 将大部分模块的 name、description 补全了，使其能更好的适配 Jetbrains IDEA Maven 工程的渲染，IDEA 默认基于 Name 来呈现项目信息其次是 artifactId，在整体上更友好、专业一些，参考 Spring 系列项目。
- 优化了一些依赖配置，如：maven compiler 配置，可以全局通过 属性配置来指定不同模块的 JDK 版本，不需要在各个子模块再去配置 compiler 插件。只需要配置插件的属性即可。这在新的 comipler 插件版本使用中是标准使用方式，大部分 maven 原生插件均支持这种使用方式。（未全部改完，太多了）