### PR TITLE
Add open latch to dubbo-samples-triple-websocket testcases

### DIFF
--- a/2-advanced/dubbo-samples-triple-websocket/src/main/resources/logback.xml
+++ b/2-advanced/dubbo-samples-triple-websocket/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{50} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/2-advanced/dubbo-samples-triple-websocket/src/test/java/org/apache/dubbo/tri/websocket/demo/test/HelloClient.java
+++ b/2-advanced/dubbo-samples-triple-websocket/src/test/java/org/apache/dubbo/tri/websocket/demo/test/HelloClient.java
@@ -16,15 +16,15 @@
  */
 package org.apache.dubbo.tri.websocket.demo.test;
 
-import org.java_websocket.client.WebSocketClient;
-import org.java_websocket.handshake.ServerHandshake;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ServerHandshake;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class HelloClient extends WebSocketClient {
 
@@ -32,17 +32,21 @@ public class HelloClient extends WebSocketClient {
 
     private final List<String> responses = new ArrayList<>();
 
+    private final CountDownLatch openLatch;
+
     private int closeCode;
 
     private String closeMessage;
 
-    public HelloClient(URI serverURI) {
+    public HelloClient(CountDownLatch openLatch, URI serverURI) {
         super(serverURI);
+        this.openLatch = openLatch;
     }
 
     @Override
     public void onOpen(ServerHandshake handshakedata) {
         LOGGER.info("new connection opened:{}", handshakedata);
+        openLatch.countDown();
     }
 
     @Override

--- a/2-advanced/dubbo-samples-triple-websocket/src/test/java/org/apache/dubbo/tri/websocket/demo/test/WebSocketWithNettyIT.java
+++ b/2-advanced/dubbo-samples-triple-websocket/src/test/java/org/apache/dubbo/tri/websocket/demo/test/WebSocketWithNettyIT.java
@@ -17,26 +17,36 @@
 package org.apache.dubbo.tri.websocket.demo.test;
 
 import io.netty.handler.codec.http.websocketx.WebSocketCloseStatus;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.junit4.SpringRunner;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 public class WebSocketWithNettyIT {
 
     private final String nettyAddress = System.getProperty("dubbo.address", "localhost") + ":50052";
 
+    private CountDownLatch openLatch;
+
+    @BeforeEach
+    public void setUp() {
+        openLatch = new CountDownLatch(1);
+    }
+
     @Test
     public void testHelloWithNetty() throws URISyntaxException, InterruptedException {
         HelloClient helloClient = new HelloClient(
+                openLatch,
                 new URI("ws://" + nettyAddress + "/org.apache.dubbo.tri.websocket.demo.DemoService/sayHello"));
         helloClient.connectBlocking();
+        Assertions.assertTrue(openLatch.await(1, TimeUnit.SECONDS));
         helloClient.send("{\"world\": 1}");
         TimeUnit.SECONDS.sleep(1);
         List<String> responses = helloClient.getResponses();
@@ -48,8 +58,10 @@ public class WebSocketWithNettyIT {
     @Test
     public void testHelloErrorWithNetty() throws URISyntaxException, InterruptedException {
         HelloClient helloClient = new HelloClient(
+                openLatch,
                 new URI("ws://" + nettyAddress + "/org.apache.dubbo.tri.websocket.demo.DemoService/sayHelloError"));
         helloClient.connectBlocking();
+        Assertions.assertTrue(openLatch.await(1, TimeUnit.SECONDS));
         helloClient.send("{\"world\": 1}");
         TimeUnit.SECONDS.sleep(1);
         List<String> responses = helloClient.getResponses();
@@ -62,8 +74,10 @@ public class WebSocketWithNettyIT {
     @Test
     public void testServerStreamWithNetty() throws URISyntaxException, InterruptedException {
         HelloClient helloClient = new HelloClient(
+                openLatch,
                 new URI("ws://" + nettyAddress + "/org.apache.dubbo.tri.websocket.demo.DemoService/greetServerStream"));
         helloClient.connectBlocking();
+        Assertions.assertTrue(openLatch.await(1, TimeUnit.SECONDS));
         helloClient.send("{\"world\": 1}");
         TimeUnit.SECONDS.sleep(1);
         List<String> responses = helloClient.getResponses();
@@ -76,9 +90,12 @@ public class WebSocketWithNettyIT {
 
     @Test
     public void testServerStreamErrorWithNetty() throws URISyntaxException, InterruptedException {
-        HelloClient helloClient = new HelloClient(new URI(
-                "ws://" + nettyAddress + "/org.apache.dubbo.tri.websocket.demo.DemoService/greetServerStreamError"));
+        HelloClient helloClient = new HelloClient(
+                openLatch,
+                new URI("ws://" + nettyAddress
+                        + "/org.apache.dubbo.tri.websocket.demo.DemoService/greetServerStreamError"));
         helloClient.connectBlocking();
+        Assertions.assertTrue(openLatch.await(1, TimeUnit.SECONDS));
         helloClient.send("{\"world\": 1}");
         TimeUnit.SECONDS.sleep(1);
         List<String> responses = helloClient.getResponses();
@@ -90,9 +107,12 @@ public class WebSocketWithNettyIT {
 
     @Test
     public void testServerStreamDirectErrorWithNetty() throws URISyntaxException, InterruptedException {
-        HelloClient helloClient = new HelloClient(new URI("ws://" + nettyAddress
-                + "/org.apache.dubbo.tri.websocket.demo.DemoService/greetServerStreamDirectError"));
+        HelloClient helloClient = new HelloClient(
+                openLatch,
+                new URI("ws://" + nettyAddress
+                        + "/org.apache.dubbo.tri.websocket.demo.DemoService/greetServerStreamDirectError"));
         helloClient.connectBlocking();
+        Assertions.assertTrue(openLatch.await(1, TimeUnit.SECONDS));
         helloClient.send("{\"world\": 1}");
         TimeUnit.SECONDS.sleep(1);
         List<String> responses = helloClient.getResponses();
@@ -105,8 +125,10 @@ public class WebSocketWithNettyIT {
     @Test
     public void testBiStreamWithNetty() throws URISyntaxException, InterruptedException {
         HelloClient helloClient = new HelloClient(
+                openLatch,
                 new URI("ws://" + nettyAddress + "/org.apache.dubbo.tri.websocket.demo.DemoService/greetBiStream"));
         helloClient.connectBlocking();
+        Assertions.assertTrue(openLatch.await(1, TimeUnit.SECONDS));
         for (int i = 0; i < 10; i++) {
             helloClient.send("{\"world\": " + i + "}");
         }
@@ -131,9 +153,12 @@ public class WebSocketWithNettyIT {
 
     @Test
     public void testBiStreamErrorWithNetty() throws URISyntaxException, InterruptedException {
-        HelloClient helloClient = new HelloClient(new URI(
-                "ws://" + nettyAddress + "/org.apache.dubbo.tri.websocket.demo.DemoService/greetBiStreamError"));
+        HelloClient helloClient = new HelloClient(
+                openLatch,
+                new URI("ws://" + nettyAddress
+                        + "/org.apache.dubbo.tri.websocket.demo.DemoService/greetBiStreamError"));
         helloClient.connectBlocking();
+        Assertions.assertTrue(openLatch.await(1, TimeUnit.SECONDS));
         for (int i = 0; i < 10; i++) {
             helloClient.send("{\"world\": " + i + "}");
         }
@@ -147,9 +172,12 @@ public class WebSocketWithNettyIT {
 
     @Test
     public void testBiStreamDirectErrorWithNetty() throws URISyntaxException, InterruptedException {
-        HelloClient helloClient = new HelloClient(new URI(
-                "ws://" + nettyAddress + "/org.apache.dubbo.tri.websocket.demo.DemoService/greetBiStreamDirectError"));
+        HelloClient helloClient = new HelloClient(
+                openLatch,
+                new URI("ws://" + nettyAddress
+                        + "/org.apache.dubbo.tri.websocket.demo.DemoService/greetBiStreamDirectError"));
         helloClient.connectBlocking();
+        Assertions.assertTrue(openLatch.await(1, TimeUnit.SECONDS));
         for (int i = 0; i < 10; i++) {
             helloClient.send("{\"world\": " + i + "}");
         }

--- a/2-advanced/dubbo-samples-triple-websocket/src/test/java/org/apache/dubbo/tri/websocket/demo/test/WebSocketWithTomcatIT.java
+++ b/2-advanced/dubbo-samples-triple-websocket/src/test/java/org/apache/dubbo/tri/websocket/demo/test/WebSocketWithTomcatIT.java
@@ -17,26 +17,36 @@
 package org.apache.dubbo.tri.websocket.demo.test;
 
 import io.netty.handler.codec.http.websocketx.WebSocketCloseStatus;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.junit4.SpringRunner;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 public class WebSocketWithTomcatIT {
 
     private final String tomcatAddress = System.getProperty("dubbo.address", "localhost") + ":8080";
 
+    private CountDownLatch openLatch;
+
+    @BeforeEach
+    public void setUp() {
+        openLatch = new CountDownLatch(1);
+    }
+
     @Test
     public void testHelloWithTomcat() throws URISyntaxException, InterruptedException {
         HelloClient helloClient = new HelloClient(
+                openLatch,
                 new URI("ws://" + tomcatAddress + "/org.apache.dubbo.tri.websocket.demo.DemoService/sayHello"));
         helloClient.connectBlocking();
+        Assertions.assertTrue(openLatch.await(1, TimeUnit.SECONDS));
         helloClient.send("{\"world\": 1}");
         TimeUnit.SECONDS.sleep(1);
         List<String> responses = helloClient.getResponses();
@@ -48,8 +58,10 @@ public class WebSocketWithTomcatIT {
     @Test
     public void testHelloErrorWithTomcat() throws URISyntaxException, InterruptedException {
         HelloClient helloClient = new HelloClient(
+                openLatch,
                 new URI("ws://" + tomcatAddress + "/org.apache.dubbo.tri.websocket.demo.DemoService/sayHelloError"));
         helloClient.connectBlocking();
+        Assertions.assertTrue(openLatch.await(1, TimeUnit.SECONDS));
         helloClient.send("{\"world\": 1}");
         TimeUnit.SECONDS.sleep(1);
         List<String> responses = helloClient.getResponses();
@@ -61,9 +73,12 @@ public class WebSocketWithTomcatIT {
 
     @Test
     public void testServerStreamWithTomcat() throws URISyntaxException, InterruptedException {
-        HelloClient helloClient = new HelloClient(new URI(
-                "ws://" + tomcatAddress + "/org.apache.dubbo.tri.websocket.demo.DemoService/greetServerStream"));
+        HelloClient helloClient = new HelloClient(
+                openLatch,
+                new URI("ws://" + tomcatAddress
+                        + "/org.apache.dubbo.tri.websocket.demo.DemoService/greetServerStream"));
         helloClient.connectBlocking();
+        Assertions.assertTrue(openLatch.await(1, TimeUnit.SECONDS));
         helloClient.send("{\"world\": 1}");
         TimeUnit.SECONDS.sleep(1);
         List<String> responses = helloClient.getResponses();
@@ -76,9 +91,12 @@ public class WebSocketWithTomcatIT {
 
     @Test
     public void testServerStreamErrorWithTomcat() throws URISyntaxException, InterruptedException {
-        HelloClient helloClient = new HelloClient(new URI(
-                "ws://" + tomcatAddress + "/org.apache.dubbo.tri.websocket.demo.DemoService/greetServerStreamError"));
+        HelloClient helloClient = new HelloClient(
+                openLatch,
+                new URI("ws://" + tomcatAddress
+                        + "/org.apache.dubbo.tri.websocket.demo.DemoService/greetServerStreamError"));
         helloClient.connectBlocking();
+        Assertions.assertTrue(openLatch.await(1, TimeUnit.SECONDS));
         helloClient.send("{\"world\": 1}");
         TimeUnit.SECONDS.sleep(1);
         List<String> responses = helloClient.getResponses();
@@ -90,9 +108,12 @@ public class WebSocketWithTomcatIT {
 
     @Test
     public void testServerStreamDirectErrorWithTomcat() throws URISyntaxException, InterruptedException {
-        HelloClient helloClient = new HelloClient(new URI("ws://" + tomcatAddress
-                + "/org.apache.dubbo.tri.websocket.demo.DemoService/greetServerStreamDirectError"));
+        HelloClient helloClient = new HelloClient(
+                openLatch,
+                new URI("ws://" + tomcatAddress
+                        + "/org.apache.dubbo.tri.websocket.demo.DemoService/greetServerStreamDirectError"));
         helloClient.connectBlocking();
+        Assertions.assertTrue(openLatch.await(1, TimeUnit.SECONDS));
         helloClient.send("{\"world\": 1}");
         TimeUnit.SECONDS.sleep(1);
         List<String> responses = helloClient.getResponses();
@@ -105,8 +126,10 @@ public class WebSocketWithTomcatIT {
     @Test
     public void testBiStreamWithTomcat() throws URISyntaxException, InterruptedException {
         HelloClient helloClient = new HelloClient(
+                openLatch,
                 new URI("ws://" + tomcatAddress + "/org.apache.dubbo.tri.websocket.demo.DemoService/greetBiStream"));
         helloClient.connectBlocking();
+        Assertions.assertTrue(openLatch.await(1, TimeUnit.SECONDS));
         for (int i = 0; i < 10; i++) {
             helloClient.send("{\"world\": " + i + "}");
         }
@@ -131,9 +154,12 @@ public class WebSocketWithTomcatIT {
 
     @Test
     public void testBiStreamErrorWithTomcat() throws URISyntaxException, InterruptedException {
-        HelloClient helloClient = new HelloClient(new URI(
-                "ws://" + tomcatAddress + "/org.apache.dubbo.tri.websocket.demo.DemoService/greetBiStreamError"));
+        HelloClient helloClient = new HelloClient(
+                openLatch,
+                new URI("ws://" + tomcatAddress
+                        + "/org.apache.dubbo.tri.websocket.demo.DemoService/greetBiStreamError"));
         helloClient.connectBlocking();
+        Assertions.assertTrue(openLatch.await(1, TimeUnit.SECONDS));
         for (int i = 0; i < 10; i++) {
             helloClient.send("{\"world\": " + i + "}");
         }
@@ -147,9 +173,12 @@ public class WebSocketWithTomcatIT {
 
     @Test
     public void testBiStreamDirectErrorWithTomcat() throws URISyntaxException, InterruptedException {
-        HelloClient helloClient = new HelloClient(new URI(
-                "ws://" + tomcatAddress + "/org.apache.dubbo.tri.websocket.demo.DemoService/greetBiStreamDirectError"));
+        HelloClient helloClient = new HelloClient(
+                openLatch,
+                new URI("ws://" + tomcatAddress
+                        + "/org.apache.dubbo.tri.websocket.demo.DemoService/greetBiStreamDirectError"));
         helloClient.connectBlocking();
+        Assertions.assertTrue(openLatch.await(1, TimeUnit.SECONDS));
         for (int i = 0; i < 10; i++) {
             helloClient.send("{\"world\": " + i + "}");
         }


### PR DESCRIPTION
fix the issue which is triggered by the websocket client calling send immediately after connectBlocking.
e.g.
![d15e6d67ad81e9c13050a7265fdef13c](https://github.com/user-attachments/assets/76743923-d00a-43f8-baaf-74d3db96d7b5)
the normal testing process should like this:
![f6ccbb928aeca1f5df5f7761e351f0e8](https://github.com/user-attachments/assets/3c43e5ae-7cb8-464f-9da7-b213824dc137)


