### PR TITLE
Update GitHub Actions version.

### DIFF
--- a/.github/workflows/dubbo-3_1.yml
+++ b/.github/workflows/dubbo-3_1.yml
@@ -44,8 +44,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-samples-maven-
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: 17
       - name: Build with Maven
         run: |
@@ -92,8 +93,9 @@ jobs:
             ${{ runner.os }}-dubbo-${{env.DUBBO_REF}}-maven-
       - name: Set up JDK 8
         if: steps.dubbocache.outputs.cache-hit != 'true'
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: 8
       - name: Build dubbo
         if: steps.dubbocache.outputs.cache-hit != 'true'
@@ -133,8 +135,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{matrix.java}}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: ${{matrix.java}}
       - name: Cache local Maven repository
         uses: actions/cache@v3

--- a/.github/workflows/dubbo-3_1.yml
+++ b/.github/workflows/dubbo-3_1.yml
@@ -35,9 +35,9 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-samples-maven-${{ hashFiles('**/pom.xml') }}
@@ -60,7 +60,7 @@ jobs:
       commit_id: ${{ steps.git-checker.outputs.commit_id }}
       version: ${{ steps.git-checker.outputs.version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: 'apache/dubbo'
           ref: ${{env.DUBBO_REF}}
@@ -78,13 +78,13 @@ jobs:
           echo "commit_id: $commit_id"
       - name: Dubbo cache
         id: dubbocache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository/org/apache/dubbo
           key: ${{ runner.os }}-dubbo-snapshot-${{steps.git-checker.outputs.commit_id}}
       - name: Cache local Maven repository
         if: steps.dubbocache.outputs.cache-hit != 'true'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-dubbo-${{env.DUBBO_REF}}-maven-${{ hashFiles('**/pom.xml') }}
@@ -106,12 +106,12 @@ jobs:
       #'JOB_COUNT' MUST match 'job_id' list of 'testjob'
       JOB_COUNT: 5
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Prepare test list
         run: |
           bash ./test/scripts/prepare-test.sh
       - name: Upload test list
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-list
           path: test/jobs
@@ -131,25 +131,25 @@ jobs:
         #testjob id list MUST match 'JOB_COUNT' of 'prepare_test'
         job_id: [1,2,3,4,5]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Set up JDK ${{matrix.java}}
         uses: actions/setup-java@v1
         with:
           java-version: ${{matrix.java}}
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-samples-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-samples-maven-
       - name: Dubbo cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository/org/apache/dubbo
           key: ${{ runner.os }}-dubbo-snapshot-${{needs.build-dubbo.outputs.commit_id}}
       - name: Download test list
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: test-list
           path: test/jobs/
@@ -165,7 +165,7 @@ jobs:
         run: cd test && bash ./run-tests.sh
       - name: Upload test result
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-result
           path: test/jobs/*-result*
@@ -182,9 +182,9 @@ jobs:
     env:
       JAVA_VER: ${{matrix.java}}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Download test result
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: test-result
           path: test/jobs/

--- a/.github/workflows/dubbo-3_2.yml
+++ b/.github/workflows/dubbo-3_2.yml
@@ -34,9 +34,9 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-samples-maven-${{ hashFiles('**/pom.xml') }}
@@ -59,7 +59,7 @@ jobs:
       commit_id: ${{ steps.git-checker.outputs.commit_id }}
       version: ${{ steps.git-checker.outputs.version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: 'apache/dubbo'
           ref: ${{env.DUBBO_REF}}
@@ -77,13 +77,13 @@ jobs:
           echo "commit_id: $commit_id"
       - name: Dubbo cache
         id: dubbocache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository/org/apache/dubbo
           key: ${{ runner.os }}-dubbo-snapshot-${{steps.git-checker.outputs.commit_id}}
       - name: Cache local Maven repository
         if: steps.dubbocache.outputs.cache-hit != 'true'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-dubbo-${{env.DUBBO_REF}}-maven-${{ hashFiles('**/pom.xml') }}
@@ -105,12 +105,12 @@ jobs:
       #'JOB_COUNT' MUST match 'job_id' list of 'testjob'
       JOB_COUNT: 5
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Prepare test list
         run: |
           bash ./test/scripts/prepare-test.sh
       - name: Upload test list
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-list
           path: test/jobs
@@ -130,25 +130,25 @@ jobs:
         #testjob id list MUST match 'JOB_COUNT' of 'prepare_test'
         job_id: [1,2,3,4,5]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Set up JDK ${{matrix.java}}
         uses: actions/setup-java@v1
         with:
           java-version: ${{matrix.java}}
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-samples-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-samples-maven-
       - name: Dubbo cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository/org/apache/dubbo
           key: ${{ runner.os }}-dubbo-snapshot-${{needs.build-dubbo.outputs.commit_id}}
       - name: Download test list
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: test-list
           path: test/jobs/
@@ -164,7 +164,7 @@ jobs:
         run: cd test && bash ./run-tests.sh
       - name: Upload test result
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-result
           path: test/jobs/*-result*
@@ -181,9 +181,9 @@ jobs:
     env:
       JAVA_VER: ${{matrix.java}}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Download test result
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: test-result
           path: test/jobs/

--- a/.github/workflows/dubbo-3_2.yml
+++ b/.github/workflows/dubbo-3_2.yml
@@ -43,8 +43,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-samples-maven-
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: 17
       - name: Build with Maven
         run: |
@@ -91,8 +92,9 @@ jobs:
             ${{ runner.os }}-dubbo-${{env.DUBBO_REF}}-maven-
       - name: Set up JDK 8
         if: steps.dubbocache.outputs.cache-hit != 'true'
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: 8
       - name: Build dubbo
         if: steps.dubbocache.outputs.cache-hit != 'true'
@@ -132,8 +134,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{matrix.java}}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: ${{matrix.java}}
       - name: Cache local Maven repository
         uses: actions/cache@v3

--- a/.github/workflows/nightly-dubbo-3.yml
+++ b/.github/workflows/nightly-dubbo-3.yml
@@ -47,8 +47,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-samples-maven-
       - name: Set up JDK ${{matrix.java}}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: ${{matrix.java}}
       - name: Build with Maven
         run: |
@@ -95,8 +96,9 @@ jobs:
             ${{ runner.os }}-dubbo-${{env.DUBBO_REF}}-maven-
       - name: Set up JDK 8
         if: steps.dubbocache.outputs.cache-hit != 'true'
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: 8
       - name: Build dubbo
         if: steps.dubbocache.outputs.cache-hit != 'true'
@@ -135,8 +137,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{matrix.java}}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: ${{matrix.java}}
       - name: Cache local Maven repository
         uses: actions/cache@v3

--- a/.github/workflows/nightly-dubbo-3.yml
+++ b/.github/workflows/nightly-dubbo-3.yml
@@ -38,9 +38,9 @@ jobs:
       matrix:
         java: [8, 11]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-samples-maven-${{ hashFiles('**/pom.xml') }}
@@ -63,7 +63,7 @@ jobs:
       commit_id: ${{ steps.git-checker.outputs.commit_id }}
       version: ${{ steps.git-checker.outputs.version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: 'apache/dubbo'
           ref: ${{env.DUBBO_REF}}
@@ -81,13 +81,13 @@ jobs:
           echo "commit_id: $commit_id"
       - name: Dubbo cache
         id: dubbocache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository/org/apache/dubbo
           key: ${{ runner.os }}-dubbo-snapshot-${{steps.git-checker.outputs.commit_id}}
       - name: Cache local Maven repository
         if: steps.dubbocache.outputs.cache-hit != 'true'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-dubbo-${{env.DUBBO_REF}}-maven-${{ hashFiles('**/pom.xml') }}
@@ -109,12 +109,12 @@ jobs:
       #'JOB_COUNT' MUST match 'job_id' list of 'testjob'
       JOB_COUNT: 5
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Prepare test list
         run: |
           bash ./test/scripts/prepare-test.sh
       - name: Upload test list
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-list
           path: test/jobs
@@ -133,25 +133,25 @@ jobs:
         #testjob id list MUST match 'JOB_COUNT' of 'prepare_test'
         job_id: [1,2,3,4,5]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Set up JDK ${{matrix.java}}
         uses: actions/setup-java@v1
         with:
           java-version: ${{matrix.java}}
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-samples-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-samples-maven-
       - name: Dubbo cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository/org/apache/dubbo
           key: ${{ runner.os }}-dubbo-snapshot-${{needs.build-dubbo.outputs.commit_id}}
       - name: Download test list
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: test-list
           path: test/jobs/
@@ -167,7 +167,7 @@ jobs:
         run: cd test && bash ./run-tests.sh
       - name: Upload test result
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-result
           path: test/jobs/*-result*
@@ -184,9 +184,9 @@ jobs:
     env:
       JAVA_VER: ${{matrix.java}}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Download test result
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: test-result
           path: test/jobs/


### PR DESCRIPTION
## What is the purpose of the change
Since Node.js 12.x has been out of support <sup>[1]</sup>, it's recommended for us to upgrade all GitHub Actions to the version that uses Node.js 16.x.

[1] https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/


## Brief changelog
Update some actions versions in workflow files.