### PR TITLE
Remove invocations of SocketUtils in embedded zookeeper.

### DIFF
--- a/1-basic/dubbo-samples-annotation/src/main/java/org/apache/dubbo/samples/annotation/EmbeddedZooKeeper.java
+++ b/1-basic/dubbo-samples-annotation/src/main/java/org/apache/dubbo/samples/annotation/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.annotation;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.annotation;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/1-basic/dubbo-samples-annotation/src/main/java/org/apache/dubbo/samples/annotation/EmbeddedZooKeeper.java
+++ b/1-basic/dubbo-samples-annotation/src/main/java/org/apache/dubbo/samples/annotation/EmbeddedZooKeeper.java
@@ -16,6 +16,8 @@
  */
 package org.apache.dubbo.samples.annotation;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -23,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -43,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -85,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -248,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-async/dubbo-samples-async-generated-future/src/main/java/org/apache/dubbo/samples/async/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-async/dubbo-samples-async-generated-future/src/main/java/org/apache/dubbo/samples/async/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.async;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.async;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-async/dubbo-samples-async-generated-future/src/main/java/org/apache/dubbo/samples/async/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-async/dubbo-samples-async-generated-future/src/main/java/org/apache/dubbo/samples/async/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.async;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -247,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-async/dubbo-samples-async-onerror/src/main/java/org/apache/dubbo/samples/governance/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-async/dubbo-samples-async-onerror/src/main/java/org/apache/dubbo/samples/governance/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.governance;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.governance;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-async/dubbo-samples-async-onerror/src/main/java/org/apache/dubbo/samples/governance/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-async/dubbo-samples-async-onerror/src/main/java/org/apache/dubbo/samples/governance/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.governance;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -247,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-async/dubbo-samples-async-original-future/src/main/java/org/apache/dubbo/samples/async/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-async/dubbo-samples-async-original-future/src/main/java/org/apache/dubbo/samples/async/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.async;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.async;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-async/dubbo-samples-async-original-future/src/main/java/org/apache/dubbo/samples/async/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-async/dubbo-samples-async-original-future/src/main/java/org/apache/dubbo/samples/async/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.async;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -247,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-async/dubbo-samples-async-provider/src/main/java/org/apache/dubbo/samples/async/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-async/dubbo-samples-async-provider/src/main/java/org/apache/dubbo/samples/async/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.async;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.async;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-async/dubbo-samples-async-provider/src/main/java/org/apache/dubbo/samples/async/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-async/dubbo-samples-async-provider/src/main/java/org/apache/dubbo/samples/async/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.async;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -247,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-async/dubbo-samples-async-simple-boot/dubbo-samples-async-simple-boot-provider/src/main/java/org/apache/dubbo/async/boot/provider/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-async/dubbo-samples-async-simple-boot/dubbo-samples-async-simple-boot-provider/src/main/java/org/apache/dubbo/async/boot/provider/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.async.boot.provider;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.async.boot.provider;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-async/dubbo-samples-async-simple-boot/dubbo-samples-async-simple-boot-provider/src/main/java/org/apache/dubbo/async/boot/provider/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-async/dubbo-samples-async-simple-boot/dubbo-samples-async-simple-boot-provider/src/main/java/org/apache/dubbo/async/boot/provider/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.async.boot.provider;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -247,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-async/dubbo-samples-async-simple/src/main/java/org/apache/dubbo/samples/async/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-async/dubbo-samples-async-simple/src/main/java/org/apache/dubbo/samples/async/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.async;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.async;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-async/dubbo-samples-async-simple/src/main/java/org/apache/dubbo/samples/async/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-async/dubbo-samples-async-simple/src/main/java/org/apache/dubbo/samples/async/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.async;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -247,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-attachment/dubbo-samples-attachment-provider/src/main/java/org/apache/dubbo/samples/attachment/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-attachment/dubbo-samples-attachment-provider/src/main/java/org/apache/dubbo/samples/attachment/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.attachment;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.attachment;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-attachment/dubbo-samples-attachment-provider/src/main/java/org/apache/dubbo/samples/attachment/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-attachment/dubbo-samples-attachment-provider/src/main/java/org/apache/dubbo/samples/attachment/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.attachment;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-autowire/dubbo-samples-autowire-provider/src/main/java/org/apache/dubbo/samples/autowire/provider/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-autowire/dubbo-samples-autowire-provider/src/main/java/org/apache/dubbo/samples/autowire/provider/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.autowire.provider;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.autowire.provider;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-autowire/dubbo-samples-autowire-provider/src/main/java/org/apache/dubbo/samples/autowire/provider/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-autowire/dubbo-samples-autowire-provider/src/main/java/org/apache/dubbo/samples/autowire/provider/EmbeddedZooKeeper.java
@@ -16,6 +16,8 @@
  */
 package org.apache.dubbo.samples.autowire.provider;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -23,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -43,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -85,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -248,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-cache/dubbo-samples-cache-provider/src/main/java/org/apache/dubbo/samples/cache/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-cache/dubbo-samples-cache-provider/src/main/java/org/apache/dubbo/samples/cache/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.cache;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.cache;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-cache/dubbo-samples-cache-provider/src/main/java/org/apache/dubbo/samples/cache/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-cache/dubbo-samples-cache-provider/src/main/java/org/apache/dubbo/samples/cache/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.cache;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-callback/dubbo-samples-callback-provider/src/main/java/org/apache/dubbo/samples/callback/provider/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-callback/dubbo-samples-callback-provider/src/main/java/org/apache/dubbo/samples/callback/provider/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.callback.provider;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.callback.provider;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-callback/dubbo-samples-callback-provider/src/main/java/org/apache/dubbo/samples/callback/provider/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-callback/dubbo-samples-callback-provider/src/main/java/org/apache/dubbo/samples/callback/provider/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.callback.provider;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-compatible/src/main/java/org/apache/dubbo/samples/compat/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-compatible/src/main/java/org/apache/dubbo/samples/compat/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.compat;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.compat;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-compatible/src/main/java/org/apache/dubbo/samples/compat/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-compatible/src/main/java/org/apache/dubbo/samples/compat/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.compat;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-context/src/main/java/org/apache/dubbo/samples/context/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-context/src/main/java/org/apache/dubbo/samples/context/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.context;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.context;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-context/src/main/java/org/apache/dubbo/samples/context/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-context/src/main/java/org/apache/dubbo/samples/context/EmbeddedZooKeeper.java
@@ -1,20 +1,22 @@
 /*
- *   Licensed to the Apache Software Foundation (ASF) under one or more
- *   contributor license agreements.  See the NOTICE file distributed with
- *   this work for additional information regarding copyright ownership.
- *   The ASF licenses this file to You under the Apache License, Version 2.0
- *   (the "License"); you may not use this file except in compliance with
- *   the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.apache.dubbo.samples.context;
+
+import org.apache.dubbo.common.utils.NetUtils;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -23,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -43,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -85,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -177,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -189,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -228,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -241,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-echo/dubbo-samples-echo-provider/src/main/java/org/apache/dubbo/samples/provider/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-echo/dubbo-samples-echo-provider/src/main/java/org/apache/dubbo/samples/provider/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.provider;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.provider;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-echo/dubbo-samples-echo-provider/src/main/java/org/apache/dubbo/samples/provider/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-echo/dubbo-samples-echo-provider/src/main/java/org/apache/dubbo/samples/provider/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.provider;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-environment-keys/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-environment-keys/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.basic;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.basic;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-environment-keys/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-environment-keys/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.basic;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-generic/dubbo-samples-generic-call/dubbo-samples-generic-call-provider/src/main/java/org/apache/dubbo/samples/generic/call/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-generic/dubbo-samples-generic-call/dubbo-samples-generic-call-provider/src/main/java/org/apache/dubbo/samples/generic/call/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.generic.call;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.generic.call;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-generic/dubbo-samples-generic-call/dubbo-samples-generic-call-provider/src/main/java/org/apache/dubbo/samples/generic/call/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-generic/dubbo-samples-generic-call/dubbo-samples-generic-call-provider/src/main/java/org/apache/dubbo/samples/generic/call/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.generic.call;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-generic/dubbo-samples-generic-impl/dubbo-samples-generic-impl-provider/src/main/java/org/apache/dubbo/samples/generic/call/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-generic/dubbo-samples-generic-impl/dubbo-samples-generic-impl-provider/src/main/java/org/apache/dubbo/samples/generic/call/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.generic.call;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.generic.call;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-generic/dubbo-samples-generic-impl/dubbo-samples-generic-impl-provider/src/main/java/org/apache/dubbo/samples/generic/call/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-generic/dubbo-samples-generic-impl/dubbo-samples-generic-impl-provider/src/main/java/org/apache/dubbo/samples/generic/call/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.generic.call;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-generic/dubbo-samples-generic-type/src/main/java/org/apache/dubbo/samples/generic/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-generic/dubbo-samples-generic-type/src/main/java/org/apache/dubbo/samples/generic/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.generic;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.generic;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-group/src/main/java/org/apache/dubbo/samples/group/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-group/src/main/java/org/apache/dubbo/samples/group/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.group;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.group;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-group/src/main/java/org/apache/dubbo/samples/group/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-group/src/main/java/org/apache/dubbo/samples/group/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.group;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-local/src/main/java/org/apache/dubbo/samples/local/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-local/src/main/java/org/apache/dubbo/samples/local/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.local;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.local;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-local/src/main/java/org/apache/dubbo/samples/local/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-local/src/main/java/org/apache/dubbo/samples/local/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.local;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-merge/dubbo-samples-merge-provider1/src/main/java/org/apache/dubbo/samples/merge/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-merge/dubbo-samples-merge-provider1/src/main/java/org/apache/dubbo/samples/merge/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.merge;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.merge;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-merge/dubbo-samples-merge-provider1/src/main/java/org/apache/dubbo/samples/merge/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-merge/dubbo-samples-merge-provider1/src/main/java/org/apache/dubbo/samples/merge/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.merge;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-migration/dubbo-samples-migration-provider/src/main/java/org/apache/dubbo/migration/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-migration/dubbo-samples-migration-provider/src/main/java/org/apache/dubbo/migration/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.migration;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.migration;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-migration/dubbo-samples-migration-provider/src/main/java/org/apache/dubbo/migration/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-migration/dubbo-samples-migration-provider/src/main/java/org/apache/dubbo/migration/EmbeddedZooKeeper.java
@@ -16,6 +16,8 @@
  */
 package org.apache.dubbo.migration;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -23,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -43,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -85,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -248,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-mock/src/main/java/org/apache/dubbo/samples/mock/zk/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-mock/src/main/java/org/apache/dubbo/samples/mock/zk/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.mock.zk;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.mock.zk;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-mock/src/main/java/org/apache/dubbo/samples/mock/zk/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-mock/src/main/java/org/apache/dubbo/samples/mock/zk/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.mock.zk;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-rpccontext/src/main/java/org/apache/dubbo/samples/rpccontext/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-rpccontext/src/main/java/org/apache/dubbo/samples/rpccontext/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.rpccontext;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.rpccontext;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-rpccontext/src/main/java/org/apache/dubbo/samples/rpccontext/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-rpccontext/src/main/java/org/apache/dubbo/samples/rpccontext/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.rpccontext;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-scala/src/main/scala/org/apache/dubbo/samples/scala/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-scala/src/main/scala/org/apache/dubbo/samples/scala/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 package org.apache.dubbo.samples.scala;
