### PR TITLE
Normalized hostname by concatenating scenarioName with index number

### DIFF
--- a/10-task/dubbo-samples-benchmark/case-configuration.yml
+++ b/10-task/dubbo-samples-benchmark/case-configuration.yml
@@ -22,7 +22,7 @@ services:
 
   bh-mysql:
     image: mysql:5.7
-    hostname: bh-mysql
+    hostname: dubbo-samples-benchmark-mysql
     environment:
       - MYSQL_ROOT_PASSWORD=123456
       - MYSQL_DATABASE=skywalking
@@ -38,18 +38,18 @@ services:
 
   skywalking:
     image: apache/skywalking-oap-server:9.3.0
-    hostname: skywalking
+    hostname: dubbo-samples-benchmark-skywalking
     ports:
       - 11800:11800
     volumes:
       - /tmp/mysql-connector-java-8.0.23.jar:/skywalking/oap-libs/mysql-connector-java-8.0.23.jar
     environment:
       - SW_STORAGE=mysql
-      - SW_JDBC_URL=jdbc:mysql://bh-mysql:3306/skywalking?useSSL=false
+      - SW_JDBC_URL=jdbc:mysql://dubbo-samples-benchmark-mysql:3306/skywalking?useSSL=false
       - SW_DATA_SOURCE_USER=root
       - SW_DATA_SOURCE_PASSWORD=123456
     waitPortsBeforeRun:
-      - bh-mysql:3306
+      - dubbo-samples-benchmark-mysql:3306
     depends_on:
       - bh-mysql
 
@@ -75,12 +75,12 @@ services:
     systemProps:
       - zookeeper.address=zookeeper
       - skywalking.agent.service_name=dubbo-samples-benchmark-consumer
-      - skywalking.collector.backend_service=skywalking:11800
+      - skywalking.collector.backend_service=dubbo-samples-benchmark-skywalking:11800
     volumes:
       - /tmp:/tmp
     waitPortsBeforeRun:
       - zookeeper:2181
       - provider:20880
-      - skywalking:11800
+      - dubbo-samples-benchmark-skywalking:11800
     depends_on:
       - provider

--- a/3-extensions/configcenter/dubbo-samples-configcenter-apollo/case-configuration.yml
+++ b/3-extensions/configcenter/dubbo-samples-configcenter-apollo/case-configuration.yml
@@ -68,7 +68,7 @@ services:
       - 8090
     environment:
       - APOLLO_SERVICE=1
-      - DB_ADDRESS=apollo-db:3306
+      - DB_ADDRESS=dubbo-samples-configcenter-apollo-db:3306
     volumes:
       - ${_basedir}/src/main/resources/docker/demo.sh:/apollo-quick-start/demo.sh
       - ./logs:/apollo-quick-start/logs
@@ -81,6 +81,7 @@ services:
 
   apollo-db:
     image: mysql:5.7
+    hostname: dubbo-samples-configcenter-apollo-db
     environment:
       - TZ=Asia/Shanghai
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes


### PR DESCRIPTION
By now, the default hostname of every dubbo-samples testing container is set to the service name,  but
1. Many test projects define same service name in their case-configuration.yml, these test projects could not be ran simutaneously because two or more containers could not using same hostname at the same time,
2. it is difficult to ensure that manually setting service name do not overlap with other projects,
3. scenarioName might be unique because it's generated from project name which should be unique,
4. there are maximum length limit of hostname in container,
so normalizing hostname by concatenating scenarioName with index number might alleviate this issue.

Setting hostname manually if some service system property or environment value contains hostname as it is difficult to determine whether part of a property or environment value is a hostname. In this situation, hostname should be set to global unique value explicitly at case-configuration.yml, and it should be different from serviceName to let this PR don't normalize it, just like this one:
```
services:
  provider:
    #set global unique hostname if some service system property or environment value contains but is not equal to the servicename: provider
    hostname: some-global-unique-name
    ...
  test:
    environment: 
      # the XXX value contains but is not equal to the hostname of provider.
      - XXX=jdbc:mysql://some-global-unique-name:3306/xxx
    systemProps:
      #the property value contains but is not equal to the hostname of provider.
      - some-property-name=some-global-unique-name:3306
```

@AlbumenJ PTAL