### PR TITLE
fixed github workflows, set unique service names of dubbo-samples-triple-rest-openapi-basic and dubbo-samples-triple-servlet

### DIFF
--- a/.github/workflows/dubbo-3_2.yml
+++ b/.github/workflows/dubbo-3_2.yml
@@ -218,8 +218,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-result
-          path: test/jobs/*-result*
+          name: test-result_${{matrix.job_id}}-java${{matrix.java}}
+          path: test/jobs/testjob_${{matrix.job_id}}-result-java${{matrix.java}}.txt
 
   test_result:
     needs: [testjob]
@@ -237,7 +237,8 @@ jobs:
       - name: Download test result
         uses: actions/download-artifact@v4
         with:
-          name: test-result
           path: test/jobs/
+          pattern: test-result_*-java${{matrix.java}}
+          merge-multiple: true
       - name: Merge test result - java ${{matrix.java}}
         run: ./test/scripts/merge-test-results.sh

--- a/.github/workflows/dubbo-3_3.yml
+++ b/.github/workflows/dubbo-3_3.yml
@@ -210,8 +210,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-result
-          path: test/jobs/*-result*
+          name: test-result_${{matrix.job_id}}-java${{matrix.java}}
+          path: test/jobs/testjob_${{matrix.job_id}}-result-java${{matrix.java}}.txt
 
   test_result:
     needs: [testjob]
@@ -229,7 +229,8 @@ jobs:
       - name: Download test result
         uses: actions/download-artifact@v4
         with:
-          name: test-result
           path: test/jobs/
+          pattern: test-result_*-java${{matrix.java}}
+          merge-multiple: true
       - name: Merge test result - java ${{matrix.java}}
         run: ./test/scripts/merge-test-results.sh

--- a/.github/workflows/nightly-dubbo-3.yml
+++ b/.github/workflows/nightly-dubbo-3.yml
@@ -172,8 +172,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-result
-          path: test/jobs/*-result*
+          name: test-result_${{matrix.job_id}}-java${{matrix.java}}
+          path: test/jobs/testjob_${{matrix.job_id}}-result-java${{matrix.java}}.txt
 
   test_result:
     needs: [testjob]
@@ -191,7 +191,8 @@ jobs:
       - name: Download test result
         uses: actions/download-artifact@v4
         with:
-          name: test-result
           path: test/jobs/
+          pattern: test-result_*-java${{matrix.java}}
+          merge-multiple: true
       - name: Merge test result - java ${{matrix.java}}
         run: ./test/scripts/merge-test-results.sh

--- a/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-openapi-basic/case-configuration.yml
+++ b/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-openapi-basic/case-configuration.yml
@@ -18,7 +18,7 @@ services:
   zookeeper4openapi:
     image: zookeeper:latest
 
-  provider:
+  provider4openapi:
     type: app
     basedir: .
     mainClass: org.apache.dubbo.rest.demo.OpenApiApplication
@@ -34,15 +34,15 @@ services:
     depends_on:
       - zookeeper4openapi
 
-  test:
+  test4openapi:
     type: test
     basedir: .
     tests:
       - "**/*IT.class"
     systemProps:
-      - dubbo.address=provider
+      - dubbo.address=provider4openapi
     waitPortsBeforeRun:
-      - provider:50052
+      - provider4openapi:50052
     depends_on:
-      - provider
+      - provider4openapi
 

--- a/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-openapi-basic/case-configuration.yml
+++ b/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-openapi-basic/case-configuration.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 services:
-  zookeeper:
+  zookeeper4openapi:
     image: zookeeper:latest
 
   provider:
@@ -23,17 +23,17 @@ services:
     basedir: .
     mainClass: org.apache.dubbo.rest.demo.OpenApiApplication
     systemProps:
-      - zookeeper.address=zookeeper
+      - zookeeper.address=zookeeper4openapi
       - zookeeper.port=2181
       - dubbo.port=50052
     waitPortsBeforeRun:
-      - zookeeper:2181
+      - zookeeper4openapi:2181
     checkPorts:
       - 50052
     checkLog: "dubbo service started"
     depends_on:
-      - zookeeper
-      -
+      - zookeeper4openapi
+
   test:
     type: test
     basedir: .

--- a/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-openapi-basic/pom.xml
+++ b/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-openapi-basic/pom.xml
@@ -32,7 +32,7 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <dubbo.version>3.3.3-SNAPSHOT</dubbo.version>
+    <dubbo.version>3.3.3</dubbo.version>
   </properties>
 
   <dependencies>