-
-import org.apache.dubbo.common.utils.NetUtils;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +25,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +290,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-scala/src/main/scala/org/apache/dubbo/samples/scala/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-scala/src/main/scala/org/apache/dubbo/samples/scala/EmbeddedZooKeeper.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package 2-advanced.dubbo-samples-scala.src.main.scala.org.apache.dubbo.samples.scala;
+package org.apache.dubbo.samples.scala;
 
 import org.apache.dubbo.common.utils.NetUtils;
 

--- a/2-advanced/dubbo-samples-scala/src/main/scala/org/apache/dubbo/samples/scala/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-scala/src/main/scala/org/apache/dubbo/samples/scala/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.scala;
+package 2-advanced.dubbo-samples-scala.src.main.scala.org.apache.dubbo.samples.scala;
+
+import org.apache.dubbo.common.utils.NetUtils;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-spi-compatible/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-spi-compatible/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.basic;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.basic;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-spi-compatible/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-spi-compatible/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.basic;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/2-advanced/dubbo-samples-spring-security/src/main/java/org/apache/dubbo/samples/zookeeper/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-spring-security/src/main/java/org/apache/dubbo/samples/zookeeper/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.zookeeper;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.zookeeper;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-spring-security/src/main/java/org/apache/dubbo/samples/zookeeper/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-spring-security/src/main/java/org/apache/dubbo/samples/zookeeper/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.zookeeper;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,17 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
-}
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
 
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
+}

--- a/2-advanced/dubbo-samples-validation/src/main/java/org/apache/dubbo/samples/validation/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-validation/src/main/java/org/apache/dubbo/samples/validation/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.validation;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.validation;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/2-advanced/dubbo-samples-validation/src/main/java/org/apache/dubbo/samples/validation/EmbeddedZooKeeper.java
+++ b/2-advanced/dubbo-samples-validation/src/main/java/org/apache/dubbo/samples/validation/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.validation;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/3-extensions/configcenter/dubbo-samples-configcenter-annotation/src/main/java/org/apache/dubbo/samples/configcenter/annotation/EmbeddedZooKeeper.java
+++ b/3-extensions/configcenter/dubbo-samples-configcenter-annotation/src/main/java/org/apache/dubbo/samples/configcenter/annotation/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.configcenter.annotation;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.configcenter.annotation;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/3-extensions/configcenter/dubbo-samples-configcenter-annotation/src/main/java/org/apache/dubbo/samples/configcenter/annotation/EmbeddedZooKeeper.java
+++ b/3-extensions/configcenter/dubbo-samples-configcenter-annotation/src/main/java/org/apache/dubbo/samples/configcenter/annotation/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.configcenter.annotation;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -247,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/3-extensions/configcenter/dubbo-samples-configcenter-apollo/src/main/java/org/apache/dubbo/samples/configcenter/EmbeddedZooKeeper.java
+++ b/3-extensions/configcenter/dubbo-samples-configcenter-apollo/src/main/java/org/apache/dubbo/samples/configcenter/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.configcenter;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.configcenter;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/3-extensions/configcenter/dubbo-samples-configcenter-apollo/src/main/java/org/apache/dubbo/samples/configcenter/EmbeddedZooKeeper.java
+++ b/3-extensions/configcenter/dubbo-samples-configcenter-apollo/src/main/java/org/apache/dubbo/samples/configcenter/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.configcenter;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -247,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/3-extensions/configcenter/dubbo-samples-configcenter-externalconfiguration/src/main/java/org/apache/dubbo/samples/externalconfiguration/provider/EmbeddedZooKeeper.java
+++ b/3-extensions/configcenter/dubbo-samples-configcenter-externalconfiguration/src/main/java/org/apache/dubbo/samples/externalconfiguration/provider/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.externalconfiguration.provider;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.externalconfiguration.provider;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/3-extensions/configcenter/dubbo-samples-configcenter-externalconfiguration/src/main/java/org/apache/dubbo/samples/externalconfiguration/provider/EmbeddedZooKeeper.java
+++ b/3-extensions/configcenter/dubbo-samples-configcenter-externalconfiguration/src/main/java/org/apache/dubbo/samples/externalconfiguration/provider/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.externalconfiguration.provider;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -107,14 +114,6 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
     }
 
     /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean isAutoStartup() {
-        return this.autoStartup;
-    }
-
-    /**
      * Specify whether to start automatically. Default is true.
      *
      * @param autoStartup whether to start automatically
@@ -127,8 +126,8 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * {@inheritDoc}
      */
     @Override
