### PR TITLE
chore: update dubbo version to 3.3.0-beta.1 in tracing demo

### DIFF
--- a/4-governance/dubbo-samples-tracing/dubbo-sample-api-tracing-otel-zipkin/pom.xml
+++ b/4-governance/dubbo-samples-tracing/dubbo-sample-api-tracing-otel-zipkin/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -25,7 +26,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dubbo-sample-api-tracing-otel-zipkin</artifactId>
-    <version>1.0-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/4-governance/dubbo-samples-tracing/dubbo-samples-spring-boot-tracing-otel-otlp/consumer/pom.xml
+++ b/4-governance/dubbo-samples-tracing/dubbo-samples-spring-boot-tracing-otel-otlp/consumer/pom.xml
@@ -59,7 +59,7 @@
 
         <dependency>
             <groupId>org.apache.dubbo</groupId>
-            <artifactId>dubbo-spring-boot-tracing-otel-otlp-starter</artifactId>
+            <artifactId>dubbo-tracing-otel-zipkin-spring-boot-starter</artifactId>
         </dependency>
     </dependencies>
 

--- a/4-governance/dubbo-samples-tracing/dubbo-samples-spring-boot-tracing-otel-otlp/provider/pom.xml
+++ b/4-governance/dubbo-samples-tracing/dubbo-samples-spring-boot-tracing-otel-otlp/provider/pom.xml
@@ -60,7 +60,7 @@
 
         <dependency>
             <groupId>org.apache.dubbo</groupId>
-            <artifactId>dubbo-spring-boot-tracing-otel-otlp-starter</artifactId>
+            <artifactId>dubbo-tracing-otel-zipkin-spring-boot-starter</artifactId>
         </dependency>
 
         <!-- Embedded Zookeeper Server Dependencies -->

--- a/4-governance/dubbo-samples-tracing/dubbo-samples-spring-boot-tracing-zipkin/consumer/pom.xml
+++ b/4-governance/dubbo-samples-tracing/dubbo-samples-spring-boot-tracing-zipkin/consumer/pom.xml
@@ -59,7 +59,7 @@
 
         <dependency>
             <groupId>org.apache.dubbo</groupId>
-            <artifactId>dubbo-spring-boot-tracing-otel-zipkin-starter</artifactId>
+            <artifactId>dubbo-tracing-otel-zipkin-spring-boot-starter</artifactId>
         </dependency>
     </dependencies>
 

--- a/4-governance/dubbo-samples-tracing/dubbo-samples-spring-boot-tracing-zipkin/provider/pom.xml
+++ b/4-governance/dubbo-samples-tracing/dubbo-samples-spring-boot-tracing-zipkin/provider/pom.xml
@@ -60,7 +60,7 @@
 
         <dependency>
             <groupId>org.apache.dubbo</groupId>
-            <artifactId>dubbo-spring-boot-tracing-otel-zipkin-starter</artifactId>
+            <artifactId>dubbo-tracing-otel-zipkin-spring-boot-starter</artifactId>
         </dependency>
 
         <!-- Embedded Zookeeper Server Dependencies -->

--- a/4-governance/dubbo-samples-tracing/pom.xml
+++ b/4-governance/dubbo-samples-tracing/pom.xml
@@ -36,6 +36,7 @@
     <description>Dubbo Samples Tracing</description>
 
     <modules>
+        <module>dubbo-sample-api-tracing-otel-zipkin</module>
         <module>dubbo-samples-spring-boot-tracing-zipkin</module>
         <module>dubbo-samples-spring-boot-tracing-otel-otlp</module>
     </modules>
@@ -45,7 +46,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.0-beta.1</dubbo.version>
         <spring-boot.version>2.7.8</spring-boot.version>
         <micrometer.version>1.10.6</micrometer.version>
         <micrometer-tracing.version>1.0.5</micrometer-tracing.version>


### PR DESCRIPTION
merge after releasing dubbo 3.3.0-beta.1

