### PR TITLE
fix dubbo ci

### DIFF
--- a/1-basic/dubbo-samples-native-image/pom.xml
+++ b/1-basic/dubbo-samples-native-image/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <dubbo.version>3.3.0-beta.1-SNAPSHOT</dubbo.version>
+        <dubbo.version>3.3.0-beta.1</dubbo.version>
         <spring-boot.version>3.0.5</spring-boot.version>
         <spring-boot-maven-plugin.version>3.0.5</spring-boot-maven-plugin.version>
         <native-maven-plugin.version>0.9.23</native-maven-plugin.version>

--- a/1-basic/dubbo-samples-native-image/pom.xml
+++ b/1-basic/dubbo-samples-native-image/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <dubbo.version>3.3.0-beta.1-SNAPSHOT</dubbo.version>
+        <dubbo.version>3.3.0-beta.2-release</dubbo.version>
         <spring-boot.version>3.0.5</spring-boot.version>
         <spring-boot-maven-plugin.version>3.0.5</spring-boot-maven-plugin.version>
         <native-maven-plugin.version>0.9.23</native-maven-plugin.version>

--- a/1-basic/dubbo-samples-native-image/pom.xml
+++ b/1-basic/dubbo-samples-native-image/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <dubbo.version>3.3.0-beta.2-release</dubbo.version>
+        <dubbo.version>3.3.0-beta.1-SNAPSHOT</dubbo.version>
         <spring-boot.version>3.0.5</spring-boot.version>
         <spring-boot-maven-plugin.version>3.0.5</spring-boot-maven-plugin.version>
         <native-maven-plugin.version>0.9.23</native-maven-plugin.version>

--- a/2-advanced/dubbo-samples-springcloud/dubbo-call-sc/pom.xml
+++ b/2-advanced/dubbo-samples-springcloud/dubbo-call-sc/pom.xml
@@ -38,7 +38,7 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
-        <dubbo.version>3.3.0-beta.1-SNAPSHOT</dubbo.version>
+        <dubbo.version>3.3.0-beta.2-release</dubbo.version>
         <junit.version>4.13.1</junit.version>
         <spring-boot.version>2.7.8</spring-boot.version>
         <spring.cloud.version>2021.0.5</spring.cloud.version>

--- a/2-advanced/dubbo-samples-springcloud/dubbo-call-sc/pom.xml
+++ b/2-advanced/dubbo-samples-springcloud/dubbo-call-sc/pom.xml
@@ -38,7 +38,7 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
-        <dubbo.version>3.3.0-beta.1-SNAPSHOT</dubbo.version>
+        <dubbo.version>3.3.0-beta.1</dubbo.version>
         <junit.version>4.13.1</junit.version>
         <spring-boot.version>2.7.8</spring-boot.version>
         <spring.cloud.version>2021.0.5</spring.cloud.version>

--- a/2-advanced/dubbo-samples-springcloud/dubbo-call-sc/pom.xml
+++ b/2-advanced/dubbo-samples-springcloud/dubbo-call-sc/pom.xml
@@ -38,7 +38,7 @@
         <source.level>1.8</source.level>
         <target.level>1.8</target.level>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
-        <dubbo.version>3.3.0-beta.2-release</dubbo.version>
+        <dubbo.version>3.3.0-beta.1-SNAPSHOT</dubbo.version>
         <junit.version>4.13.1</junit.version>
         <spring-boot.version>2.7.8</spring-boot.version>
         <spring.cloud.version>2021.0.5</spring.cloud.version>

--- a/2-advanced/dubbo-samples-springcloud/sc-call-dubbo/pom.xml
+++ b/2-advanced/dubbo-samples-springcloud/sc-call-dubbo/pom.xml
@@ -40,7 +40,7 @@
         <target.level>1.8</target.level>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
         <junit.version>4.13.1</junit.version>
-        <dubbo.version>3.3.0-beta.1-SNAPSHOT</dubbo.version>
+        <dubbo.version>3.3.0-beta.1</dubbo.version>
         <spring-boot.version>2.7.8</spring-boot.version>
         <spring.cloud.version>2021.0.5</spring.cloud.version>
         <spring.cloud.alibaba.version>2021.0.5.0</spring.cloud.alibaba.version>

