### PR TITLE
support "dubbo-samples-native-image" builds and launches with jar or native-image

### DIFF
--- a/2-advanced/dubbo-samples-native-image/case-configuration.yml
+++ b/2-advanced/dubbo-samples-native-image/case-configuration.yml
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+    zookeeper:
+        image: zookeeper:latest
+
+    provider:
+        type: app
+        basedir: dubbo-samples-native-image-provider
+        mainClass: org.apache.dubbo.samples.mock.provider.ProviderApplication
+        systemProps:
+            - zookeeper.address=zookeeper
+        waitPortsBeforeRun:
+            - zookeeper:2181
+        checkPorts:
+            - 50052
+        checkLog: "dubbo service started"
+
+    direct-consumer:
+        type: test
+        basedir: dubbo-samples-native-image-consumer
+        tests:
+            - "**/*IT.class"
+        systemProps:
+            - zookeeper.address=zookeeper
+            - zookeeper.port=2181
+            - dubbo.address=provider
+            - dubbo.port=50052
+        waitPortsBeforeRun:
+            - zookeeper:2181
+            - provider:50052
+        depends_on:
+            - provider

--- a/2-advanced/dubbo-samples-native-image/case-versions.conf
+++ b/2-advanced/dubbo-samples-native-image/case-versions.conf
@@ -1,0 +1,24 @@
+#
+#
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Supported component versions of the test case
+
+# Spring app
+dubbo.version=3.3.*
+spring.version=6.*
+java.version= [ >= 17]


### PR DESCRIPTION
add config