### PR TITLE
add spring-context-support version

### DIFF
--- a/2-advanced/dubbo-samples-gateway/dubbo-samples-gateway-higress/dubbo-samples-gateway-higress-dubbo/dubbo-samples-gateway-higress-dubbo-interface/pom.xml
+++ b/2-advanced/dubbo-samples-gateway/dubbo-samples-gateway-higress/dubbo-samples-gateway-higress-dubbo/dubbo-samples-gateway-higress-dubbo-interface/pom.xml
@@ -33,6 +33,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <alibaba-spring-context-support.version>1.0.11</alibaba-spring-context-support.version>
     </properties>
 
     <dependencies>
@@ -44,6 +45,7 @@
         <dependency>
             <groupId>com.alibaba.spring</groupId>
             <artifactId>spring-context-support</artifactId>
+            <version>${spring-context-support.verison}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/2-advanced/dubbo-samples-gateway/dubbo-samples-gateway-higress/dubbo-samples-gateway-higress-triple/dubbo-samples-gateway-higress-triple-interface/pom.xml
+++ b/2-advanced/dubbo-samples-gateway/dubbo-samples-gateway-higress/dubbo-samples-gateway-higress-triple/dubbo-samples-gateway-higress-triple-interface/pom.xml
@@ -33,6 +33,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <alibaba-spring-context-support.version>1.0.11</alibaba-spring-context-support.version>
     </properties>
 
     <dependencies>
@@ -44,6 +45,7 @@
         <dependency>
             <groupId>com.alibaba.spring</groupId>
             <artifactId>spring-context-support</artifactId>
+            <version>${spring-context-support.verison}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-springmvc/pom.xml
+++ b/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-springmvc/pom.xml
@@ -51,6 +51,7 @@
         <dependency>
             <groupId>com.alibaba.spring</groupId>
             <artifactId>spring-context-support</artifactId>
+            <version>1.0.11</version>
         </dependency>
 
         <!-- spring boot starter -->

--- a/3-extensions/protocol/dubbo-samples-rest/pom.xml
+++ b/3-extensions/protocol/dubbo-samples-rest/pom.xml
@@ -41,6 +41,7 @@
         <swagger.version>1.5.19</swagger.version>
         <tomcat.version>8.0.53</tomcat.version>
         <zookeeper.version>3.8.3</zookeeper.version>
+        <alibaba-spring-context-support.version>1.0.11</alibaba-spring-context-support.version>
     </properties>
 
     <dependencyManagement>
@@ -187,6 +188,7 @@
         <dependency>
             <groupId>com.alibaba.spring</groupId>
             <artifactId>spring-context-support</artifactId>
+            <version>${alibaba-spring-context-support.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Some modules have spring-context-support dependencies in them, but they don't write the version number, they rely on dubbo-dependencies, and now the bom is gone, and an error will be reported.