### PR TITLE
[3.3] Fix dubbo servicediscovery migration testcase

### DIFF
--- a/2-advanced/dubbo-samples-service-discovery/dubbo-servicediscovery-migration/dubbo-servicediscovery-migration-consumer/src/test/java/org/apache/dubbo/demo/consumer/DemoServiceConfigIT.java
+++ b/2-advanced/dubbo-samples-service-discovery/dubbo-servicediscovery-migration/dubbo-servicediscovery-migration-consumer/src/test/java/org/apache/dubbo/demo/consumer/DemoServiceConfigIT.java
@@ -43,7 +43,8 @@ public class DemoServiceConfigIT {
     public void setup() {
         applicationModel = FrameworkModel.defaultModel().newApplication();
         ApplicationConfig applicationConfig = new ApplicationConfig(applicationModel);
-        applicationConfig.setName("dubbo-servicediscovery-migration-consumer");
+        // Set a different name to avoid affecting DemoServiceIT.
+        applicationConfig.setName("dubbo-servicediscovery-migration-consumer-1");
 
         RegistryConfig registryConfig = new RegistryConfig(applicationModel);
         registryConfig.setProtocol("zookeeper");


### PR DESCRIPTION
1. add expected migration report count to control ```dubbo-servicediscovery-migration/org.apache.dubbo.demo.consumer.DemoServiceIT``` process.
2. set different application name for ```dubbo-servicediscovery-migration/DemoServiceConfigIT``` to avoid no provider issue triggered by unpredictable migration. 

Fix running issue of testcase ```dubbo-servicediscovery-migration```,   see details at https://github.com/apache/dubbo-samples/actions/runs/15306242647/job/43059693107
```
2025-05-28T17:16:52.9035391Z 2025-05-28T17:16:43.343Z  INFO 19 --- [igrate-thread-1] o.a.d.r.c.m.MigrationRuleHandler         :  [DUBBO] Succeed Migrated to APPLICATION_FIRST mode. Service Name: org.apache.dubbo.demo.DemoService, dubbo version: 3.3.4-SNAPSHOT, current host: 172.18.0.5
<====== migrate to APPLICATION_FIRST mode

2025-05-28T17:16:52.9037975Z 2025-05-28T17:16:48.298Z  INFO 19 --- [           main] o.a.d.r.z.ZookeeperRegistry              :  [DUBBO] Subscribe: consumer://172.18.0.5/org.apache.dubbo.demo.DemoService?application=dubbo-servicediscovery-migration-consumer&background=false&category=providers,configurators,routers&dubbo=2.0.2&executor-management-mode=isolation&file-cache=true&group=service&interface=org.apache.dubbo.demo.DemoService&methods=sayHello&pid=19&qos.enable=false&release=3.3.4-SNAPSHOT&revision=1.0-SNAPSHOT&side=consumer&sticky=false&timestamp=1748452608294&unloadClusterRelated=false, dubbo version: 3.3.4-SNAPSHOT, current host: 172.18.0.5
2025-05-28T17:16:52.9041161Z 2025-05-28T17:16:48.299Z  WARN 19 --- [           main] o.a.d.r.s.CacheableFailbackRegistry      :  [DUBBO] Service service/org.apache.dubbo.demo.DemoService received empty address list and empty protection is disabled, will clear current available addresses, dubbo version: 3.3.4-SNAPSHOT, current host: 172.18.0.5, error code: 1-4. This may be caused by , go to https://dubbo.apache.org/faq/1/4 to find instructions. 
2025-05-28T17:16:52.9045914Z 2025-05-28T17:16:48.301Z  INFO 19 --- [           main] o.a.d.r.z.ZookeeperRegistry              :  [DUBBO] Notify urls for subscribe url consumer://172.18.0.5/org.apache.dubbo.demo.DemoService?application=dubbo-servicediscovery-migration-consumer&background=false&category=providers,configurators,routers&dubbo=2.0.2&executor-management-mode=isolation&file-cache=true&group=service&interface=org.apache.dubbo.demo.DemoService&methods=sayHello&pid=19&qos.enable=false&release=3.3.4-SNAPSHOT&revision=1.0-SNAPSHOT&side=consumer&sticky=false&timestamp=1748452608294&unloadClusterRelated=false, url size: 3, dubbo version: 3.3.4-SNAPSHOT, current host: 172.18.0.5
2025-05-28T17:16:52.9050897Z 2025-05-28T17:16:48.301Z  INFO 19 --- [           main] o.a.d.r.i.RegistryDirectory              :  [DUBBO] Received invokers changed event from registry. Registry type: interface. Service Key: service/org.apache.dubbo.demo.DemoService. Urls Size : 1. Invokers Size : 0. Available Size: 0. Available Invokers : empty, dubbo version: 3.3.4-SNAPSHOT, current host: 172.18.0.5
2025-05-28T17:16:52.9052729Z 2025-05-28T17:16:48.302Z  INFO 19 --- [           main] o.a.d.r.c.m.MigrationRuleHandler         :  [DUBBO] Succeed Migrated to FORCE_INTERFACE mode. Service Name: org.apache.dubbo.demo.DemoService, dubbo version: 3.3.4-SNAPSHOT, current host: 172.18.0.5
<=== migrated to FORCE_INTERFACE mode (should be APPLICATION_FIRST) because it was affected by DemoServiceConfigIT.

2025-05-28T17:16:52.9054031Z 2025-05-28T17:16:48.302Z  INFO 19 --- [           main] o.a.d.c.ReferenceConfig                  :  [DUBBO] Referred dubbo service: [org.apache.dubbo.demo.DemoService]. it's not GenericService reference, dubbo version: 3.3.4-SNAPSHOT, current host: 172.18.0.5
2025-05-28T17:16:52.9057243Z 2025-05-28T17:16:48.303Z  INFO 19 --- [Report-thread-1] o.a.d.m.s.z.ZookeeperMetadataReport      :  [DUBBO] store consumer metadata. Identifier : MetadataIdentifier{application='dubbo-servicediscovery-migration-consumer', serviceInterface='org.apache.dubbo.demo.DemoService', version='', group='service', side='consumer'}; definition: {dubbo=2.0.2, application=dubbo-servicediscovery-migration-consumer, pid=19, side=consumer, group=service, release=3.3.4-SNAPSHOT, interface=org.apache.dubbo.demo.DemoService, executor-management-mode=isolation, file-cache=true, register.ip=172.18.0.5, methods=sayHello, background=false, sticky=false, qos.enable=false, unloadClusterRelated=false, revision=1.0-SNAPSHOT, timestamp=1748452608294}, dubbo version: 3.3.4-SNAPSHOT, current host: 172.18.0.5
2025-05-28T17:16:52.9062131Z 2025-05-28T17:16:48.403Z  WARN 19 --- [           main] o.a.d.c.ReferenceConfig                  :  [DUBBO] Check reference of [service/org.apache.dubbo.demo.DemoService] failed very beginning. After 100ms reties, finally failed., dubbo version: 3.3.4-SNAPSHOT, current host: 172.18.0.5, error code: 1-4. This may be caused by , go to https://dubbo.apache.org/faq/1/4 to find instructions. 
2025-05-28T17:16:52.9063865Z 2025-05-28T17:16:48.404Z ERROR 19 --- [           main] o.a.d.c.ReferenceConfig                  :  [DUBBO] No provider available., dubbo version: 3.3.4-SNAPSHOT, current host: 172.18.0.5, error code: 2-2. This may be caused by provider not started, go to https://dubbo.apache.org/faq/2/2 to find instructions. 
2025-05-28T17:16:52.9064650Z 
2025-05-28T17:16:52.9067366Z java.lang.IllegalStateException: Failed to check the status of the service org.apache.dubbo.demo.DemoService. No provider available for the service service/org.apache.dubbo.demo.DemoService from the url consumer://172.18.0.5/org.apache.dubbo.demo.DemoService?application=dubbo-servicediscovery-migration-consumer&background=false&dubbo=2.0.2&executor-management-mode=isolation&file-cache=true&group=service&interface=org.apache.dubbo.demo.DemoService&methods=sayHello&pid=19&qos.enable=false&register.ip=172.18.0.5&release=3.3.4-SNAPSHOT&revision=1.0-SNAPSHOT&side=consumer&sticky=false&timestamp=1748452608294&unloadClusterRelated=false to the consumer 172.18.0.5 use dubbo version 3.3.4-SNAPSHOT
```