-    public int getPhase() {
-        return this.phase;
+    public boolean isAutoStartup() {
+        return this.autoStartup;
     }
 
     /**
@@ -138,6 +137,14 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      */
     public void setPhase(int phase) {
         this.phase = phase;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getPhase() {
+        return this.phase;
     }
 
     /**
@@ -247,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/3-extensions/configcenter/dubbo-samples-configcenter-multiprotocol/src/main/java/org/apache/dubbo/samples/configcenter/EmbeddedZooKeeper.java
+++ b/3-extensions/configcenter/dubbo-samples-configcenter-multiprotocol/src/main/java/org/apache/dubbo/samples/configcenter/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.configcenter;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.configcenter;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/3-extensions/configcenter/dubbo-samples-configcenter-multiprotocol/src/main/java/org/apache/dubbo/samples/configcenter/EmbeddedZooKeeper.java
+++ b/3-extensions/configcenter/dubbo-samples-configcenter-multiprotocol/src/main/java/org/apache/dubbo/samples/configcenter/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.configcenter;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -247,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/3-extensions/configcenter/dubbo-samples-configcenter-xml/src/main/java/org/apache/dubbo/samples/configcenter/EmbeddedZooKeeper.java
+++ b/3-extensions/configcenter/dubbo-samples-configcenter-xml/src/main/java/org/apache/dubbo/samples/configcenter/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.configcenter;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.configcenter;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/3-extensions/configcenter/dubbo-samples-configcenter-xml/src/main/java/org/apache/dubbo/samples/configcenter/EmbeddedZooKeeper.java
+++ b/3-extensions/configcenter/dubbo-samples-configcenter-xml/src/main/java/org/apache/dubbo/samples/configcenter/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.configcenter;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -247,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/3-extensions/protocol/dubbo-samples-grpc/dubbo-samples-original/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
+++ b/3-extensions/protocol/dubbo-samples-grpc/dubbo-samples-original/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.basic;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.basic;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/3-extensions/protocol/dubbo-samples-grpc/dubbo-samples-original/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
+++ b/3-extensions/protocol/dubbo-samples-grpc/dubbo-samples-original/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.basic;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/3-extensions/protocol/dubbo-samples-grpc/dubbo-samples-reactor/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
+++ b/3-extensions/protocol/dubbo-samples-grpc/dubbo-samples-reactor/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.basic;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.basic;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/3-extensions/protocol/dubbo-samples-grpc/dubbo-samples-reactor/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
+++ b/3-extensions/protocol/dubbo-samples-grpc/dubbo-samples-reactor/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.basic;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/3-extensions/protocol/dubbo-samples-grpc/dubbo-samples-rxjava/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
+++ b/3-extensions/protocol/dubbo-samples-grpc/dubbo-samples-rxjava/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.basic;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.basic;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/3-extensions/protocol/dubbo-samples-grpc/dubbo-samples-rxjava/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
+++ b/3-extensions/protocol/dubbo-samples-grpc/dubbo-samples-rxjava/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.basic;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/3-extensions/protocol/dubbo-samples-grpc/dubbo-samples-ssl/dubbo-samples-grpc-ssl-provider/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
+++ b/3-extensions/protocol/dubbo-samples-grpc/dubbo-samples-ssl/dubbo-samples-grpc-ssl-provider/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.basic;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.basic;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/3-extensions/protocol/dubbo-samples-grpc/dubbo-samples-ssl/dubbo-samples-grpc-ssl-provider/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
+++ b/3-extensions/protocol/dubbo-samples-grpc/dubbo-samples-ssl/dubbo-samples-grpc-ssl-provider/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.basic;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/3-extensions/protocol/dubbo-samples-resilience4j/dubbo-samples-resilience4j-filter/src/main/java/org/apache/dubbo/samples/resilience4j/EmbeddedZooKeeper.java
+++ b/3-extensions/protocol/dubbo-samples-resilience4j/dubbo-samples-resilience4j-filter/src/main/java/org/apache/dubbo/samples/resilience4j/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.resilience4j;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.resilience4j;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/3-extensions/protocol/dubbo-samples-resilience4j/dubbo-samples-resilience4j-filter/src/main/java/org/apache/dubbo/samples/resilience4j/EmbeddedZooKeeper.java
+++ b/3-extensions/protocol/dubbo-samples-resilience4j/dubbo-samples-resilience4j-filter/src/main/java/org/apache/dubbo/samples/resilience4j/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.resilience4j;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/3-extensions/protocol/dubbo-samples-resilience4j/dubbo-samples-resilience4j-springboot2/src/main/java/org/apache/dubbo/samples/resilience4jboot2/EmbeddedZooKeeper.java
+++ b/3-extensions/protocol/dubbo-samples-resilience4j/dubbo-samples-resilience4j-springboot2/src/main/java/org/apache/dubbo/samples/resilience4jboot2/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.resilience4jboot2;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.resilience4jboot2;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/3-extensions/protocol/dubbo-samples-resilience4j/dubbo-samples-resilience4j-springboot2/src/main/java/org/apache/dubbo/samples/resilience4jboot2/EmbeddedZooKeeper.java
+++ b/3-extensions/protocol/dubbo-samples-resilience4j/dubbo-samples-resilience4j-springboot2/src/main/java/org/apache/dubbo/samples/resilience4jboot2/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.resilience4jboot2;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/3-extensions/protocol/dubbo-samples-rest/src/main/java/org/apache/dubbo/samples/rest/EmbeddedZooKeeper.java
+++ b/3-extensions/protocol/dubbo-samples-rest/src/main/java/org/apache/dubbo/samples/rest/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.rest;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.rest;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/3-extensions/protocol/dubbo-samples-rest/src/main/java/org/apache/dubbo/samples/rest/EmbeddedZooKeeper.java
+++ b/3-extensions/protocol/dubbo-samples-rest/src/main/java/org/apache/dubbo/samples/rest/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.rest;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/3-extensions/protocol/dubbo-samples-triple-reactor/src/main/java/org/apache/dubbo/samples/triple/reactor/util/EmbeddedZooKeeper.java
+++ b/3-extensions/protocol/dubbo-samples-triple-reactor/src/main/java/org/apache/dubbo/samples/triple/reactor/util/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.triple.reactor.util;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.triple.reactor.util;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/3-extensions/protocol/dubbo-samples-triple/src/main/java/org/apache/dubbo/sample/tri/util/EmbeddedZooKeeper.java
+++ b/3-extensions/protocol/dubbo-samples-triple/src/main/java/org/apache/dubbo/sample/tri/util/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.sample.tri.util;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.sample.tri.util;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/3-extensions/protocol/dubbo-samples-triple/src/main/java/org/apache/dubbo/sample/tri/util/EmbeddedZooKeeper.java
+++ b/3-extensions/protocol/dubbo-samples-triple/src/main/java/org/apache/dubbo/sample/tri/util/EmbeddedZooKeeper.java
@@ -16,6 +16,8 @@
  */
 package org.apache.dubbo.sample.tri.util;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -23,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -43,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -85,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -248,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/3-extensions/registry/dubbo-samples-default-config/src/main/java/org/apache/dubbo/samples/multi/registry/EmbeddedZooKeeper.java
+++ b/3-extensions/registry/dubbo-samples-default-config/src/main/java/org/apache/dubbo/samples/multi/registry/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.multi.registry;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.multi.registry;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -292,12 +291,12 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
     }
 
-    private static boolean isPortInUsed(int port) {
+    private static boolean isPortInUse(int port) {
         try (ServerSocket ignored = new ServerSocket(port)) {
             return false;
         } catch (IOException e) {

--- a/3-extensions/registry/dubbo-samples-default-config/src/main/java/org/apache/dubbo/samples/multi/registry/EmbeddedZooKeeper.java
+++ b/3-extensions/registry/dubbo-samples-default-config/src/main/java/org/apache/dubbo/samples/multi/registry/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.multi.registry;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -247,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/3-extensions/registry/dubbo-samples-default-config/src/main/java/org/apache/dubbo/samples/multi/registry/EmbeddedZooKeeper.java
+++ b/3-extensions/registry/dubbo-samples-default-config/src/main/java/org/apache/dubbo/samples/multi/registry/EmbeddedZooKeeper.java
@@ -27,7 +27,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +292,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUsed(port));
 
         return port;
+    }
+
+    private static boolean isPortInUsed(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/3-extensions/registry/dubbo-samples-multi-registry/src/main/java/org/apache/dubbo/samples/multi/registry/EmbeddedZooKeeper.java
+++ b/3-extensions/registry/dubbo-samples-multi-registry/src/main/java/org/apache/dubbo/samples/multi/registry/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.multi.registry;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.multi.registry;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/3-extensions/registry/dubbo-samples-multi-registry/src/main/java/org/apache/dubbo/samples/multi/registry/EmbeddedZooKeeper.java
+++ b/3-extensions/registry/dubbo-samples-multi-registry/src/main/java/org/apache/dubbo/samples/multi/registry/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.multi.registry;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/3-extensions/registry/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-annotation/src/main/java/org/apache/dubbo/samples/simplified/annotation/EmbeddedZooKeeper.java
+++ b/3-extensions/registry/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-annotation/src/main/java/org/apache/dubbo/samples/simplified/annotation/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.simplified.annotation;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.simplified.annotation;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/3-extensions/registry/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-annotation/src/main/java/org/apache/dubbo/samples/simplified/annotation/EmbeddedZooKeeper.java
+++ b/3-extensions/registry/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-annotation/src/main/java/org/apache/dubbo/samples/simplified/annotation/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.simplified.annotation;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -247,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/3-extensions/registry/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-nosimple/src/main/java/org/apache/dubbo/samples/simplified/registry/nosimple/EmbeddedZooKeeper.java
+++ b/3-extensions/registry/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-nosimple/src/main/java/org/apache/dubbo/samples/simplified/registry/nosimple/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.simplified.registry.nosimple;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.simplified.registry.nosimple;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/3-extensions/registry/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-nosimple/src/main/java/org/apache/dubbo/samples/simplified/registry/nosimple/EmbeddedZooKeeper.java
+++ b/3-extensions/registry/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-nosimple/src/main/java/org/apache/dubbo/samples/simplified/registry/nosimple/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.simplified.registry.nosimple;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -247,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/3-extensions/registry/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-properties/src/main/java/org/apache/dubbo/samples/simplified/registry/properties/EmbeddedZooKeeper.java
+++ b/3-extensions/registry/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-properties/src/main/java/org/apache/dubbo/samples/simplified/registry/properties/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.simplified.registry.properties;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.simplified.registry.properties;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/3-extensions/registry/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-properties/src/main/java/org/apache/dubbo/samples/simplified/registry/properties/EmbeddedZooKeeper.java
+++ b/3-extensions/registry/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-properties/src/main/java/org/apache/dubbo/samples/simplified/registry/properties/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.simplified.registry.properties;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -247,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/3-extensions/registry/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-xml/src/main/java/org/apache/dubbo/samples/simplified/registry/xml/EmbeddedZooKeeper.java
+++ b/3-extensions/registry/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-xml/src/main/java/org/apache/dubbo/samples/simplified/registry/xml/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.simplified.registry.xml;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.simplified.registry.xml;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/3-extensions/registry/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-xml/src/main/java/org/apache/dubbo/samples/simplified/registry/xml/EmbeddedZooKeeper.java
+++ b/3-extensions/registry/dubbo-samples-simplified-registry/dubbo-samples-simplified-registry-xml/src/main/java/org/apache/dubbo/samples/simplified/registry/xml/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.simplified.registry.xml;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -247,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/3-extensions/serialization/dubbo-samples-prefer-serialization/pom.xml
+++ b/3-extensions/serialization/dubbo-samples-prefer-serialization/pom.xml
@@ -95,4 +95,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/3-extensions/serialization/dubbo-samples-prefer-serialization/src/main/java/org/apache/dubbo/samples/prefer/serialization/EmbeddedZooKeeper.java
+++ b/3-extensions/serialization/dubbo-samples-prefer-serialization/src/main/java/org/apache/dubbo/samples/prefer/serialization/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.prefer.serialization;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.prefer.serialization;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/3-extensions/serialization/dubbo-samples-prefer-serialization/src/main/java/org/apache/dubbo/samples/prefer/serialization/EmbeddedZooKeeper.java
+++ b/3-extensions/serialization/dubbo-samples-prefer-serialization/src/main/java/org/apache/dubbo/samples/prefer/serialization/EmbeddedZooKeeper.java
@@ -16,6 +16,8 @@
  */
 package org.apache.dubbo.samples.prefer.serialization;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -23,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -43,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -85,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -177,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -189,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -228,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -241,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/3-extensions/serialization/dubbo-samples-protobuf-json/protobuf-json-serialization-demo/src/main/java/org/apache/dubbo/sample/protobuf/provider/EmbeddedZooKeeper.java
+++ b/3-extensions/serialization/dubbo-samples-protobuf-json/protobuf-json-serialization-demo/src/main/java/org/apache/dubbo/sample/protobuf/provider/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.sample.protobuf.provider;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.sample.protobuf.provider;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -292,12 +291,12 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
     }
 
-    private static boolean isPortInUsed(int port) {
+    private static boolean isPortInUse(int port) {
         try (ServerSocket ignored = new ServerSocket(port)) {
             return false;
         } catch (IOException e) {

--- a/3-extensions/serialization/dubbo-samples-protobuf-json/protobuf-json-serialization-demo/src/main/java/org/apache/dubbo/sample/protobuf/provider/EmbeddedZooKeeper.java
+++ b/3-extensions/serialization/dubbo-samples-protobuf-json/protobuf-json-serialization-demo/src/main/java/org/apache/dubbo/sample/protobuf/provider/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.sample.protobuf.provider;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -247,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/3-extensions/serialization/dubbo-samples-protobuf-json/protobuf-json-serialization-demo/src/main/java/org/apache/dubbo/sample/protobuf/provider/EmbeddedZooKeeper.java
+++ b/3-extensions/serialization/dubbo-samples-protobuf-json/protobuf-json-serialization-demo/src/main/java/org/apache/dubbo/sample/protobuf/provider/EmbeddedZooKeeper.java
@@ -27,7 +27,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +292,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUsed(port));
 
         return port;
+    }
+
+    private static boolean isPortInUsed(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/3-extensions/serialization/dubbo-samples-serialization/dubbo-samples-serialization-java/src/main/java/org/apache/dubbo/samples/serialization/EmbeddedZooKeeper.java
+++ b/3-extensions/serialization/dubbo-samples-serialization/dubbo-samples-serialization-java/src/main/java/org/apache/dubbo/samples/serialization/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.serialization;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.serialization;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/3-extensions/serialization/dubbo-samples-serialization/dubbo-samples-serialization-java/src/main/java/org/apache/dubbo/samples/serialization/EmbeddedZooKeeper.java
+++ b/3-extensions/serialization/dubbo-samples-serialization/dubbo-samples-serialization-java/src/main/java/org/apache/dubbo/samples/serialization/EmbeddedZooKeeper.java
@@ -16,6 +16,8 @@
  */
 package org.apache.dubbo.samples.serialization;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -23,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -43,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -85,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -177,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -189,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -228,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -241,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/4-governance/dubbo-samples-metrics-prometheus/dubbo-samples-metrics-prometheus-provider/src/main/java/org/apache/dubbo/samples/metrics/prometheus/provider/EmbeddedZooKeeper.java
+++ b/4-governance/dubbo-samples-metrics-prometheus/dubbo-samples-metrics-prometheus-provider/src/main/java/org/apache/dubbo/samples/metrics/prometheus/provider/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.dubbo.samples.metrics.prometheus.provider;
+
+import org.apache.dubbo.common.utils.NetUtils;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -23,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -43,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -85,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -248,5 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
-}
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
 
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
+}

--- a/4-governance/dubbo-samples-metrics-prometheus/dubbo-samples-metrics-prometheus-provider/src/main/java/org/apache/dubbo/samples/metrics/prometheus/provider/EmbeddedZooKeeper.java
+++ b/4-governance/dubbo-samples-metrics-prometheus/dubbo-samples-metrics-prometheus-provider/src/main/java/org/apache/dubbo/samples/metrics/prometheus/provider/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.metrics.prometheus.provider;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.metrics.prometheus.provider;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/4-governance/dubbo-samples-metrics/src/main/java/org/apache/dubbo/samples/metrics/EmbeddedZooKeeper.java
+++ b/4-governance/dubbo-samples-metrics/src/main/java/org/apache/dubbo/samples/metrics/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.metrics;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.metrics;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/4-governance/dubbo-samples-metrics/src/main/java/org/apache/dubbo/samples/metrics/EmbeddedZooKeeper.java
+++ b/4-governance/dubbo-samples-metrics/src/main/java/org/apache/dubbo/samples/metrics/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.metrics;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,17 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
-}
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
 
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
+}

