### PR TITLE
chore: update observability starter

### DIFF
--- a/4-governance/dubbo-samples-metrics-prometheus/pom.xml
+++ b/4-governance/dubbo-samples-metrics-prometheus/pom.xml
@@ -97,7 +97,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>
-            <artifactId>dubbo-spring-boot-observability-otel-zipkin-starter</artifactId>
+            <artifactId>dubbo-spring-boot-tracing-otel-zipkin-starter</artifactId>
         </dependency>
 
         <dependency>

--- a/4-governance/dubbo-samples-metrics-prometheus/pom.xml
+++ b/4-governance/dubbo-samples-metrics-prometheus/pom.xml
@@ -97,7 +97,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>
-            <artifactId>dubbo-spring-boot-tracing-otel-zipkin-starter</artifactId>
+            <artifactId>dubbo-spring-boot-observability-starter</artifactId>
         </dependency>
 
         <dependency>

--- a/4-governance/dubbo-samples-metrics-prometheus/pom.xml
+++ b/4-governance/dubbo-samples-metrics-prometheus/pom.xml
@@ -97,7 +97,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>
-            <artifactId>dubbo-spring-boot-observability-starter</artifactId>
+            <artifactId>dubbo-spring-boot-observability-otel-zipkin-starter</artifactId>
         </dependency>
 
         <dependency>

