### PR TITLE
Change the wrong version of dubbo from 3.2.1-SNAPSHOT to 3.2.1.

### DIFF
--- a/4-governance/dubbo-samples-spring-boot3-tracing/pom.xml
+++ b/4-governance/dubbo-samples-spring-boot3-tracing/pom.xml
@@ -46,7 +46,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>17</java.version>
-        <dubbo.version>3.2.1-SNAPSHOT</dubbo.version>
+        <dubbo.version>3.2.1</dubbo.version>
         <nacos.version>2.2.0</nacos.version>
         <micrometer.version>1.10.5</micrometer.version>
         <micrometer-tracing.version>1.0.3</micrometer-tracing.version>


### PR DESCRIPTION
Wrong version 3.2.1-SNAPSHOT will cause the following error when resolving the dependency:

```bash
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]   
[ERROR]   The project org.apache.dubbo:dubbo-samples-spring-boot3-tracing:1.0-SNAPSHOT (/home/gabriel/dubbo-samples/4-governance/dubbo-samples-spring-boot3-tracing/pom.xml) has 1 error
[ERROR]     Non-resolvable import POM: org.apache.dubbo:dubbo-bom:pom:3.2.1-SNAPSHOT was not found in https://repository.apache.org/snapshots during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of apache.snapshots has elapsed or updates are forced @ line 95, column 25 -> [Help 2]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
[ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/UnresolvableModelException
```