### PR TITLE
Fix the wrong maven command in readme

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -80,6 +80,8 @@ header:
     - '**/*.properties'
     - '**/*.yml'
     - '**/*.yaml'
+    - 'online_bontique_demo/frontend/src/main/resources/static/styles/bootstrap.min.css'
+
 
   comment: on-failure
 

--- a/2-advanced/dubbo-samples-triple-streaming/README.md
+++ b/2-advanced/dubbo-samples-triple-streaming/README.md
@@ -13,12 +13,12 @@ mvn clean compile #Compile and generate code
 Make sure you are in `dubbo-samples-triple-streaming` directory and then run the following command:
 
 ```shell
-$ mvn compile exec:java -Dexec.mainClass="org.apache.dubbo.samples.tri.streaming.TriStreamServer"
+$ mvn compile exec:java -D"exec.mainClass"="org.apache.dubbo.samples.tri.streaming.TriStreamServer"
 ```
 
 #### Start client
 Open a new terminal, enter `dubbo-samples-triple-streaming` directory and then run the following command:
 
 ```shell
-$ mvn compile exec:java -Dexec.mainClass="org.apache.dubbo.samples.tri.streaming.TriStreamClient"
+$ mvn compile exec:java -D"exec.mainClass"="org.apache.dubbo.samples.tri.streaming.TriStreamClient"
 ```

--- a/online_bontique_demo/frontend/src/main/resources/static/styles/bootstrap.min.css
+++ b/online_bontique_demo/frontend/src/main/resources/static/styles/bootstrap.min.css
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /*!
  * Bootstrap v4.3.1 (https://getbootstrap.com/)
  * Copyright 2011-2019 The Bootstrap Authors

--- a/online_bontique_demo/frontend/src/main/resources/static/styles/bootstrap.min.css
+++ b/online_bontique_demo/frontend/src/main/resources/static/styles/bootstrap.min.css
@@ -1,19 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 /*!
  * Bootstrap v4.3.1 (https://getbootstrap.com/)
  * Copyright 2011-2019 The Bootstrap Authors


### PR DESCRIPTION
In windows11, I directly ran the instructions in the readme error, which caused me some trouble running the case.