--- a/2-advanced/dubbo-samples-springcloud/sc-call-dubbo/pom.xml
+++ b/2-advanced/dubbo-samples-springcloud/sc-call-dubbo/pom.xml
@@ -40,7 +40,7 @@
         <target.level>1.8</target.level>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
         <junit.version>4.13.1</junit.version>
-        <dubbo.version>3.3.0-beta.1-SNAPSHOT</dubbo.version>
+        <dubbo.version>3.3.0-beta.2-release</dubbo.version>
         <spring-boot.version>2.7.8</spring-boot.version>
         <spring.cloud.version>2021.0.5</spring.cloud.version>
         <spring.cloud.alibaba.version>2021.0.5.0</spring.cloud.alibaba.version>

--- a/2-advanced/dubbo-samples-springcloud/sc-call-dubbo/pom.xml
+++ b/2-advanced/dubbo-samples-springcloud/sc-call-dubbo/pom.xml
@@ -40,7 +40,7 @@
         <target.level>1.8</target.level>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
         <junit.version>4.13.1</junit.version>
-        <dubbo.version>3.3.0-beta.2-release</dubbo.version>
+        <dubbo.version>3.3.0-beta.1-SNAPSHOT</dubbo.version>
         <spring-boot.version>2.7.8</spring-boot.version>
         <spring.cloud.version>2021.0.5</spring.cloud.version>
         <spring.cloud.alibaba.version>2021.0.5.0</spring.cloud.alibaba.version>

--- a/99-integration/dubbo-samples-rest-withtoken/case-versions.conf
+++ b/99-integration/dubbo-samples-rest-withtoken/case-versions.conf
@@ -20,6 +20,6 @@
 # Supported component versions of the test case
 
 # Spring app
-dubbo.version=[ 3.2* ]
+dubbo.version=3.2*
 spring.version=5.*
 java.version= [>= 8]

--- a/99-integration/dubbo-samples-rest-withtoken/case-versions.conf
+++ b/99-integration/dubbo-samples-rest-withtoken/case-versions.conf
@@ -20,6 +20,6 @@
 # Supported component versions of the test case
 
 # Spring app
-dubbo.version=[ >= 3.2.0 ]
+dubbo.version=[ 3.2* ]
 spring.version=5.*
 java.version= [>= 8]

--- a/99-integration/dubbo-samples-test-register-3-3/pom.xml
+++ b/99-integration/dubbo-samples-test-register-3-3/pom.xml
@@ -36,7 +36,7 @@
     <description>Dubbo Samples Test For Register on Dubbo 3.3</description>
 
     <properties>
-        <dubbo.version>3.3.0-beta.1-SNAPSHOT</dubbo.version>
+        <dubbo.version>3.3.0-beta.1</dubbo.version>
         <junit5.version>5.9.2</junit5.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/99-integration/dubbo-samples-test-register-3-3/pom.xml
+++ b/99-integration/dubbo-samples-test-register-3-3/pom.xml
@@ -36,7 +36,7 @@
     <description>Dubbo Samples Test For Register on Dubbo 3.3</description>
 
     <properties>
-        <dubbo.version>3.3.0-beta.2-release</dubbo.version>
+        <dubbo.version>3.3.0-beta.1-SNAPSHOT</dubbo.version>
         <junit5.version>5.9.2</junit5.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/99-integration/dubbo-samples-test-register-3-3/pom.xml
+++ b/99-integration/dubbo-samples-test-register-3-3/pom.xml
@@ -36,7 +36,7 @@
     <description>Dubbo Samples Test For Register on Dubbo 3.3</description>
 
     <properties>
-        <dubbo.version>3.3.0-beta.1-SNAPSHOT</dubbo.version>
+        <dubbo.version>3.3.0-beta.2-release</dubbo.version>
         <junit5.version>5.9.2</junit5.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
Due to the removal of some modules, the ci of dubbo repository cannot pass, and the version of samples related tests is lowered here. Plase look https://github.com/apache/dubbo/pull/14170