### PR TITLE
Fix Nacos YAML configuration

### DIFF
--- a/2-advanced/dubbo-samples-gateway/dubbo-samples-gateway-higress/dubbo-samples-gateway-higress-triple/deploy/nacos/Nacos.yaml
+++ b/2-advanced/dubbo-samples-gateway/dubbo-samples-gateway-higress/dubbo-samples-gateway-higress-triple/deploy/nacos/Nacos.yaml
@@ -17,47 +17,47 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-	name: nacos-server
+  name: nacos-server
 spec:
-	replicas: 1
-	selector:
-		matchLabels:
-			app: nacos-server
-	template:
-		metadata:
-			labels:
-				app: nacos-server
-		spec:
-			containers:
-				- env:
-					  - name: MODE
-						value: standalone
-				  image: nacos/nacos-server:v2.2.0
-				  imagePullPolicy: Always
-				  name: nacos-server
-				  ports:
-					  - containerPort: 8848
-					    name: client
-					  - containerPort: 9848
-					    name: client-rpc
-					  - containerPort: 9849
-					    name: raft-rpc
-					  - containerPort: 7848
-					    name: old-raft-rpc
-			dnsPolicy: ClusterFirst
-			restartPolicy: Always
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nacos-server
+  template:
+    metadata:
+      labels:
+        app: nacos-server
+    spec:
+      containers:
+        - env:
+          - name: MODE
+            value: standalone
+          image: nacos/nacos-server:v2.2.0
+          imagePullPolicy: Always
+          name: nacos-server
+          ports:
+            - containerPort: 8848
+              name: client
+            - containerPort: 9848
+              name: client-rpc
+            - containerPort: 9849
+              name: raft-rpc
+            - containerPort: 7848
+              name: old-raft-rpc
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
 
 ---
 apiVersion: v1
 kind: Service
 metadata:
-	name: nacos-server
+  name: nacos-server
 spec:
-	ports:
-		- port: 8848
-		  name: server
-		  protocol: TCP
-		  targetPort: 8848
-	selector:
-		app: nacos-server
-	type: ClusterIP
+  ports:
+    - port: 8848
+      name: server
+      protocol: TCP
+      targetPort: 8848
+  selector:
+    app: nacos-server
+  type: ClusterIP


### PR DESCRIPTION
这个文件格式不对，执行
`kubectl apply -f https://raw.githubusercontent.com/apache/dubbo-samples/master/2-advanced/dubbo-samples-gateway/dubbo-samples-gateway-higress/dubbo-samples-gateway-higress-triple/deploy/nacos/Nacos.yaml
`报错，改了一下，现在可以了