### PR TITLE
Reduce the size of the Response body

### DIFF
--- a/3-extensions/protocol/dubbo-samples-triple/src/test/java/org/apache/dubbo/sample/tri/BaseTriPojoClientTest.java
+++ b/3-extensions/protocol/dubbo-samples-triple/src/test/java/org/apache/dubbo/sample/tri/BaseTriPojoClientTest.java
@@ -162,7 +162,7 @@ public abstract class BaseTriPojoClientTest {
 
     @Test
     public void greetLong() {
-        int power = 25;
+        int power = 23;
         for (int i = 0; i < power; i++) {
             final int len = (1 << i);
             final String response = longDelegate.greetLong(len);

--- a/3-extensions/protocol/dubbo-samples-triple/src/test/java/org/apache/dubbo/sample/tri/TriPojoClientTest.java
+++ b/3-extensions/protocol/dubbo-samples-triple/src/test/java/org/apache/dubbo/sample/tri/TriPojoClientTest.java
@@ -182,7 +182,7 @@ public class TriPojoClientTest {
 
     @Test
     public void greetLong() {
-        int power = 25;
+        int power = 23;
         for (int i = 0; i < power; i++) {
             final int len = (1 << i);
             final String response = longDelegate.greetLong(len);


### PR DESCRIPTION
Because the default limit of version 3.3 is 8M, reduce the size of the Response body to be compatible with versions 3.2 and 3.3.