--- a/4-governance/dubbo-samples-spring-boot-tracing/README.md
+++ b/4-governance/dubbo-samples-spring-boot-tracing/README.md
@@ -41,55 +41,30 @@ Open [http://localhost:9411/zipkin/](http://localhost:9411/zipkin/) in browser.
 
 ### 1. Adding `dubbo-spring-boot-observability-starter` To Your Project
 
-For the Springboot project, you can use `dubbo-spring-boot-observability-starter` to easily have observability:
+For the Springboot project, you can use `dubbo-spring-boot-observability-starter` to easily have observability, Dubbo
+provides two types of starters at present, select one to add to pom:
 
 ```xml
 
-<!-- Dubbo-Observability-starter -->
+<!-- Opentelemetry as Tracer, Zipkin as exporter -->
 <dependency>
     <groupId>org.apache.dubbo</groupId>
-    <artifactId>dubbo-spring-boot-observability-starter</artifactId>
+    <artifactId>dubbo-spring-boot-observability-otel-zipkin-starter</artifactId>
 </dependency>
 ```
-
-### 2. Adding Micrometer Tracing Bridge To Your Project
-
-In order to start creating spans for Dubbo based projects a `bridge` between Micrometer Tracing and an actual Tracer is
-required.
-
-> NOTE: Tracer is a library that handles lifecycle of spans (e.g. it can create, start, stop, sample, report spans).
-
-Micrometer Tracing supports [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-java)
-and [Brave](https://github.com/openzipkin/brave) as Tracers as shown below:
 
 ```xml
 
-<!-- OpenTelemetry Tracer -->
+<!-- Brave as Tracer, Zipkin as exporter -->
 <dependency>
-    <groupId>io.micrometer</groupId>
-    <artifactId>micrometer-tracing-bridge-otel</artifactId>
+    <groupId>org.apache.dubbo</groupId>
+    <artifactId>dubbo-spring-boot-observability-brave-zipkin-starter</artifactId>
 </dependency>
 ```
 
-### 3. Adding Micrometer Tracing Exporter To Your Project
+Dubbo will support more in the future, such as skywalking, Jagger.
 
-After having added the Tracer, an exporter (also known as a reporter) is required. It's a component that will export the
-finished span and send it to a reporting system.
-
-zipkin as exporter with OpenTelemetry:
-
-```xml
-
-<!-- Exporter-Zipkin -->
-<dependency>
-    <groupId>io.opentelemetry</groupId>
-    <artifactId>opentelemetry-exporter-zipkin</artifactId>
-</dependency>
-```
-
-You can read more about tracing setup [this documentation, under docs/tracing](https://micrometer.io/).
-
-### 4. Configuration Tracing
+### 2. Configuration Tracing
 
 #### application.yml:
 
@@ -113,7 +88,7 @@ logging:
     level: '%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]'
 ```
 
-### 5. Customizing Observation Filters
+### 3. Customizing Observation Filters
 
 To customize the tags present in metrics (low cardinality tags) and in spans (low and high cardinality tags) you should
 create your own versions of `DubboServerObservationConvention` (server side) and `DubboClientObservationConvention` (
@@ -122,38 +97,6 @@ check `DefaultDubboServerObservationConvention` (server side) and `DefaultDubboC
 side).
 
 ## Extension
-
-### Other Micrometer Tracing Bridge
-
-```xml
-<!-- Brave Tracer -->
-<dependency>
-    <groupId>io.micrometer</groupId>
-    <artifactId>micrometer-tracing-bridge-brave</artifactId>
-</dependency>
-```
-
-### Other Micrometer Tracing Exporter
-
-Tanzu Observability by Wavefront
-
-```xml
-
-<dependency>
-    <groupId>io.micrometer</groupId>
-    <artifactId>micrometer-tracing-reporter-wavefront</artifactId>
-</dependency>
-```
-
-OpenZipkin Zipkin with Brave
-
-```xml
-
-<dependency>
-    <groupId>io.zipkin.reporter2</groupId>
-    <artifactId>zipkin-reporter-brave</artifactId>
-</dependency>
-```
 
 An OpenZipkin URL sender dependency to send out spans to Zipkin via a URLConnectionSender
 

--- a/4-governance/dubbo-samples-spring-boot-tracing/README.md
+++ b/4-governance/dubbo-samples-spring-boot-tracing/README.md
@@ -49,7 +49,7 @@ provides two types of starters at present, select one to add to pom:
 <!-- Opentelemetry as Tracer, Zipkin as exporter -->
 <dependency>
     <groupId>org.apache.dubbo</groupId>
-    <artifactId>dubbo-spring-boot-observability-otel-zipkin-starter</artifactId>
+    <artifactId>dubbo-spring-boot-tracing-otel-zipkin-starter</artifactId>
 </dependency>
 ```
 
@@ -58,7 +58,7 @@ provides two types of starters at present, select one to add to pom:
 <!-- Brave as Tracer, Zipkin as exporter -->
 <dependency>
     <groupId>org.apache.dubbo</groupId>
-    <artifactId>dubbo-spring-boot-observability-brave-zipkin-starter</artifactId>
+    <artifactId>dubbo-spring-boot-tracing-brave-zipkin-starter</artifactId>
 </dependency>
 ```
 

--- a/4-governance/dubbo-samples-spring-boot-tracing/dubbo-samples-spring-boot-tracing-consumer/pom.xml
+++ b/4-governance/dubbo-samples-spring-boot-tracing/dubbo-samples-spring-boot-tracing-consumer/pom.xml
@@ -58,7 +58,7 @@
 
         <dependency>
             <groupId>org.apache.dubbo</groupId>
-            <artifactId>dubbo-spring-boot-observability-otel-zipkin-starter</artifactId>
+            <artifactId>dubbo-spring-boot-tracing-otel-zipkin-starter</artifactId>
         </dependency>
     </dependencies>
 

--- a/4-governance/dubbo-samples-spring-boot-tracing/dubbo-samples-spring-boot-tracing-consumer/pom.xml
+++ b/4-governance/dubbo-samples-spring-boot-tracing/dubbo-samples-spring-boot-tracing-consumer/pom.xml
@@ -56,20 +56,9 @@
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
 
-        <!-- OpenTelemetry Tracer -->
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-tracing-bridge-otel</artifactId>
-        </dependency>
-        <!-- Dubbo-Observability-starter -->
         <dependency>
             <groupId>org.apache.dubbo</groupId>
-            <artifactId>dubbo-spring-boot-observability-starter</artifactId>
-        </dependency>
-        <!-- Exporter-Zipkin -->
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-zipkin</artifactId>
+            <artifactId>dubbo-spring-boot-observability-otel-zipkin-starter</artifactId>
         </dependency>
     </dependencies>
 

--- a/4-governance/dubbo-samples-spring-boot-tracing/dubbo-samples-spring-boot-tracing-provider/pom.xml
+++ b/4-governance/dubbo-samples-spring-boot-tracing/dubbo-samples-spring-boot-tracing-provider/pom.xml
@@ -57,20 +57,9 @@
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
 
-        <!-- OpenTelemetry Tracer -->
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-tracing-bridge-otel</artifactId>
-        </dependency>
-        <!-- Dubbo-Observability-starter -->
         <dependency>
             <groupId>org.apache.dubbo</groupId>
-            <artifactId>dubbo-spring-boot-observability-starter</artifactId>
-        </dependency>
-        <!-- Exporter-Zipkin -->
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-zipkin</artifactId>
+            <artifactId>dubbo-spring-boot-observability-otel-zipkin-starter</artifactId>
         </dependency>
     </dependencies>
 

--- a/4-governance/dubbo-samples-spring-boot-tracing/dubbo-samples-spring-boot-tracing-provider/pom.xml
+++ b/4-governance/dubbo-samples-spring-boot-tracing/dubbo-samples-spring-boot-tracing-provider/pom.xml
@@ -59,7 +59,7 @@
 
         <dependency>
             <groupId>org.apache.dubbo</groupId>
-            <artifactId>dubbo-spring-boot-observability-otel-zipkin-starter</artifactId>
+            <artifactId>dubbo-spring-boot-tracing-otel-zipkin-starter</artifactId>
         </dependency>
     </dependencies>
 

--- a/4-governance/dubbo-samples-spring-boot-tracing/pom.xml
+++ b/4-governance/dubbo-samples-spring-boot-tracing/pom.xml
@@ -45,7 +45,7 @@
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dubbo.version>3.2.0-beta.7-SNAPSHOT</dubbo.version>
+        <dubbo.version>3.2.1-SNAPSHOT</dubbo.version>
         <micrometer.version>1.10.5</micrometer.version>
         <micrometer-tracing.version>1.0.3</micrometer-tracing.version>
         <opentelemetry.version>1.19.0</opentelemetry.version>

--- a/4-governance/dubbo-samples-spring-boot3-tracing/README.md
+++ b/4-governance/dubbo-samples-spring-boot3-tracing/README.md
@@ -53,7 +53,7 @@ provides two types of starters at present, select one to add to pom:
 <!-- Opentelemetry as Tracer, Zipkin as exporter -->
 <dependency>
     <groupId>org.apache.dubbo</groupId>
-    <artifactId>dubbo-spring-boot-observability-otel-zipkin-starter</artifactId>
+    <artifactId>dubbo-spring-boot-tracing-otel-zipkin-starter</artifactId>
 </dependency>
 ```
 
@@ -62,7 +62,7 @@ provides two types of starters at present, select one to add to pom:
 <!-- Brave as Tracer, Zipkin as exporter -->
 <dependency>
     <groupId>org.apache.dubbo</groupId>
-    <artifactId>dubbo-spring-boot-observability-brave-zipkin-starter</artifactId>
+    <artifactId>dubbo-spring-boot-tracing-brave-zipkin-starter</artifactId>
 </dependency>
 ```
 

--- a/4-governance/dubbo-samples-spring-boot3-tracing/README.md
+++ b/4-governance/dubbo-samples-spring-boot3-tracing/README.md
@@ -45,53 +45,30 @@ Open [http://localhost:9411/zipkin/](http://localhost:9411/zipkin/) in browser.
 
 ### 1. Adding `dubbo-spring-boot-observability-starter` To Your Project
 
-For the Springboot project, you can use `dubbo-spring-boot-observability-starter` to easily have observability:
+For the Springboot project, you can use `dubbo-spring-boot-observability-starter` to easily have observability, Dubbo
+provides two types of starters at present, select one to add to pom:
 
 ```xml
 
+<!-- Opentelemetry as Tracer, Zipkin as exporter -->
 <dependency>
     <groupId>org.apache.dubbo</groupId>
-    <artifactId>dubbo-spring-boot-observability-starter</artifactId>
+    <artifactId>dubbo-spring-boot-observability-otel-zipkin-starter</artifactId>
 </dependency>
 ```
-
-### 2. Adding Micrometer Tracing Bridge To Your Project
-
-In order to start creating spans for Dubbo based projects a `bridge` between Micrometer Tracing and an actual Tracer is
-required.
-
-> NOTE: Tracer is a library that handles lifecycle of spans (e.g. it can create, start, stop, sample, report spans).
-
-Micrometer Tracing supports  [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-java)
-and [Brave](https://github.com/openzipkin/brave) as Tracers. Dubbo recommends using OpenTelemetry as the protocol of
-tracing, you can add dependency as shown below:
-
-```xml
-<!-- OpenTelemetry Tracer -->
-<dependency>
-    <groupId>io.micrometer</groupId>
-    <artifactId>micrometer-tracing-bridge-otel</artifactId>
-</dependency>
-```
-
-### 3. Adding Micrometer Tracing Exporter To Your Project
-
-After having added the Tracer, an exporter (also known as a reporter) is required. It's a component that will export the
-finished span and send it to a reporting system.
-
-zipkin as exporter with OpenTelemetry:
 
 ```xml
 
+<!-- Brave as Tracer, Zipkin as exporter -->
 <dependency>
-    <groupId>io.opentelemetry</groupId>
-    <artifactId>opentelemetry-exporter-zipkin</artifactId>
+    <groupId>org.apache.dubbo</groupId>
+    <artifactId>dubbo-spring-boot-observability-brave-zipkin-starter</artifactId>
 </dependency>
 ```
 
-You can read more about tracing setup [this documentation, under docs/tracing](https://micrometer.io/).
+Dubbo will support more in the future, such as skywalking, Jagger.
 
-### 4. Configuration Tracing
+### 2. Configuration Tracing
 
 #### application.yml:
 
@@ -115,7 +92,7 @@ logging:
     level: '%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]'
 ```
 
-### 5. Customizing Observation Filters
+### 3. Customizing Observation Filters
 
 To customize the tags present in metrics (low cardinality tags) and in spans (low and high cardinality tags) you should
 create your own versions of `DubboServerObservationConvention` (server side) and `DubboClientObservationConvention` (
@@ -124,38 +101,6 @@ check `DefaultDubboServerObservationConvention` (server side) and `DefaultDubboC
 side).
 
 ## Extension
-
-### Other Micrometer Tracing Bridge
-
-```xml
-<!-- Brave Tracer -->
-<dependency>
-    <groupId>io.micrometer</groupId>
-    <artifactId>micrometer-tracing-bridge-brave</artifactId>
-</dependency>
-```
-
-### Other Micrometer Tracing Exporter
-
-Tanzu Observability by Wavefront
-
-```xml
-
-<dependency>
-    <groupId>io.micrometer</groupId>
-    <artifactId>micrometer-tracing-reporter-wavefront</artifactId>
-</dependency>
-```
-
-OpenZipkin Zipkin with Brave
-
-```xml
-
-<dependency>
-    <groupId>io.zipkin.reporter2</groupId>
-    <artifactId>zipkin-reporter-brave</artifactId>
-</dependency>
-```
 
 An OpenZipkin URL sender dependency to send out spans to Zipkin via a URLConnectionSender
 

--- a/4-governance/dubbo-samples-spring-boot3-tracing/dubbo-samples-spring-boot3-tracing-consumer/pom.xml
+++ b/4-governance/dubbo-samples-spring-boot3-tracing/dubbo-samples-spring-boot3-tracing-consumer/pom.xml
@@ -57,7 +57,7 @@
         <!-- Observability -->
         <dependency>
             <groupId>org.apache.dubbo</groupId>
-            <artifactId>dubbo-spring-boot-observability-otel-zipkin-starter</artifactId>
+            <artifactId>dubbo-spring-boot-tracing-otel-zipkin-starter</artifactId>
         </dependency>
     </dependencies>
 

--- a/4-governance/dubbo-samples-spring-boot3-tracing/dubbo-samples-spring-boot3-tracing-consumer/pom.xml
+++ b/4-governance/dubbo-samples-spring-boot3-tracing/dubbo-samples-spring-boot3-tracing-consumer/pom.xml
@@ -54,20 +54,10 @@
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
 
-        <!-- Observability-OpenTelemetry -->
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-tracing-bridge-otel</artifactId>
-        </dependency>
-        <!-- Dubbo-Observability-starter -->
+        <!-- Observability -->
         <dependency>
             <groupId>org.apache.dubbo</groupId>
-            <artifactId>dubbo-spring-boot-observability-starter</artifactId>
-        </dependency>
-        <!-- Exporter-Zipkin -->
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-zipkin</artifactId>
+            <artifactId>dubbo-spring-boot-observability-otel-zipkin-starter</artifactId>
         </dependency>
     </dependencies>
 

--- a/4-governance/dubbo-samples-spring-boot3-tracing/dubbo-samples-spring-boot3-tracing-provider/pom.xml
+++ b/4-governance/dubbo-samples-spring-boot3-tracing/dubbo-samples-spring-boot3-tracing-provider/pom.xml
@@ -52,20 +52,10 @@
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
 
-        <!-- Observability-OpenTelemetry -->
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-tracing-bridge-otel</artifactId>
-        </dependency>
-        <!-- Dubbo-Observability-starter -->
+        <!-- Observability -->
         <dependency>
             <groupId>org.apache.dubbo</groupId>
-            <artifactId>dubbo-spring-boot-observability-starter</artifactId>
-        </dependency>
-        <!-- Exporter-Zipkin -->
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-zipkin</artifactId>
+            <artifactId>dubbo-spring-boot-observability-otel-zipkin-starter</artifactId>
         </dependency>
     </dependencies>
 

--- a/4-governance/dubbo-samples-spring-boot3-tracing/dubbo-samples-spring-boot3-tracing-provider/pom.xml
+++ b/4-governance/dubbo-samples-spring-boot3-tracing/dubbo-samples-spring-boot3-tracing-provider/pom.xml
@@ -55,7 +55,7 @@
         <!-- Observability -->
         <dependency>
             <groupId>org.apache.dubbo</groupId>
-            <artifactId>dubbo-spring-boot-observability-otel-zipkin-starter</artifactId>
+            <artifactId>dubbo-spring-boot-tracing-otel-zipkin-starter</artifactId>
         </dependency>
     </dependencies>
 

--- a/4-governance/dubbo-samples-spring-boot3-tracing/pom.xml
+++ b/4-governance/dubbo-samples-spring-boot3-tracing/pom.xml
@@ -46,7 +46,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>17</java.version>
-        <dubbo.version>3.2.0-beta.7-SNAPSHOT</dubbo.version>
+        <dubbo.version>3.2.1-SNAPSHOT</dubbo.version>
         <nacos.version>2.2.0</nacos.version>
         <micrometer.version>1.10.5</micrometer.version>
         <micrometer-tracing.version>1.0.3</micrometer-tracing.version>


### PR DESCRIPTION
Due to the addition of two starters in Dubbo 3.2, the sample also needs to be changed.

- dubbo-spring-boot-observability-otel-zipkin-starter
- dubbo-spring-boot-observability-brave-zipkin-starter