### PR TITLE
fix(stub): add default protocol and add onconnect example

### DIFF
--- a/2-advanced/dubbo-samples-stub/README.md
+++ b/2-advanced/dubbo-samples-stub/README.md
@@ -10,3 +10,21 @@ For example: do ThreadLocal cache, verify parameters, return mock data when call
 shows how. In this sample, a "DemoServiceStub" is defined in the module of "dubbo-samples-stub-interface",
 alongside with the interface class of "DemoService". The way to use this stub on consumer side
 is explicitly configuring the "stub" and "interfaceName" fields of @DubboReference annotation.
+
+If you want to listen to the `onconnect` and `ondisconnect` events of the connection on the consumer side,
+you can set them by the annotation `@DubboReference` attributes `onconnect` and `disconnect`,
+where the value is the method name in the stub class `DemoServiceStub`.
+
+When the consumer side sets the above listening method, the stub class `DemoServiceStub` will be export when the consumer side is started.
+At this time, you need to specify the protocol used for stub class export on the consumer side, such as `dubbo.consumer.protocol=dubbo`,
+because the stub class export stage requires the creation of the `Invoker` like the provider side, and this process needs to be based on a protocol.
+
+After starting the consumer side, it is highly likely that the stub method set by `onconnect` cannot be executed.
+This is because the process of creating a connection on the consumer side is asynchronous, through listening to the push of the registration center in the directory,
+or the first active reading, and then the client connection is established.
+
+If the local stub class `DemoServiceStub` is export after the client connection is established,
+the invoker cannot be found when the connection event method is executed.
+
+In this case, you can restart the service on the provider side, so that the connection on the consumer side will be reestablished,
+and you can see that the method for monitoring the connection establishment in `DemoServiceStub` has been successfully executed.

--- a/2-advanced/dubbo-samples-stub/README_ZH.md
+++ b/2-advanced/dubbo-samples-stub/README_ZH.md
@@ -3,3 +3,14 @@
 * 该案例是关于实现本地存根的。远程服务后，客户端通常只剩下接口，而实现全在服务器端，但提供方有些时候想在客户端也执行部分逻辑。
 * 该案例的实现方式就是在interface包中定义DemoServiceStub，之后关键是在consumer端的service类声明的@DubboReference注解中设置stub属性为定义的stub类，设置interfaceName属性为interface的name。
 
+如果在consumer端想要监听连接的`建立`与`断开`事件，可以通过注解 `@DubboReference` 中的属性 `onconnect` 和 `disconnect` 来设置，其中的值
+是存根类 `DemoServiceStub` 中的方法名。
+
+当consumer端设置了如上监听方法，在consumer端启动时是会把存根类 `DemoServiceStub` 进行服务暴露的，此时需要在consumer端指定服务暴露使用的协议，
+比如 `dubbo.consumer.protocol=dubbo`，因为在暴露存根类服务阶段是需要像provider一样创建`Invoker`对象，在这个过程中需要基于一个 protocol 进行。
+
+在启动consumer端后大概率无法执行到 `onconnect` 设置的存根方法，这是因为consumer端创建连接的过程是异步的，通过directory中监听注册中心的推送，
+或首次的主动读取，然后才建立的客户端连接。
+
+如果本地存根类 `DemoServiceStub` 的暴露过程是在客户端连接建立之后，则执行连接事件方法时是找不到执行的 invoker 的。此时可以通过重启provider端
+的服务，这样consumer端的连接会重新建立，这样就能看到 `DemoServiceStub` 中监听连接建立的方法被成功执行了。

--- a/2-advanced/dubbo-samples-stub/dubbo-samples-stub-consumer/src/main/java/org/apache/dubbo/samples/stub/consumer/StubConsumer.java
+++ b/2-advanced/dubbo-samples-stub/dubbo-samples-stub-consumer/src/main/java/org/apache/dubbo/samples/stub/consumer/StubConsumer.java
@@ -34,7 +34,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 public class StubConsumer {
     private static Logger logger = LoggerFactory.getLogger(StubConsumer.class);
 
-    @DubboReference(check=false, stub="org.apache.dubbo.samples.stub.DemoServiceStub", interfaceName = "org.apache.dubbo.samples.stub.DemoService")
+    @DubboReference(check=false, onconnect = "onConnectEvent", stub="org.apache.dubbo.samples.stub.DemoServiceStub", interfaceName = "org.apache.dubbo.samples.stub.DemoService")
     private DemoService demoService;
 
     public static void main(String[] args) {

--- a/2-advanced/dubbo-samples-stub/dubbo-samples-stub-consumer/src/main/resources/application.yml
+++ b/2-advanced/dubbo-samples-stub/dubbo-samples-stub-consumer/src/main/resources/application.yml
@@ -27,3 +27,5 @@ dubbo:
     port: -1
   registry:
     address: zookeeper://${zookeeper.address:127.0.0.1}:2181
+  consumer:
+    protocol: dubbo

--- a/2-advanced/dubbo-samples-stub/dubbo-samples-stub-interface/src/main/java/org/apache/dubbo/samples/stub/DemoServiceStub.java
+++ b/2-advanced/dubbo-samples-stub/dubbo-samples-stub-interface/src/main/java/org/apache/dubbo/samples/stub/DemoServiceStub.java
@@ -42,4 +42,8 @@ public class DemoServiceStub implements DemoService {
             return null;
         }
     }
+
+    public void onConnectEvent() {
+        logger.info("A new connection has been created");
+    }
 }


### PR DESCRIPTION
related issue apache/dubbo#15446

add the `onconnect` example and add the config item `dubbo.consumer.protocol=dubbo`.
otherwise, an error `No such extension org.apache.dubbo.rpc.Protocol by name consumer` will be reported.