--- a/4-governance/dubbo-samples-spring-boot-hystrix/src/main/java/org/apache/dubbo/spring/boot/provider/EmbeddedZooKeeper.java
+++ b/4-governance/dubbo-samples-spring-boot-hystrix/src/main/java/org/apache/dubbo/spring/boot/provider/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.spring.boot.provider;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.spring.boot.provider;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/4-governance/dubbo-samples-spring-boot-hystrix/src/main/java/org/apache/dubbo/spring/boot/provider/EmbeddedZooKeeper.java
+++ b/4-governance/dubbo-samples-spring-boot-hystrix/src/main/java/org/apache/dubbo/spring/boot/provider/EmbeddedZooKeeper.java
@@ -1,21 +1,4 @@
 /*
- * Copyright 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-package org.apache.dubbo.spring.boot.provider;
-
-/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -31,6 +14,9 @@ package org.apache.dubbo.spring.boot.provider;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.dubbo.spring.boot.provider;
+
+import org.apache.dubbo.common.utils.NetUtils;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -39,234 +25,273 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- * 
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- * 
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
- * 
+ *
  * @author Patrick Peralta
  * @author Mark Fisher
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
 
-	/**
-	 * Logger.
-	 */
-	private static final Logger logger = LoggerFactory.getLogger(EmbeddedZooKeeper.class);
+    private static final Random RANDOM = new Random();
 
-	/**
-	 * ZooKeeper client port. This will be determined dynamically upon startup.
-	 */
-	private final int clientPort;
+    /**
+     * Logger.
+     */
+    private static final Logger logger = LoggerFactory.getLogger(EmbeddedZooKeeper.class);
 
-	/**
-	 * Whether to auto-start. Default is true.
-	 */
-	private boolean autoStartup = true;
+    /**
+     * ZooKeeper client port. This will be determined dynamically upon startup.
+     */
+    private final int clientPort;
 
-	/**
-	 * Lifecycle phase. Default is 0.
-	 */
-	private int phase = 0;
+    /**
+     * Whether to auto-start. Default is true.
+     */
+    private boolean autoStartup = true;
 
-	/**
-	 * Thread for running the ZooKeeper server.
-	 */
-	private volatile Thread zkServerThread;
+    /**
+     * Lifecycle phase. Default is 0.
+     */
+    private int phase = 0;
 
-	/**
-	 * ZooKeeper server.
-	 */
-	private volatile ZooKeeperServerMain zkServer;
+    /**
+     * Thread for running the ZooKeeper server.
+     */
+    private volatile Thread zkServerThread;
 
-	/**
-	 * {@link ErrorHandler} to be invoked if an Exception is thrown from the ZooKeeper server thread.
-	 */
-	private ErrorHandler errorHandler;
+    /**
+     * ZooKeeper server.
+     */
+    private volatile ZooKeeperServerMain zkServer;
 
-	private boolean daemon = true;
+    /**
+     * {@link ErrorHandler} to be invoked if an Exception is thrown from the ZooKeeper server thread.
+     */
+    private ErrorHandler errorHandler;
 
-	/**
-	 * Construct an EmbeddedZooKeeper with a random port.
-	 */
-	public EmbeddedZooKeeper() {
-		clientPort = SocketUtils.findAvailableTcpPort();
-	}
+    private boolean daemon = true;
 
-	/**
-	 * Construct an EmbeddedZooKeeper with the provided port.
-	 *
-	 * @param clientPort  port for ZooKeeper server to bind to
-	 */
-	public EmbeddedZooKeeper(int clientPort, boolean daemon) {
-		this.clientPort = clientPort;
-		this.daemon = daemon;
-	}
+    /**
+     * Construct an EmbeddedZooKeeper with a random port.
+     */
+    public EmbeddedZooKeeper() {
+        clientPort = findRandomPort(30000, 65535);
+    }
 
-	/**
-	 * Returns the port that clients should use to connect to this embedded server.
-	 * 
-	 * @return dynamically determined client port
-	 */
-	public int getClientPort() {
-		return this.clientPort;
-	}
+    /**
+     * Construct an EmbeddedZooKeeper with the provided port.
+     *
+     * @param clientPort port for ZooKeeper server to bind to
+     */
+    public EmbeddedZooKeeper(int clientPort, boolean daemon) {
+        this.clientPort = clientPort;
+        this.daemon = daemon;
+    }
 
