### PR TITLE
fix case-versions.conf

### DIFF
--- a/4-governance/dubbo-samples-meshrule-router/case-versions.conf
+++ b/4-governance/dubbo-samples-meshrule-router/case-versions.conf
@@ -20,6 +20,6 @@
 # Supported component versions of the test case
 
 # Spring app
-dubbo.version=3.*
+dubbo.version=!3.*
 spring.version=4.*, 5.*
 java.version= [>= 8]


### PR DESCRIPTION
Since the mesh router has been moved to SPI extensions, this sample needs to be temporarily blocked, and it will be added to SPI samples later