### PR TITLE
Replace invocation of deprecated commons-io `toString` method.

### DIFF
--- a/3-extensions/registry/dubbo-samples-nacos/dubbo-samples-nacos-conditionrouter/src/main/java/org/apache/dubbo/samples/governance/util/NacosUtils.java
+++ b/3-extensions/registry/dubbo-samples-nacos/dubbo-samples-nacos-conditionrouter/src/main/java/org/apache/dubbo/samples/governance/util/NacosUtils.java
@@ -23,6 +23,7 @@ import com.alibaba.nacos.api.config.ConfigService;
 import org.apache.commons.io.IOUtils;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 public class NacosUtils {
@@ -41,7 +42,7 @@ public class NacosUtils {
         ConfigService configService = NacosFactory.createConfigService(properties);
 
         try (InputStream is = NacosUtils.class.getClassLoader().getResourceAsStream("dubbo-routers-condition.yml")) {
-            String content = IOUtils.toString(is);
+            String content = IOUtils.toString(is, StandardCharsets.UTF_8);
             if (configService.publishConfig(dataId, group, content)) {
                 System.out.println("write " + dataId + ":" + group + " successfully.");
             }

--- a/3-extensions/registry/dubbo-samples-nacos/dubbo-samples-nacos-override/src/main/java/org/apache/dubbo/samples/governance/util/NacosUtils.java
+++ b/3-extensions/registry/dubbo-samples-nacos/dubbo-samples-nacos-override/src/main/java/org/apache/dubbo/samples/governance/util/NacosUtils.java
@@ -24,6 +24,7 @@ import com.alibaba.nacos.api.exception.NacosException;
 import org.apache.commons.io.IOUtils;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 public class NacosUtils {
@@ -52,7 +53,7 @@ public class NacosUtils {
 
     public static void writeAppRule() throws Throwable {
         try (InputStream is = NacosUtils.class.getClassLoader().getResourceAsStream("dubbo-override.yml")) {
-            String content = IOUtils.toString(is);
+            String content = IOUtils.toString(is, StandardCharsets.UTF_8);
             if (configService.publishConfig(DATAID, GROUP, content)) {
                 System.out.println("write " + DATAID + ":" + GROUP + " successfully.");
             }

--- a/3-extensions/registry/dubbo-samples-nacos/dubbo-samples-nacos-tagrouter/src/main/java/org/apache/dubbo/samples/governance/util/NacosUtils.java
+++ b/3-extensions/registry/dubbo-samples-nacos/dubbo-samples-nacos-tagrouter/src/main/java/org/apache/dubbo/samples/governance/util/NacosUtils.java
@@ -24,6 +24,7 @@ import com.alibaba.nacos.api.exception.NacosException;
 import org.apache.commons.io.IOUtils;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 public class NacosUtils {
@@ -53,7 +54,7 @@ public class NacosUtils {
 
     public static void writeAppRule() throws Throwable {
         try (InputStream is = NacosUtils.class.getClassLoader().getResourceAsStream(YAML)) {
-            String content = IOUtils.toString(is);
+            String content = IOUtils.toString(is, StandardCharsets.UTF_8);
             if (configService.publishConfig(DATAID, GROUP, content)) {
                 System.out.println("write " + DATAID + ":" + GROUP + " successfully.");
             }


### PR DESCRIPTION
The IOUtils.toString(InputStream) is deprecated. This PR replaces it to the toString(InputStream, StandardCharsets.UTF_8) one.