-	/**
-	 * Specify whether to start automatically. Default is true.
-	 * 
-	 * @param autoStartup whether to start automatically
-	 */
-	public void setAutoStartup(boolean autoStartup) {
-		this.autoStartup = autoStartup;
-	}
+    /**
+     * Returns the port that clients should use to connect to this embedded server.
+     *
+     * @return dynamically determined client port
+     */
+    public int getClientPort() {
+        return this.clientPort;
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public boolean isAutoStartup() {
-		return this.autoStartup;
-	}
+    /**
+     * Specify whether to start automatically. Default is true.
+     *
+     * @param autoStartup whether to start automatically
+     */
+    public void setAutoStartup(boolean autoStartup) {
+        this.autoStartup = autoStartup;
+    }
 
-	/**
-	 * Specify the lifecycle phase for the embedded server.
-	 * 
-	 * @param phase the lifecycle phase
-	 */
-	public void setPhase(int phase) {
-		this.phase = phase;
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isAutoStartup() {
+        return this.autoStartup;
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public int getPhase() {
-		return this.phase;
-	}
+    /**
+     * Specify the lifecycle phase for the embedded server.
+     *
+     * @param phase the lifecycle phase
+     */
+    public void setPhase(int phase) {
+        this.phase = phase;
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public boolean isRunning() {
-		return (zkServerThread != null);
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getPhase() {
+        return this.phase;
+    }
 
-	/**
-	 * Start the ZooKeeper server in a background thread.
-	 * <p>
-	 * Register an error handler via {@link #setErrorHandler} in order to handle
-	 * any exceptions thrown during startup or execution.
-	 */
-	@Override
-	public synchronized void start() {
-		if (zkServerThread == null) {
-			zkServerThread = new Thread(new ServerRunnable(), "ZooKeeper Server Starter");
-			zkServerThread.setDaemon(daemon);
-			zkServerThread.start();
-		}
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isRunning() {
+        return (zkServerThread != null);
+    }
 
-	/**
-	 * Shutdown the ZooKeeper server.
-	 */
-	@Override
-	public synchronized void stop() {
-		if (zkServerThread != null) {
-			// The shutdown method is protected...thus this hack to invoke it.
-			// This will log an exception on shutdown; see
-			// https://issues.apache.org/jira/browse/ZOOKEEPER-1873 for details.
-			try {
-				Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
-				shutdown.setAccessible(true);
-				shutdown.invoke(zkServer);
-			}
+    /**
+     * Start the ZooKeeper server in a background thread.
+     * <p>
+     * Register an error handler via {@link #setErrorHandler} in order to handle
+     * any exceptions thrown during startup or execution.
+     */
+    @Override
+    public synchronized void start() {
+        if (zkServerThread == null) {
+            zkServerThread = new Thread(new ServerRunnable(), "ZooKeeper Server Starter");
+            zkServerThread.setDaemon(daemon);
+            zkServerThread.start();
+        }
+    }
 
-			catch (Exception e) {
-				throw new RuntimeException(e);
-			}
+    /**
+     * Shutdown the ZooKeeper server.
+     */
+    @Override
+    public synchronized void stop() {
+        if (zkServerThread != null) {
+            // The shutdown method is protected...thus this hack to invoke it.
+            // This will log an exception on shutdown; see
+            // https://issues.apache.org/jira/browse/ZOOKEEPER-1873 for details.
+            try {
+                Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
+                shutdown.setAccessible(true);
+                shutdown.invoke(zkServer);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
 
-			// It is expected that the thread will exit after
-			// the server is shutdown; this will block until
-			// the shutdown is complete.
-			try {
-				zkServerThread.join(5000);
-				zkServerThread = null;
-			}
-			catch (InterruptedException e) {
-				Thread.currentThread().interrupt();
-				logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
-				// abandoning zk thread
-				zkServerThread = null;
-			}
-		}
-	}
+            // It is expected that the thread will exit after
+            // the server is shutdown; this will block until
+            // the shutdown is complete.
+            try {
+                zkServerThread.join(5000);
+                zkServerThread = null;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
+                // abandoning zk thread
+                zkServerThread = null;
+            }
+        }
+    }
 
-	/**
-	 * Stop the server if running and invoke the callback when complete.
-	 */
-	@Override
-	public void stop(Runnable callback) {
-		stop();
-		callback.run();
-	}
+    /**
+     * Stop the server if running and invoke the callback when complete.
+     */
+    @Override
+    public void stop(Runnable callback) {
+        stop();
+        callback.run();
+    }
 
-	/**
-	 * Provide an {@link ErrorHandler} to be invoked if an Exception is thrown from the ZooKeeper server thread. If none
-	 * is provided, only error-level logging will occur.
-	 * 
-	 * @param errorHandler the {@link ErrorHandler} to be invoked
-	 */
-	public void setErrorHandler(ErrorHandler errorHandler) {
-		this.errorHandler = errorHandler;
-	}
+    /**
+     * Provide an {@link ErrorHandler} to be invoked if an Exception is thrown from the ZooKeeper server thread. If none
+     * is provided, only error-level logging will occur.
+     *
+     * @param errorHandler the {@link ErrorHandler} to be invoked
+     */
+    public void setErrorHandler(ErrorHandler errorHandler) {
+        this.errorHandler = errorHandler;
+    }
 
-	/**
-	 * Runnable implementation that starts the ZooKeeper server.
-	 */
-	private class ServerRunnable implements Runnable {
+    /**
+     * Runnable implementation that starts the ZooKeeper server.
+     */
+    private class ServerRunnable implements Runnable {
 
-		@Override
-		public void run() {
-			try {
-				Properties properties = new Properties();
-				File file = new File(System.getProperty("java.io.tmpdir")
-						+ File.separator + UUID.randomUUID());
-				file.deleteOnExit();
-				properties.setProperty("dataDir", file.getAbsolutePath());
-				properties.setProperty("clientPort", String.valueOf(clientPort));
+        @Override
+        public void run() {
+            try {
+                Properties properties = new Properties();
+                File file = new File(System.getProperty("java.io.tmpdir")
+                        + File.separator + UUID.randomUUID());
+                file.deleteOnExit();
+                properties.setProperty("dataDir", file.getAbsolutePath());
+                properties.setProperty("clientPort", String.valueOf(clientPort));
 
-				QuorumPeerConfig quorumPeerConfig = new QuorumPeerConfig();
-				quorumPeerConfig.parseProperties(properties);
+                QuorumPeerConfig quorumPeerConfig = new QuorumPeerConfig();
+                quorumPeerConfig.parseProperties(properties);
 
-				zkServer = new ZooKeeperServerMain();
-				ServerConfig configuration = new ServerConfig();
-				configuration.readFrom(quorumPeerConfig);
+                zkServer = new ZooKeeperServerMain();
+                ServerConfig configuration = new ServerConfig();
+                configuration.readFrom(quorumPeerConfig);
 
-				zkServer.runFromConfig(configuration);
-			}
-			catch (Exception e) {
-				if (errorHandler != null) {
-					errorHandler.handleError(e);
-				}
-				else {
-					logger.error("Exception running embedded ZooKeeper", e);
-				}
-			}
-		}
-	}
+                zkServer.runFromConfig(configuration);
+            } catch (Exception e) {
+                if (errorHandler != null) {
+                    errorHandler.handleError(e);
+                } else {
+                    logger.error("Exception running embedded ZooKeeper", e);
+                }
+            }
+        }
+    }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/4-governance/dubbo-samples-spring-boot-tracing/dubbo-samples-spring-boot-tracing-provider/src/main/java/org/apache/dubbo/springboot/demo/provider/EmbeddedZooKeeper.java
+++ b/4-governance/dubbo-samples-spring-boot-tracing/dubbo-samples-spring-boot-tracing-provider/src/main/java/org/apache/dubbo/springboot/demo/provider/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.springboot.demo.provider;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.springboot.demo.provider;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/4-governance/dubbo-samples-spring-boot-tracing/dubbo-samples-spring-boot-tracing-provider/src/main/java/org/apache/dubbo/springboot/demo/provider/EmbeddedZooKeeper.java
+++ b/4-governance/dubbo-samples-spring-boot-tracing/dubbo-samples-spring-boot-tracing-provider/src/main/java/org/apache/dubbo/springboot/demo/provider/EmbeddedZooKeeper.java
@@ -16,6 +16,8 @@
  */
 package org.apache.dubbo.springboot.demo.provider;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -23,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -43,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -85,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -248,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/4-governance/dubbo-samples-spring-hystrix/src/main/java/org/apache/dubbo/samples/annotation/EmbeddedZooKeeper.java
+++ b/4-governance/dubbo-samples-spring-hystrix/src/main/java/org/apache/dubbo/samples/annotation/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.annotation;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.annotation;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/4-governance/dubbo-samples-spring-hystrix/src/main/java/org/apache/dubbo/samples/annotation/EmbeddedZooKeeper.java
+++ b/4-governance/dubbo-samples-spring-hystrix/src/main/java/org/apache/dubbo/samples/annotation/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.annotation;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/4-governance/dubbo-samples-ssl/dubbo-samples-ssl-provider/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
+++ b/4-governance/dubbo-samples-ssl/dubbo-samples-ssl-provider/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.basic;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.basic;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/4-governance/dubbo-samples-ssl/dubbo-samples-ssl-provider/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
+++ b/4-governance/dubbo-samples-ssl/dubbo-samples-ssl-provider/src/main/java/org/apache/dubbo/samples/basic/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.basic;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/4-governance/dubbo-samples-tagrouter/src/main/java/org/apache/dubbo/samples/governance/EmbeddedZooKeeper.java
+++ b/4-governance/dubbo-samples-tagrouter/src/main/java/org/apache/dubbo/samples/governance/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.governance;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.governance;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/4-governance/dubbo-samples-tagrouter/src/main/java/org/apache/dubbo/samples/governance/EmbeddedZooKeeper.java
+++ b/4-governance/dubbo-samples-tagrouter/src/main/java/org/apache/dubbo/samples/governance/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.governance;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -247,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/99-integration/dubbo-samples-empty-protection/src/main/java/org/apache/dubbo/samples/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-empty-protection/src/main/java/org/apache/dubbo/samples/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/99-integration/dubbo-samples-empty-protection/src/main/java/org/apache/dubbo/samples/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-empty-protection/src/main/java/org/apache/dubbo/samples/EmbeddedZooKeeper.java
@@ -16,6 +16,8 @@
  */
 package org.apache.dubbo.samples;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -23,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -43,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -85,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -248,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/99-integration/dubbo-samples-hibernate/dubbo-samples-spring-boot-hibernate-provider/src/main/java/org/apache/dubbo/springboot/hibernate/samples/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-hibernate/dubbo-samples-spring-boot-hibernate-provider/src/main/java/org/apache/dubbo/springboot/hibernate/samples/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.springboot.hibernate.samples;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.springboot.hibernate.samples;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/99-integration/dubbo-samples-hibernate/dubbo-samples-spring-boot-hibernate-provider/src/main/java/org/apache/dubbo/springboot/hibernate/samples/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-hibernate/dubbo-samples-spring-boot-hibernate-provider/src/main/java/org/apache/dubbo/springboot/hibernate/samples/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.springboot.hibernate.samples;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-configcenter/src/main/java/org/apache/dubbo/samples/metadatareport/configcenter/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-configcenter/src/main/java/org/apache/dubbo/samples/metadatareport/configcenter/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.metadatareport.configcenter;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.metadatareport.configcenter;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-configcenter/src/main/java/org/apache/dubbo/samples/metadatareport/configcenter/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-configcenter/src/main/java/org/apache/dubbo/samples/metadatareport/configcenter/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.metadatareport.configcenter;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -247,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-annotation/src/main/java/org/apache/dubbo/samples/metadatareport/local/annotation/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-annotation/src/main/java/org/apache/dubbo/samples/metadatareport/local/annotation/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.metadatareport.local.annotation;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.metadatareport.local.annotation;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-annotation/src/main/java/org/apache/dubbo/samples/metadatareport/local/annotation/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-annotation/src/main/java/org/apache/dubbo/samples/metadatareport/local/annotation/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.metadatareport.local.annotation;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -247,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/src/main/java/org/apache/dubbo/samples/metadatareport/local/properties/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/src/main/java/org/apache/dubbo/samples/metadatareport/local/properties/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.metadatareport.local.properties;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.metadatareport.local.properties;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/src/main/java/org/apache/dubbo/samples/metadatareport/local/properties/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/src/main/java/org/apache/dubbo/samples/metadatareport/local/properties/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.metadatareport.local.properties;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -247,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-xml/src/main/java/org/apache/dubbo/samples/metadatareport/local/xml/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-xml/src/main/java/org/apache/dubbo/samples/metadatareport/local/xml/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.metadatareport.local.xml;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.metadatareport.local.xml;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-xml/src/main/java/org/apache/dubbo/samples/metadatareport/local/xml/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-xml/src/main/java/org/apache/dubbo/samples/metadatareport/local/xml/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.metadatareport.local.xml;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,12 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,7 +91,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
@@ -247,4 +254,44 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/99-integration/dubbo-samples-mybatis/dubbo-samples-spring-boot-mybatis-provider/src/main/java/org/apache/dubbo/springboot/mybatis/samples/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-mybatis/dubbo-samples-spring-boot-mybatis-provider/src/main/java/org/apache/dubbo/springboot/mybatis/samples/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.springboot.mybatis.samples;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.springboot.mybatis.samples;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/99-integration/dubbo-samples-mybatis/dubbo-samples-spring-boot-mybatis-provider/src/main/java/org/apache/dubbo/springboot/mybatis/samples/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-mybatis/dubbo-samples-spring-boot-mybatis-provider/src/main/java/org/apache/dubbo/springboot/mybatis/samples/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.springboot.mybatis.samples;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/99-integration/dubbo-samples-port-unification-netty3/src/main/java/org/apache/dubbo/samples/zookeeper/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-port-unification-netty3/src/main/java/org/apache/dubbo/samples/zookeeper/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.zookeeper;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.zookeeper;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/99-integration/dubbo-samples-port-unification-netty3/src/main/java/org/apache/dubbo/samples/zookeeper/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-port-unification-netty3/src/main/java/org/apache/dubbo/samples/zookeeper/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.zookeeper;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/99-integration/dubbo-samples-router-chain-switch/src/main/java/org/apache/dubbo/samples/zookeeper/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-router-chain-switch/src/main/java/org/apache/dubbo/samples/zookeeper/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.zookeeper;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.zookeeper;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/99-integration/dubbo-samples-router-chain-switch/src/main/java/org/apache/dubbo/samples/zookeeper/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-router-chain-switch/src/main/java/org/apache/dubbo/samples/zookeeper/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.zookeeper;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/99-integration/dubbo-samples-sentinel-compact/src/main/java/org/apache/samples/sentinel/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-sentinel-compact/src/main/java/org/apache/samples/sentinel/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.samples.sentinel;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.samples.sentinel;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/99-integration/dubbo-samples-sentinel-compact/src/main/java/org/apache/samples/sentinel/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-sentinel-compact/src/main/java/org/apache/samples/sentinel/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.samples.sentinel;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/99-integration/dubbo-samples-sentinel-dubbo3/src/main/java/org/apache/samples/sentinel/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-sentinel-dubbo3/src/main/java/org/apache/samples/sentinel/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.samples.sentinel;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.samples.sentinel;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/99-integration/dubbo-samples-sentinel-dubbo3/src/main/java/org/apache/samples/sentinel/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-sentinel-dubbo3/src/main/java/org/apache/samples/sentinel/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.samples.sentinel;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/99-integration/dubbo-samples-switch-serialization-thread/src/main/java/org/apache/dubbo/samples/serialization/change/thread/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-switch-serialization-thread/src/main/java/org/apache/dubbo/samples/serialization/change/thread/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.serialization.change.thread;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.serialization.change.thread;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/99-integration/dubbo-samples-switch-serialization-thread/src/main/java/org/apache/dubbo/samples/serialization/change/thread/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-switch-serialization-thread/src/main/java/org/apache/dubbo/samples/serialization/change/thread/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.serialization.change.thread;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/99-integration/dubbo-samples-test-10704/src/main/java/org/apache/dubbo/samples/local/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-test-10704/src/main/java/org/apache/dubbo/samples/local/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples.local;
 
-import org.apache.dubbo.common.utils.NetUtils;
+package org.apache.dubbo.samples.local;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
@@ -27,7 +26,9 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -290,8 +291,17 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
 
             port = randomInts.get(counter);
             counter++;
-        } while (NetUtils.isPortInUsed(port));
+        } while (isPortInUse(port));
 
         return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/99-integration/dubbo-samples-test-10704/src/main/java/org/apache/dubbo/samples/local/EmbeddedZooKeeper.java
+++ b/99-integration/dubbo-samples-test-10704/src/main/java/org/apache/dubbo/samples/local/EmbeddedZooKeeper.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +16,8 @@
  */
 package org.apache.dubbo.samples.local;
 
+import org.apache.dubbo.common.utils.NetUtils;
+
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -22,18 +25,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- *
+ * <p>
  * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- *
+ * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
  *
@@ -42,6 +47,8 @@ import java.util.UUID;
  * @author David Turanski
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
 
     /**
      * Logger.
@@ -84,13 +91,13 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = findRandomPort(30000, 65535);
     }
 
     /**
      * Construct an EmbeddedZooKeeper with the provided port.
      *
-     * @param clientPort  port for ZooKeeper server to bind to
+     * @param clientPort port for ZooKeeper server to bind to
      */
     public EmbeddedZooKeeper(int clientPort, boolean daemon) {
         this.clientPort = clientPort;
@@ -176,9 +183,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
                 shutdown.setAccessible(true);
                 shutdown.invoke(zkServer);
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
@@ -188,8 +193,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 zkServerThread.join(5000);
                 zkServerThread = null;
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
                 // abandoning zk thread
@@ -227,7 +231,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
             try {
                 Properties properties = new Properties();
                 File file = new File(System.getProperty("java.io.tmpdir")
-                    + File.separator + UUID.randomUUID());
+                        + File.separator + UUID.randomUUID());
                 file.deleteOnExit();
                 properties.setProperty("dataDir", file.getAbsolutePath());
                 properties.setProperty("clientPort", String.valueOf(clientPort));
@@ -240,16 +244,54 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
                 configuration.readFrom(quorumPeerConfig);
 
                 zkServer.runFromConfig(configuration);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 if (errorHandler != null) {
                     errorHandler.handleError(e);
-                }
-                else {
+                } else {
                     logger.error("Exception running embedded ZooKeeper", e);
                 }
             }
         }
     }
 
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+        }
+
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
+    }
 }

