### PR TITLE
Unified logging framework

### DIFF
--- a/2-advanced/dubbo-samples-callback/dubbo-samples-callback-consumer/pom.xml
+++ b/2-advanced/dubbo-samples-callback/dubbo-samples-callback-consumer/pom.xml
@@ -35,12 +35,12 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-spring-boot-starter</artifactId>
-            <version>3.3.0-beta.1</version>
+            <version>${dubbo.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-zookeeper-curator5-spring-boot-starter</artifactId>
-            <version>3.3.0-beta.1</version>
+            <version>${dubbo.version}</version>
         </dependency>
 
         <!-- spring starter -->
@@ -53,6 +53,11 @@
                     <groupId>org.springframework.boot</groupId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-log4j2</artifactId>
         </dependency>
 
         <dependency>

--- a/2-advanced/dubbo-samples-callback/dubbo-samples-callback-provider/pom.xml
+++ b/2-advanced/dubbo-samples-callback/dubbo-samples-callback-provider/pom.xml
@@ -36,12 +36,12 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-spring-boot-starter</artifactId>
-            <version>3.3.0-beta.1</version>
+            <version>${dubbo.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-zookeeper-curator5-spring-boot-starter</artifactId>
-            <version>3.3.0-beta.1</version>
+            <version>${dubbo.version}</version>
         </dependency>
 
         <!-- spring starter -->
@@ -54,6 +54,11 @@
                     <groupId>org.springframework.boot</groupId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-log4j2</artifactId>
         </dependency>
 
         <!-- Embedded Zookeeper Server Dependencies -->

--- a/2-advanced/dubbo-samples-callback/pom.xml
+++ b/2-advanced/dubbo-samples-callback/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.3.0-beta.1</dubbo.version>
+        <dubbo.version>3.3.0-beta.2</dubbo.version>
         <spring-boot.version>3.2.3</spring-boot.version>
         <junit.version>4.13.1</junit.version>
     </properties>

--- a/2-advanced/dubbo-samples-environment-keys/dubbo-samples-environment-keys-consumer/pom.xml
+++ b/2-advanced/dubbo-samples-environment-keys/dubbo-samples-environment-keys-consumer/pom.xml
@@ -48,6 +48,11 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-log4j2</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/2-advanced/dubbo-samples-environment-keys/dubbo-samples-environment-keys-provider/pom.xml
+++ b/2-advanced/dubbo-samples-environment-keys/dubbo-samples-environment-keys-provider/pom.xml
@@ -46,6 +46,10 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-log4j2</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/2-advanced/dubbo-samples-environment-keys/pom.xml
+++ b/2-advanced/dubbo-samples-environment-keys/pom.xml
@@ -33,7 +33,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.3.0-beta.1</dubbo.version>
+        <dubbo.version>3.3.0-beta.2</dubbo.version>
         <spring-boot.version>3.2.3</spring-boot.version>
         <junit5.version>5.10.1</junit5.version>
         <junit.platform>1.9.3</junit.platform>

--- a/2-advanced/dubbo-samples-triple-rest/pom.xml
+++ b/2-advanced/dubbo-samples-triple-rest/pom.xml
@@ -40,7 +40,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.3.0-beta.2-SNAPSHOT</dubbo.version>
+        <dubbo.version>3.3.0-beta.2</dubbo.version>
         <spring-boot.version>3.2.3</spring-boot.version>
         <spring.version>6.1.5</spring.version>
     </properties>

--- a/3-extensions/protocol/dubbo-samples-triple/case-versions.conf
+++ b/3-extensions/protocol/dubbo-samples-triple/case-versions.conf
@@ -19,7 +19,7 @@
 # Supported component versions of the test case
 
 # Spring app
-dubbo.version=[ >=3.1.0 ]
+dubbo.version=[ >=3.1.0, < 3.3.0 ]
 spring.version=4.*, 5.*
 java.version= [>= 8]
 compiler.version=0.0.*, 3.*


### PR DESCRIPTION
Previously, the `dubbo-samples-environment-keys` and `dubbo-samples-callback` modules utilized the SLF4J logging framework in conjunction with Logback. The inclusion of Logback was propagated through the `dubbo-zookeeper-curator5-spring-boot-starter` dependency. 

This setup resulted in an inconsistency with the project's logging framework. Furthermore, with recent updates to the related dependencies, the SLF4J provider was no longer being passed down to the project, leading to a missing logging implementation.

To address these issues, this PR includes the following modifications:

Update dubbo version to 3.3.0-beta.2 (this version of `dubbo-zookeeper-curator5-spring-boot-starter` does not introduce the logging implementation)
Introduce Log4j2 dependency `spring-boot-starter-log4j2`