### PR TITLE
Set default reserved ports for triple tests

### DIFF
--- a/test/dubbo-scenario-builder/src/main/resources/docker-compose.template
+++ b/test/dubbo-scenario-builder/src/main/resources/docker-compose.template
@@ -96,4 +96,6 @@ services:
             - ${item}
         </#list>
         </#if>
+        sysctls:
+          net.ipv4.ip_local_reserved_ports: 50050-50059
 </#list>

--- a/test/dubbo-test-runner/src/docker/run.sh
+++ b/test/dubbo-test-runner/src/docker/run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 echo "Start at: $(date "+%Y-%m-%d %H:%M:%S")"
+echo "Current "`sysctl net.ipv4.ip_local_reserved_ports`
 
 DIR=/usr/local/dubbo
 cd $DIR

--- a/test/dubbo-test-runner/src/native/run.sh
+++ b/test/dubbo-test-runner/src/native/run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -x
 echo "Start at: $(date "+%Y-%m-%d %H:%M:%S")"
+echo "Current "`sysctl net.ipv4.ip_local_reserved_ports`
 
 DIR=/usr/local/dubbo
 cd $DIR
@@ -25,4 +26,3 @@ elif [ "$SERVICE_TYPE" == "nativeTest"  ]; then
 fi
 
 /bin/bash $script_file 2>&1
-


### PR DESCRIPTION
50051,50052,50053 ports fall within Linux's default ephemeral port range (32768–61000). According to port classification standards, these ports belong to the dynamic/private port range (49152–65535) and are typically used for temporary connection assignments in client programs, they should be reserved to avoid address already in used exception during testing like this:
![image](https://github.com/user-attachments/assets/dc9bf32c-9f09-4f25-b8f3-5efd95e8ce66)