--- a/tools/embedded-zookeeper/pom.xml
+++ b/tools/embedded-zookeeper/pom.xml
@@ -102,6 +102,16 @@
                     <mainClass>org.apache.dubbo.samples.EmbeddedZooKeeper</mainClass>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/tools/embedded-zookeeper/src/main/java/org/apache/dubbo/samples/EmbeddedZooKeeper.java
+++ b/tools/embedded-zookeeper/src/main/java/org/apache/dubbo/samples/EmbeddedZooKeeper.java
@@ -16,41 +16,282 @@
  */
 package org.apache.dubbo.samples;
 
-import java.io.File;
-import java.util.Properties;
-import java.util.UUID;
+import org.apache.dubbo.common.utils.NetUtils;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.util.ErrorHandler;
 
-public class EmbeddedZooKeeper {
+import java.io.File;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Properties;
+import java.util.Random;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
-    public static void main(String[] args) throws Exception {
-        int port = 2181;
-        if (args.length == 1) {
-            port = Integer.parseInt(args[0]);
+/**
+ * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
+ * <p>
+ * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
+ * <p>
+ * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
+ * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
+ *
+ * @author Patrick Peralta
+ * @author Mark Fisher
+ * @author David Turanski
+ */
+public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
+
+    /**
+     * Logger.
+     */
+    private static final Logger logger = LoggerFactory.getLogger(EmbeddedZooKeeper.class);
+
+    /**
+     * ZooKeeper client port. This will be determined dynamically upon startup.
+     */
+    private final int clientPort;
+
+    /**
+     * Whether to auto-start. Default is true.
+     */
+    private boolean autoStartup = true;
+
+    /**
+     * Lifecycle phase. Default is 0.
+     */
+    private int phase = 0;
+
+    /**
+     * Thread for running the ZooKeeper server.
+     */
+    private volatile Thread zkServerThread;
+
+    /**
+     * ZooKeeper server.
+     */
+    private volatile ZooKeeperServerMain zkServer;
+
+    /**
+     * {@link ErrorHandler} to be invoked if an Exception is thrown from the ZooKeeper server thread.
+     */
+    private ErrorHandler errorHandler;
+
+    private boolean daemon = true;
+
+    /**
+     * Construct an EmbeddedZooKeeper with a random port.
+     */
+    public EmbeddedZooKeeper() {
+        clientPort = findRandomPort(30000, 65535);
+    }
+
+    /**
+     * Construct an EmbeddedZooKeeper with the provided port.
+     *
+     * @param clientPort port for ZooKeeper server to bind to
+     */
+    public EmbeddedZooKeeper(int clientPort, boolean daemon) {
+        this.clientPort = clientPort;
+        this.daemon = daemon;
+    }
+
+    /**
+     * Returns the port that clients should use to connect to this embedded server.
+     *
+     * @return dynamically determined client port
+     */
+    public int getClientPort() {
+        return this.clientPort;
+    }
+
+    /**
+     * Specify whether to start automatically. Default is true.
+     *
+     * @param autoStartup whether to start automatically
+     */
+    public void setAutoStartup(boolean autoStartup) {
+        this.autoStartup = autoStartup;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isAutoStartup() {
+        return this.autoStartup;
+    }
+
+    /**
+     * Specify the lifecycle phase for the embedded server.
+     *
+     * @param phase the lifecycle phase
+     */
+    public void setPhase(int phase) {
+        this.phase = phase;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getPhase() {
+        return this.phase;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isRunning() {
+        return (zkServerThread != null);
+    }
+
+    /**
+     * Start the ZooKeeper server in a background thread.
+     * <p>
+     * Register an error handler via {@link #setErrorHandler} in order to handle
+     * any exceptions thrown during startup or execution.
+     */
+    @Override
+    public synchronized void start() {
+        if (zkServerThread == null) {
+            zkServerThread = new Thread(new ServerRunnable(), "ZooKeeper Server Starter");
+            zkServerThread.setDaemon(daemon);
+            zkServerThread.start();
+        }
+    }
+
+    /**
+     * Shutdown the ZooKeeper server.
+     */
+    @Override
+    public synchronized void stop() {
+        if (zkServerThread != null) {
+            // The shutdown method is protected...thus this hack to invoke it.
+            // This will log an exception on shutdown; see
+            // https://issues.apache.org/jira/browse/ZOOKEEPER-1873 for details.
+            try {
+                Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
+                shutdown.setAccessible(true);
+                shutdown.invoke(zkServer);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            // It is expected that the thread will exit after
+            // the server is shutdown; this will block until
+            // the shutdown is complete.
+            try {
+                zkServerThread.join(5000);
+                zkServerThread = null;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
+                // abandoning zk thread
+                zkServerThread = null;
+            }
+        }
+    }
+
+    /**
+     * Stop the server if running and invoke the callback when complete.
+     */
+    @Override
+    public void stop(Runnable callback) {
+        stop();
+        callback.run();
+    }
+
+    /**
+     * Provide an {@link ErrorHandler} to be invoked if an Exception is thrown from the ZooKeeper server thread. If none
+     * is provided, only error-level logging will occur.
+     *
+     * @param errorHandler the {@link ErrorHandler} to be invoked
+     */
+    public void setErrorHandler(ErrorHandler errorHandler) {
+        this.errorHandler = errorHandler;
+    }
+
+    /**
+     * Runnable implementation that starts the ZooKeeper server.
+     */
+    private class ServerRunnable implements Runnable {
+
+        @Override
+        public void run() {
+            try {
+                Properties properties = new Properties();
+                File file = new File(System.getProperty("java.io.tmpdir")
+                        + File.separator + UUID.randomUUID());
+                file.deleteOnExit();
+                properties.setProperty("dataDir", file.getAbsolutePath());
+                properties.setProperty("clientPort", String.valueOf(clientPort));
+
+                QuorumPeerConfig quorumPeerConfig = new QuorumPeerConfig();
+                quorumPeerConfig.parseProperties(properties);
+
+                zkServer = new ZooKeeperServerMain();
+                ServerConfig configuration = new ServerConfig();
+                configuration.readFrom(quorumPeerConfig);
+
+                zkServer.runFromConfig(configuration);
+            } catch (Exception e) {
+                if (errorHandler != null) {
+                    errorHandler.handleError(e);
+                } else {
+                    logger.error("Exception running embedded ZooKeeper", e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
         }
 
-        Properties properties = new Properties();
-        File file = new File(System.getProperty("java.io.tmpdir")
-                + File.separator + UUID.randomUUID());
-        file.deleteOnExit();
-        properties.setProperty("dataDir", file.getAbsolutePath());
-        properties.setProperty("clientPort", String.valueOf(port));
-
-        QuorumPeerConfig quorumPeerConfig = new QuorumPeerConfig();
-        quorumPeerConfig.parseProperties(properties);
-
-        ZooKeeperServerMain zkServer = new ZooKeeperServerMain();
-        ServerConfig configuration = new ServerConfig();
-        configuration.readFrom(quorumPeerConfig);
-
-        try {
-            zkServer.runFromConfig(configuration);
-        } catch (Exception e) {
-            e.printStackTrace();
-            System.exit(1);
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
         }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (NetUtils.isPortInUsed(port));
+
+        return port;
     }
 }

--- a/tools/embedded-zookeeper/src/main/java/org/apache/dubbo/samples/EmbeddedZooKeeper.java
+++ b/tools/embedded-zookeeper/src/main/java/org/apache/dubbo/samples/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
-
 /*
- * Copyright 2014 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,294 +14,43 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.dubbo.samples;
+
+import java.io.File;
+import java.util.Properties;
+import java.util.UUID;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.context.SmartLifecycle;
-import org.springframework.util.ErrorHandler;
 
-import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.Method;
-import java.net.ServerSocket;
-import java.util.List;
-import java.util.Properties;
-import java.util.Random;
-import java.util.UUID;
-import java.util.stream.Collectors;
+public class EmbeddedZooKeeper {
 
-/**
- * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- * <p>
- * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- * <p>
- * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
- * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
- *
- * @author Patrick Peralta
- * @author Mark Fisher
- * @author David Turanski
- */
-public class EmbeddedZooKeeper implements SmartLifecycle {
-
-    private static final Random RANDOM = new Random();
-
-    /**
-     * Logger.
-     */
-    private static final Logger logger = LoggerFactory.getLogger(EmbeddedZooKeeper.class);
-
-    /**
-     * ZooKeeper client port. This will be determined dynamically upon startup.
-     */
-    private final int clientPort;
-
-    /**
-     * Whether to auto-start. Default is true.
-     */
-    private boolean autoStartup = true;
-
-    /**
-     * Lifecycle phase. Default is 0.
-     */
-    private int phase = 0;
-
-    /**
-     * Thread for running the ZooKeeper server.
-     */
-    private volatile Thread zkServerThread;
-
-    /**
-     * ZooKeeper server.
-     */
-    private volatile ZooKeeperServerMain zkServer;
-
-    /**
-     * {@link ErrorHandler} to be invoked if an Exception is thrown from the ZooKeeper server thread.
-     */
-    private ErrorHandler errorHandler;
-
-    private boolean daemon = true;
-
-    /**
-     * Construct an EmbeddedZooKeeper with a random port.
-     */
-    public EmbeddedZooKeeper() {
-        clientPort = findRandomPort(30000, 65535);
-    }
-
-    /**
-     * Construct an EmbeddedZooKeeper with the provided port.
-     *
-     * @param clientPort port for ZooKeeper server to bind to
-     */
-    public EmbeddedZooKeeper(int clientPort, boolean daemon) {
-        this.clientPort = clientPort;
-        this.daemon = daemon;
-    }
-
-    /**
-     * Returns the port that clients should use to connect to this embedded server.
-     *
-     * @return dynamically determined client port
-     */
-    public int getClientPort() {
-        return this.clientPort;
-    }
-
-    /**
-     * Specify whether to start automatically. Default is true.
-     *
-     * @param autoStartup whether to start automatically
-     */
-    public void setAutoStartup(boolean autoStartup) {
-        this.autoStartup = autoStartup;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean isAutoStartup() {
-        return this.autoStartup;
-    }
-
-    /**
-     * Specify the lifecycle phase for the embedded server.
-     *
-     * @param phase the lifecycle phase
-     */
-    public void setPhase(int phase) {
-        this.phase = phase;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public int getPhase() {
-        return this.phase;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean isRunning() {
-        return (zkServerThread != null);
-    }
-
-    /**
-     * Start the ZooKeeper server in a background thread.
-     * <p>
-     * Register an error handler via {@link #setErrorHandler} in order to handle
-     * any exceptions thrown during startup or execution.
-     */
-    @Override
-    public synchronized void start() {
-        if (zkServerThread == null) {
-            zkServerThread = new Thread(new ServerRunnable(), "ZooKeeper Server Starter");
-            zkServerThread.setDaemon(daemon);
-            zkServerThread.start();
-        }
-    }
-
-    /**
-     * Shutdown the ZooKeeper server.
-     */
-    @Override
-    public synchronized void stop() {
-        if (zkServerThread != null) {
-            // The shutdown method is protected...thus this hack to invoke it.
-            // This will log an exception on shutdown; see
-            // https://issues.apache.org/jira/browse/ZOOKEEPER-1873 for details.
-            try {
-                Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
-                shutdown.setAccessible(true);
-                shutdown.invoke(zkServer);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-
-            // It is expected that the thread will exit after
-            // the server is shutdown; this will block until
-            // the shutdown is complete.
-            try {
-                zkServerThread.join(5000);
-                zkServerThread = null;
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
-                // abandoning zk thread
-                zkServerThread = null;
-            }
-        }
-    }
-
-    /**
-     * Stop the server if running and invoke the callback when complete.
-     */
-    @Override
-    public void stop(Runnable callback) {
-        stop();
-        callback.run();
-    }
-
-    /**
-     * Provide an {@link ErrorHandler} to be invoked if an Exception is thrown from the ZooKeeper server thread. If none
-     * is provided, only error-level logging will occur.
-     *
-     * @param errorHandler the {@link ErrorHandler} to be invoked
-     */
-    public void setErrorHandler(ErrorHandler errorHandler) {
-        this.errorHandler = errorHandler;
-    }
-
-    /**
-     * Runnable implementation that starts the ZooKeeper server.
-     */
-    private class ServerRunnable implements Runnable {
-
-        @Override
-        public void run() {
-            try {
-                Properties properties = new Properties();
-                File file = new File(System.getProperty("java.io.tmpdir")
-                        + File.separator + UUID.randomUUID());
-                file.deleteOnExit();
-                properties.setProperty("dataDir", file.getAbsolutePath());
-                properties.setProperty("clientPort", String.valueOf(clientPort));
-
-                QuorumPeerConfig quorumPeerConfig = new QuorumPeerConfig();
-                quorumPeerConfig.parseProperties(properties);
-
-                zkServer = new ZooKeeperServerMain();
-                ServerConfig configuration = new ServerConfig();
-                configuration.readFrom(quorumPeerConfig);
-
-                zkServer.runFromConfig(configuration);
-            } catch (Exception e) {
-                if (errorHandler != null) {
-                    errorHandler.handleError(e);
-                } else {
-                    logger.error("Exception running embedded ZooKeeper", e);
-                }
-            }
-        }
-    }
-
-    /**
-     * Workaround for SocketUtils.findRandomPort() deprecation.
-     *
-     * @param min min port
-     * @param max max port
-     * @return a random generated available port
-     */
-    private static int findRandomPort(int min, int max) {
-        if (min < 1024) {
-            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+    public static void main(String[] args) throws Exception {
+        int port = 2181;
+        if (args.length == 1) {
+            port = Integer.parseInt(args[0]);
         }
 
-        if (max > 65535) {
-            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        Properties properties = new Properties();
+        File file = new File(System.getProperty("java.io.tmpdir")
+                + File.separator + UUID.randomUUID());
+        file.deleteOnExit();
+        properties.setProperty("dataDir", file.getAbsolutePath());
+        properties.setProperty("clientPort", String.valueOf(port));
+
+        QuorumPeerConfig quorumPeerConfig = new QuorumPeerConfig();
+        quorumPeerConfig.parseProperties(properties);
+
+        ZooKeeperServerMain zkServer = new ZooKeeperServerMain();
+        ServerConfig configuration = new ServerConfig();
+        configuration.readFrom(quorumPeerConfig);
+
+        try {
+            zkServer.runFromConfig(configuration);
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.exit(1);
         }
-
-        if (min > max) {
-            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
-        }
-
-        int port = 0;
-        int counter = 0;
-
-        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
-        List<Integer> randomInts = RANDOM.ints(min, max + 1)
-                .limit(max - min)
-                .mapToObj(Integer::valueOf)
-                .collect(Collectors.toList());
-
-        do {
-            if (counter > max - min) {
-                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
-            }
-
-            port = randomInts.get(counter);
-            counter++;
-        } while (isPortInUse(port));
-
-        return port;
-    }
-
-    private static boolean isPortInUse(int port) {
-        try (ServerSocket ignored = new ServerSocket(port)) {
-            return false;
-        } catch (IOException e) {
-            // continue
-        }
-        return true;
     }
 }

--- a/tools/embedded-zookeeper/src/main/java/org/apache/dubbo/samples/EmbeddedZooKeeper.java
+++ b/tools/embedded-zookeeper/src/main/java/org/apache/dubbo/samples/EmbeddedZooKeeper.java
@@ -1,12 +1,12 @@
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,43 +14,294 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.samples;
 
-import java.io.File;
-import java.util.Properties;
-import java.util.UUID;
+package org.apache.dubbo.samples;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.util.ErrorHandler;
 
-public class EmbeddedZooKeeper {
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.ServerSocket;
+import java.util.List;
+import java.util.Properties;
+import java.util.Random;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
-    public static void main(String[] args) throws Exception {
-        int port = 2181;
-        if (args.length == 1) {
-            port = Integer.parseInt(args[0]);
+/**
+ * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
+ * <p>
+ * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
+ * <p>
+ * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
+ * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
+ *
+ * @author Patrick Peralta
+ * @author Mark Fisher
+ * @author David Turanski
+ */
+public class EmbeddedZooKeeper implements SmartLifecycle {
+
+    private static final Random RANDOM = new Random();
+
+    /**
+     * Logger.
+     */
+    private static final Logger logger = LoggerFactory.getLogger(EmbeddedZooKeeper.class);
+
+    /**
+     * ZooKeeper client port. This will be determined dynamically upon startup.
+     */
+    private final int clientPort;
+
+    /**
+     * Whether to auto-start. Default is true.
+     */
+    private boolean autoStartup = true;
+
+    /**
+     * Lifecycle phase. Default is 0.
+     */
+    private int phase = 0;
+
+    /**
+     * Thread for running the ZooKeeper server.
+     */
+    private volatile Thread zkServerThread;
+
+    /**
+     * ZooKeeper server.
+     */
+    private volatile ZooKeeperServerMain zkServer;
+
+    /**
+     * {@link ErrorHandler} to be invoked if an Exception is thrown from the ZooKeeper server thread.
+     */
+    private ErrorHandler errorHandler;
+
+    private boolean daemon = true;
+
+    /**
+     * Construct an EmbeddedZooKeeper with a random port.
+     */
+    public EmbeddedZooKeeper() {
+        clientPort = findRandomPort(30000, 65535);
+    }
+
+    /**
+     * Construct an EmbeddedZooKeeper with the provided port.
+     *
+     * @param clientPort port for ZooKeeper server to bind to
+     */
+    public EmbeddedZooKeeper(int clientPort, boolean daemon) {
+        this.clientPort = clientPort;
+        this.daemon = daemon;
+    }
+
+    /**
+     * Returns the port that clients should use to connect to this embedded server.
+     *
+     * @return dynamically determined client port
+     */
+    public int getClientPort() {
+        return this.clientPort;
+    }
+
+    /**
+     * Specify whether to start automatically. Default is true.
+     *
+     * @param autoStartup whether to start automatically
+     */
+    public void setAutoStartup(boolean autoStartup) {
+        this.autoStartup = autoStartup;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isAutoStartup() {
+        return this.autoStartup;
+    }
+
+    /**
+     * Specify the lifecycle phase for the embedded server.
+     *
+     * @param phase the lifecycle phase
+     */
+    public void setPhase(int phase) {
+        this.phase = phase;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getPhase() {
+        return this.phase;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isRunning() {
+        return (zkServerThread != null);
+    }
+
+    /**
+     * Start the ZooKeeper server in a background thread.
+     * <p>
+     * Register an error handler via {@link #setErrorHandler} in order to handle
+     * any exceptions thrown during startup or execution.
+     */
+    @Override
+    public synchronized void start() {
+        if (zkServerThread == null) {
+            zkServerThread = new Thread(new ServerRunnable(), "ZooKeeper Server Starter");
+            zkServerThread.setDaemon(daemon);
+            zkServerThread.start();
+        }
+    }
+
+    /**
+     * Shutdown the ZooKeeper server.
+     */
+    @Override
+    public synchronized void stop() {
+        if (zkServerThread != null) {
+            // The shutdown method is protected...thus this hack to invoke it.
+            // This will log an exception on shutdown; see
+            // https://issues.apache.org/jira/browse/ZOOKEEPER-1873 for details.
+            try {
+                Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
+                shutdown.setAccessible(true);
+                shutdown.invoke(zkServer);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            // It is expected that the thread will exit after
+            // the server is shutdown; this will block until
+            // the shutdown is complete.
+            try {
+                zkServerThread.join(5000);
+                zkServerThread = null;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
+                // abandoning zk thread
+                zkServerThread = null;
+            }
+        }
+    }
+
+    /**
+     * Stop the server if running and invoke the callback when complete.
+     */
+    @Override
+    public void stop(Runnable callback) {
+        stop();
+        callback.run();
+    }
+
+    /**
+     * Provide an {@link ErrorHandler} to be invoked if an Exception is thrown from the ZooKeeper server thread. If none
+     * is provided, only error-level logging will occur.
+     *
+     * @param errorHandler the {@link ErrorHandler} to be invoked
+     */
+    public void setErrorHandler(ErrorHandler errorHandler) {
+        this.errorHandler = errorHandler;
+    }
+
+    /**
+     * Runnable implementation that starts the ZooKeeper server.
+     */
+    private class ServerRunnable implements Runnable {
+
+        @Override
+        public void run() {
+            try {
+                Properties properties = new Properties();
+                File file = new File(System.getProperty("java.io.tmpdir")
+                        + File.separator + UUID.randomUUID());
+                file.deleteOnExit();
+                properties.setProperty("dataDir", file.getAbsolutePath());
+                properties.setProperty("clientPort", String.valueOf(clientPort));
+
+                QuorumPeerConfig quorumPeerConfig = new QuorumPeerConfig();
+                quorumPeerConfig.parseProperties(properties);
+
+                zkServer = new ZooKeeperServerMain();
+                ServerConfig configuration = new ServerConfig();
+                configuration.readFrom(quorumPeerConfig);
+
+                zkServer.runFromConfig(configuration);
+            } catch (Exception e) {
+                if (errorHandler != null) {
+                    errorHandler.handleError(e);
+                } else {
+                    logger.error("Exception running embedded ZooKeeper", e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Workaround for SocketUtils.findRandomPort() deprecation.
+     *
+     * @param min min port
+     * @param max max port
+     * @return a random generated available port
+     */
+    private static int findRandomPort(int min, int max) {
+        if (min < 1024) {
+            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
         }
 
-        Properties properties = new Properties();
-        File file = new File(System.getProperty("java.io.tmpdir")
-                + File.separator + UUID.randomUUID());
-        file.deleteOnExit();
-        properties.setProperty("dataDir", file.getAbsolutePath());
-        properties.setProperty("clientPort", String.valueOf(port));
-
-        QuorumPeerConfig quorumPeerConfig = new QuorumPeerConfig();
-        quorumPeerConfig.parseProperties(properties);
-
-        ZooKeeperServerMain zkServer = new ZooKeeperServerMain();
-        ServerConfig configuration = new ServerConfig();
-        configuration.readFrom(quorumPeerConfig);
-
-        try {
-            zkServer.runFromConfig(configuration);
-        } catch (Exception e) {
-            e.printStackTrace();
-            System.exit(1);
+        if (max > 65535) {
+            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
         }
+
+        if (min > max) {
+            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
+        }
+
+        int port = 0;
+        int counter = 0;
+
+        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
+        List<Integer> randomInts = RANDOM.ints(min, max + 1)
+                .limit(max - min)
+                .mapToObj(Integer::valueOf)
+                .collect(Collectors.toList());
+
+        do {
+            if (counter > max - min) {
+                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
+            }
+
+            port = randomInts.get(counter);
+            counter++;
+        } while (isPortInUse(port));
+
+        return port;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
     }
 }

--- a/tools/embedded-zookeeper/src/main/java/org/apache/dubbo/samples/EmbeddedZooKeeper.java
+++ b/tools/embedded-zookeeper/src/main/java/org/apache/dubbo/samples/EmbeddedZooKeeper.java
@@ -16,282 +16,41 @@
  */
 package org.apache.dubbo.samples;
 
-import org.apache.dubbo.common.utils.NetUtils;
+import java.io.File;
+import java.util.Properties;
+import java.util.UUID;
 
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.context.SmartLifecycle;
-import org.springframework.util.ErrorHandler;
 
-import java.io.File;
-import java.lang.reflect.Method;
-import java.util.List;
-import java.util.Properties;
-import java.util.Random;
-import java.util.UUID;
-import java.util.stream.Collectors;
+public class EmbeddedZooKeeper {
 
-/**
- * from: https://github.com/spring-projects/spring-xd/blob/v1.3.1.RELEASE/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
- * <p>
- * Helper class to start an embedded instance of standalone (non clustered) ZooKeeper.
- * <p>
- * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
- * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
- *
- * @author Patrick Peralta
- * @author Mark Fisher
- * @author David Turanski
- */
-public class EmbeddedZooKeeper implements SmartLifecycle {
-
-    private static final Random RANDOM = new Random();
-
-    /**
-     * Logger.
-     */
-    private static final Logger logger = LoggerFactory.getLogger(EmbeddedZooKeeper.class);
-
-    /**
-     * ZooKeeper client port. This will be determined dynamically upon startup.
-     */
-    private final int clientPort;
-
-    /**
-     * Whether to auto-start. Default is true.
-     */
-    private boolean autoStartup = true;
-
-    /**
-     * Lifecycle phase. Default is 0.
-     */
-    private int phase = 0;
-
-    /**
-     * Thread for running the ZooKeeper server.
-     */
-    private volatile Thread zkServerThread;
-
-    /**
-     * ZooKeeper server.
-     */
-    private volatile ZooKeeperServerMain zkServer;
-
-    /**
-     * {@link ErrorHandler} to be invoked if an Exception is thrown from the ZooKeeper server thread.
-     */
-    private ErrorHandler errorHandler;
-
-    private boolean daemon = true;
-
-    /**
-     * Construct an EmbeddedZooKeeper with a random port.
-     */
-    public EmbeddedZooKeeper() {
-        clientPort = findRandomPort(30000, 65535);
-    }
-
-    /**
-     * Construct an EmbeddedZooKeeper with the provided port.
-     *
-     * @param clientPort port for ZooKeeper server to bind to
-     */
-    public EmbeddedZooKeeper(int clientPort, boolean daemon) {
-        this.clientPort = clientPort;
-        this.daemon = daemon;
-    }
-
-    /**
-     * Returns the port that clients should use to connect to this embedded server.
-     *
-     * @return dynamically determined client port
-     */
-    public int getClientPort() {
-        return this.clientPort;
-    }
-
-    /**
-     * Specify whether to start automatically. Default is true.
-     *
-     * @param autoStartup whether to start automatically
-     */
-    public void setAutoStartup(boolean autoStartup) {
-        this.autoStartup = autoStartup;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean isAutoStartup() {
-        return this.autoStartup;
-    }
-
-    /**
-     * Specify the lifecycle phase for the embedded server.
-     *
-     * @param phase the lifecycle phase
-     */
-    public void setPhase(int phase) {
-        this.phase = phase;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public int getPhase() {
-        return this.phase;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean isRunning() {
-        return (zkServerThread != null);
-    }
-
-    /**
-     * Start the ZooKeeper server in a background thread.
-     * <p>
-     * Register an error handler via {@link #setErrorHandler} in order to handle
-     * any exceptions thrown during startup or execution.
-     */
-    @Override
-    public synchronized void start() {
-        if (zkServerThread == null) {
-            zkServerThread = new Thread(new ServerRunnable(), "ZooKeeper Server Starter");
-            zkServerThread.setDaemon(daemon);
-            zkServerThread.start();
-        }
-    }
-
-    /**
-     * Shutdown the ZooKeeper server.
-     */
-    @Override
-    public synchronized void stop() {
-        if (zkServerThread != null) {
-            // The shutdown method is protected...thus this hack to invoke it.
-            // This will log an exception on shutdown; see
-            // https://issues.apache.org/jira/browse/ZOOKEEPER-1873 for details.
-            try {
-                Method shutdown = ZooKeeperServerMain.class.getDeclaredMethod("shutdown");
-                shutdown.setAccessible(true);
-                shutdown.invoke(zkServer);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-
-            // It is expected that the thread will exit after
-            // the server is shutdown; this will block until
-            // the shutdown is complete.
-            try {
-                zkServerThread.join(5000);
-                zkServerThread = null;
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                logger.warn("Interrupted while waiting for embedded ZooKeeper to exit");
-                // abandoning zk thread
-                zkServerThread = null;
-            }
-        }
-    }
-
-    /**
-     * Stop the server if running and invoke the callback when complete.
-     */
-    @Override
-    public void stop(Runnable callback) {
-        stop();
-        callback.run();
-    }
-
-    /**
-     * Provide an {@link ErrorHandler} to be invoked if an Exception is thrown from the ZooKeeper server thread. If none
-     * is provided, only error-level logging will occur.
-     *
-     * @param errorHandler the {@link ErrorHandler} to be invoked
-     */
-    public void setErrorHandler(ErrorHandler errorHandler) {
-        this.errorHandler = errorHandler;
-    }
-
-    /**
-     * Runnable implementation that starts the ZooKeeper server.
-     */
-    private class ServerRunnable implements Runnable {
-
-        @Override
-        public void run() {
-            try {
-                Properties properties = new Properties();
-                File file = new File(System.getProperty("java.io.tmpdir")
-                        + File.separator + UUID.randomUUID());
-                file.deleteOnExit();
-                properties.setProperty("dataDir", file.getAbsolutePath());
-                properties.setProperty("clientPort", String.valueOf(clientPort));
-
-                QuorumPeerConfig quorumPeerConfig = new QuorumPeerConfig();
-                quorumPeerConfig.parseProperties(properties);
-
-                zkServer = new ZooKeeperServerMain();
-                ServerConfig configuration = new ServerConfig();
-                configuration.readFrom(quorumPeerConfig);
-
-                zkServer.runFromConfig(configuration);
-            } catch (Exception e) {
-                if (errorHandler != null) {
-                    errorHandler.handleError(e);
-                } else {
-                    logger.error("Exception running embedded ZooKeeper", e);
-                }
-            }
-        }
-    }
-
-    /**
-     * Workaround for SocketUtils.findRandomPort() deprecation.
-     *
-     * @param min min port
-     * @param max max port
-     * @return a random generated available port
-     */
-    private static int findRandomPort(int min, int max) {
-        if (min < 1024) {
-            throw new IllegalArgumentException("Max port shouldn't be less than 1024.");
+    public static void main(String[] args) throws Exception {
+        int port = 2181;
+        if (args.length == 1) {
+            port = Integer.parseInt(args[0]);
         }
 
-        if (max > 65535) {
-            throw new IllegalArgumentException("Max port shouldn't be greater than 65535.");
+        Properties properties = new Properties();
+        File file = new File(System.getProperty("java.io.tmpdir")
+                + File.separator + UUID.randomUUID());
+        file.deleteOnExit();
+        properties.setProperty("dataDir", file.getAbsolutePath());
+        properties.setProperty("clientPort", String.valueOf(port));
+
+        QuorumPeerConfig quorumPeerConfig = new QuorumPeerConfig();
+        quorumPeerConfig.parseProperties(properties);
+
+        ZooKeeperServerMain zkServer = new ZooKeeperServerMain();
+        ServerConfig configuration = new ServerConfig();
+        configuration.readFrom(quorumPeerConfig);
+
+        try {
+            zkServer.runFromConfig(configuration);
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.exit(1);
         }
-
-        if (min > max) {
-            throw new IllegalArgumentException("Min port shouldn't be greater than max port.");
-        }
-
-        int port = 0;
-        int counter = 0;
-
-        // Workaround for legacy JDK doesn't support Random.nextInt(min, max).
-        List<Integer> randomInts = RANDOM.ints(min, max + 1)
-                .limit(max - min)
-                .mapToObj(Integer::valueOf)
-                .collect(Collectors.toList());
-
-        do {
-            if (counter > max - min) {
-                throw new IllegalStateException("Unable to find a port between " + min + "-" + max);
-            }
-
-            port = randomInts.get(counter);
-            counter++;
-        } while (NetUtils.isPortInUsed(port));
-
-        return port;
     }
 }


### PR DESCRIPTION
SocketUtils is going to be removed in Spring 6. This PR is intended to replace the invocation of it to the Dubbo one.