### PR TITLE
Lower version

### DIFF
--- a/3-extensions/protocol/dubbo-samples-rest/case-versions.conf
+++ b/3-extensions/protocol/dubbo-samples-rest/case-versions.conf
@@ -20,6 +20,6 @@
 # Supported component versions of the test case
 
 # Spring app
-dubbo.version=2.7*, 3.*
+dubbo.version=[ 2.7*, <= 3.3.0 ]
 spring.version=4.*, 5.*
 java.version= [>= 8]


### PR DESCRIPTION
Since the dubbo module is to remove rest to spi-extensions, the ci of dubbo-samples cannot pass, and version reduction is carried out here
ci error details here https://github.com/apache/dubbo/pull/14084
task details here https://github.com/apache/dubbo/issues/13958