--- a/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-openapi-basic/src/main/resources/application.yml
+++ b/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-openapi-basic/src/main/resources/application.yml
@@ -30,6 +30,6 @@ dubbo:
           enabled: true
   registry:
     id: zk-registry
-    address: zookeeper://127.0.0.1:2181
+    address: zookeeper://${zookeeper.address:127.0.0.1}:2181
 server:
   port: 8082

--- a/2-advanced/dubbo-samples-triple-servlet/README.md
+++ b/2-advanced/dubbo-samples-triple-servlet/README.md
@@ -78,6 +78,6 @@ dubbo:
         name: tri
         port: ${server.port}
         triple:
-        servlet:
-            enabled: true
+            servlet:
+                enabled: true
 ```

--- a/2-advanced/dubbo-samples-triple-servlet/case-configuration.yml
+++ b/2-advanced/dubbo-samples-triple-servlet/case-configuration.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 services:
-  nacos:
+  nacos4tripleServlet:
     image: nacos/nacos-server:${nacos-server.version:2.0.0}
     environment:
       - PREFER_HOST_MODE=hostname
@@ -30,15 +30,15 @@ services:
     basedir: .
     mainClass: org.apache.dubbo.demo.ProviderApplication
     systemProps:
-      - nacos.address=nacos
+      - nacos.address=nacos4tripleServlet
       - nacos.port=8848
     waitPortsBeforeRun:
-      - nacos:8848
+      - nacos4tripleServlet:8848
     checkPorts:
       - 50052
     checkLog: "dubbo service started"
     depends_on:
-      - nacos
+      - nacos4tripleServlet
 
   test:
     type: test
@@ -46,12 +46,12 @@ services:
     tests:
       - "**/*IT.class"
     systemProps:
-      - nacos.address=nacos
+      - nacos.address=nacos4tripleServlet
       - nacos.port=8848
       - dubbo.address=provider
     waitPortsBeforeRun:
-      - nacos:8848
+      - nacos4tripleServlet:8848
       - provider:50052
     depends_on:
-      - nacos
+      - nacos4tripleServlet
       - provider

--- a/2-advanced/dubbo-samples-triple-servlet/case-configuration.yml
+++ b/2-advanced/dubbo-samples-triple-servlet/case-configuration.yml
@@ -25,7 +25,7 @@ services:
       - JVM_XMX=512m
       - JVM_XMN=256m
 
-  provider:
+  provider4tripleServlet:
     type: app
     basedir: .
     mainClass: org.apache.dubbo.demo.ProviderApplication
@@ -40,7 +40,7 @@ services:
     depends_on:
       - nacos4tripleServlet
 
-  test:
+  test4tripleServlet:
     type: test
     basedir: .
     tests:
@@ -48,10 +48,10 @@ services:
     systemProps:
       - nacos.address=nacos4tripleServlet
       - nacos.port=8848
-      - dubbo.address=provider
+      - dubbo.address=provider4tripleServlet
     waitPortsBeforeRun:
       - nacos4tripleServlet:8848
-      - provider:50052
+      - provider4tripleServlet:50052
     depends_on:
       - nacos4tripleServlet
-      - provider
+      - provider4tripleServlet

--- a/2-advanced/dubbo-samples-triple-servlet/src/main/resources/application.yml
+++ b/2-advanced/dubbo-samples-triple-servlet/src/main/resources/application.yml
@@ -34,7 +34,6 @@ dubbo:
       verbose: true
       servlet:
         enabled: true
-        enable: true
   registry:
     address: nacos://${nacos.address:127.0.0.1}:8848
     username: nacos


### PR DESCRIPTION
try to solve
1. there were too many dubbo-samples github Actions errors should be fixed, since upload-artifact@v4 (#1203) does not support uploading same test result name for different jobs anymore.
2. ```dubbo-samples-triple-rest-openapi-basic```  that was always timeout which might be caused by using same zookeeper service name among different test jobs, those jobs might be running on the same time and one of them might destroy the zookeeper service while other are still running.
3. ```dubbo-samples-triple-servlet``` that was always timeout which might be caused by using same nacos service name among different test jobs, those jobs might be running on the same time and one of them might destroy the nacos service while other are still running. 
3.1 ```dubbo-samples-triple-servlet``` has another problem: NPE will be thrown at ```HttpMetadataAdapter.headers``` as ```request.getHeader(HttpHeaderNames.HOST.getName())``` returns null, but it could not be fixed by this pull request,  it had been fixed by https://github.com/apache/dubbo/pull/15141 which used ```request.getServerName()``` instead.


@AlbumenJ  PTAL
