### PR TITLE
feat: bump spring boot(3.1.2) in 11-quickstart example module

### DIFF
--- a/11-quickstart/HELP.md
+++ b/11-quickstart/HELP.md
@@ -9,4 +9,3 @@ For further reference, please consider the following sections:
 * [Dubbo Zookeeper registry configuration reference](https://dubbo.apache.org/zh-cn/overview/mannual/java-sdk/reference-manual/registry/zookeeper/)
 * [Dubbo triple protocol reference](https://dubbo.apache.org/zh-cn/overview/mannual/java-sdk/reference-manual/protocol/triple/)
 * [Dubbo Zookeeper registry configuration reference](https://docs.spring.io/spring-boot/docs/3.1.2/reference/htmlsingle/#web.servlet.spring-mvc.template-engines)
-

--- a/11-quickstart/pom.xml
+++ b/11-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <dubbo.version>3.3.0-beta.1</dubbo.version>
-        <spring-boot.version>3.1.2</spring-boot.version>
+        <spring-boot.version>3.2.3</spring-boot.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Bump spring boot 3.1.2 in `11-quickstart` example.