### PR TITLE
fix: fix dubbo filter sample

### DIFF
--- a/10-task/dubbo-samples-extensibility/dubbo-samples-extensibility-filter-provider/src/main/java/org/apache/dubbo/samples/extensibility/filter/provider/AppendedFilter.java
+++ b/10-task/dubbo-samples-extensibility/dubbo-samples-extensibility-filter-provider/src/main/java/org/apache/dubbo/samples/extensibility/filter/provider/AppendedFilter.java
@@ -31,7 +31,9 @@ public class AppendedFilter implements Filter {
         // Obtain the returned value
         Result appResponse = ((AsyncRpcResult) result).getAppResponse();
         // Appended value
-        appResponse.setValue(appResponse.getValue()+"'s customized AppendedFilter");
+        if (appResponse.getValue() instanceof String) {
+            appResponse.setValue(appResponse.getValue() + "'s customized AppendedFilter");
+        }
         return result;
     }
 }


### PR DESCRIPTION
I clarify the bug in [[Bug] dubbo samples extensibility filter ArrayIndexOutOfBoundsException](https://github.com/apache/dubbo/issues/14744). My solution is to judge the type of `appResponse.getValue()` before trying to setValue as a String Object.