### PR TITLE
fix: add -parameters for quickstart pom

### DIFF
--- a/11-quickstart/pom.xml
+++ b/11-quickstart/pom.xml
@@ -60,6 +60,7 @@
                     <source>17</source>
                     <target>17</target>
                     <encoding>UTF-8</encoding>
+                    <parameters>true</parameters>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
fix bug:
Accessing dubbo service via rest resulting in the following error:
![image](https://github.com/user-attachments/assets/69d05f00-a4ac-457a-a05c-073f28374f35)
