### PR TITLE
Upgrade triple rest cases to JUni5

### DIFF
--- a/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-jaxrs/src/test/java/org/apache/dubbo/rest/demo/test/AbnormalRequestServiceIT.java
+++ b/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-jaxrs/src/test/java/org/apache/dubbo/rest/demo/test/AbnormalRequestServiceIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.dubbo.rest.demo.test;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.client.RestClient;
@@ -32,7 +32,7 @@ public class AbnormalRequestServiceIT extends BaseTest {
                 .uri(toUri("/abnormal/not"))
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange((request, response) -> {
-                    Assert.assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+                    Assertions.assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
                     return response;
                 });
     }
@@ -45,7 +45,7 @@ public class AbnormalRequestServiceIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange((request, response) -> {
                     System.out.println(response.getStatusCode());
-                    Assert.assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+                    Assertions.assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
                     return response;
                 });
     }
@@ -57,7 +57,7 @@ public class AbnormalRequestServiceIT extends BaseTest {
                 .uri(toUri("/abnormal/paramConvertFail?zonedDateTime=2023-03-08T10:15:30+08:00"))
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange((request, response) -> {
-                    Assert.assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+                    Assertions.assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
                     return response;
                 });
     }
@@ -69,7 +69,7 @@ public class AbnormalRequestServiceIT extends BaseTest {
                 .uri(toUri("/abnormal/throwException"))
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange((request, response) -> {
-                    Assert.assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+                    Assertions.assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
                     return response;
                 });
     }

--- a/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-jaxrs/src/test/java/org/apache/dubbo/rest/demo/test/BaseTest.java
+++ b/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-jaxrs/src/test/java/org/apache/dubbo/rest/demo/test/BaseTest.java
@@ -19,12 +19,12 @@ package org.apache.dubbo.rest.demo.test;
 
 import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
 
-import org.junit.runner.RunWith;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.client.RestClient;
 
 @EnableDubbo
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public abstract class BaseTest {
 
     protected static final String HOST = System.getProperty("dubbo.address", "localhost");

--- a/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-jaxrs/src/test/java/org/apache/dubbo/rest/demo/test/BasicParamRequestIT.java
+++ b/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-jaxrs/src/test/java/org/apache/dubbo/rest/demo/test/BasicParamRequestIT.java
@@ -35,8 +35,8 @@ import java.util.Calendar;
 import java.util.Date;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -49,92 +49,92 @@ public class BasicParamRequestIT extends BaseTest {
     @Test
     public void testPrimitive() {
         int result1 = basicParamRequestService.primitiveInt(1, 1);
-        Assert.assertEquals(2, result1);
+        Assertions.assertEquals(2, result1);
 
         byte result2 = basicParamRequestService.primitiveByte((byte) 1, (byte) 1);
-        Assert.assertEquals((byte) 2, result2);
+        Assertions.assertEquals((byte) 2, result2);
 
         long result3 = basicParamRequestService.primitiveLong(1L, 1L);
-        Assert.assertEquals(2L, result3);
+        Assertions.assertEquals(2L, result3);
 
         double result4 = basicParamRequestService.primitiveDouble(1.1, 1.2);
-        Assert.assertEquals(2.3, result4, 0.00001);
+        Assertions.assertEquals(2.3, result4, 0.00001);
 
         short result5 = basicParamRequestService.primitiveShort((short) 1, (short) 1);
-        Assert.assertEquals((short) 2, result5);
+        Assertions.assertEquals((short) 2, result5);
 
         boolean result6 = basicParamRequestService.primitiveBoolean(true, false);
-        Assert.assertFalse(result6);
+        Assertions.assertFalse(result6);
 
         char result7 = basicParamRequestService.primitiveChar('a', 'b');
-        Assert.assertEquals((char) ('a' + 'b'), result7);
+        Assertions.assertEquals((char) ('a' + 'b'), result7);
 
         double result8 = basicParamRequestService.primitiveFloat(1.1f, 1.2f);
-        Assert.assertEquals(2.3f, result8, 0.00001f);
+        Assertions.assertEquals(2.3f, result8, 0.00001f);
     }
 
     @Test
     public void test() {
         BigInteger result17 = basicParamRequestService.bigInt(BigInteger.ONE, BigInteger.ONE);
-        Assert.assertEquals(BigInteger.TWO, result17);
+        Assertions.assertEquals(BigInteger.TWO, result17);
 
         BigDecimal result18 = basicParamRequestService.bigDecimal(BigDecimal.ONE, BigDecimal.ZERO);
-        Assert.assertEquals(BigDecimal.ONE, result18);
+        Assertions.assertEquals(BigDecimal.ONE, result18);
 
         int[] array1 = basicParamRequestService.intArray(new int[] {1, 2, 3});
-        Assert.assertArrayEquals(new int[] {1, 2, 3}, array1);
+        Assertions.assertArrayEquals(new int[] {1, 2, 3}, array1);
 
         long[] array2 = basicParamRequestService.longArray(new long[] {1L, 2L, 3L});
-        Assert.assertArrayEquals(new long[] {1L, 2L, 3L}, array2);
+        Assertions.assertArrayEquals(new long[] {1L, 2L, 3L}, array2);
     }
 
     @Test
     public void testWrapper() {
         Boolean result9 = basicParamRequestService.wrapperBoolean(Boolean.TRUE, Boolean.FALSE);
-        Assert.assertEquals(Boolean.FALSE, result9);
+        Assertions.assertEquals(Boolean.FALSE, result9);
 
         Byte result10 = basicParamRequestService.wrapperByte((byte) 1, (byte) 1);
-        Assert.assertEquals(Byte.valueOf((byte) 2), result10);
+        Assertions.assertEquals(Byte.valueOf((byte) 2), result10);
 
         Character result11 = basicParamRequestService.wrapperChar('a', 'b');
-        Assert.assertEquals(Character.valueOf((char) ('a' + 'b')), result11);
+        Assertions.assertEquals(Character.valueOf((char) ('a' + 'b')), result11);
 
         Double result12 = basicParamRequestService.wrapperDouble(1.1, 1.2);
-        Assert.assertEquals(Double.valueOf(2.3), result12);
+        Assertions.assertEquals(Double.valueOf(2.3), result12);
 
         Integer result13 = basicParamRequestService.wrapperInt(1, 1);
-        Assert.assertEquals(Integer.valueOf(2), result13);
+        Assertions.assertEquals(Integer.valueOf(2), result13);
 
         Long result14 = basicParamRequestService.wrapperLong(1L, 1L);
-        Assert.assertEquals(Long.valueOf(2L), result14);
+        Assertions.assertEquals(Long.valueOf(2L), result14);
 
         Short result16 = basicParamRequestService.wrapperShort((short) 1, (short) 1);
-        Assert.assertEquals(Short.valueOf((short) 2), result16);
+        Assertions.assertEquals(Short.valueOf((short) 2), result16);
     }
 
     @Test
     public void testDateTime() {
         Date date = basicParamRequestService.date(Date.from(Instant.parse("2023-03-08T09:30:05Z")));
-        Assert.assertEquals(Date.from(Instant.parse("2023-03-08T09:30:05Z")), date);
+        Assertions.assertEquals(Date.from(Instant.parse("2023-03-08T09:30:05Z")), date);
 
         Instant date1 = basicParamRequestService.date(Instant.parse("2023-03-08T09:30:05Z"));
-        Assert.assertEquals(Instant.parse("2023-03-08T09:30:05Z"), date1);
+        Assertions.assertEquals(Instant.parse("2023-03-08T09:30:05Z"), date1);
 
         Calendar calendar = Calendar.getInstance();
         Calendar date2 = basicParamRequestService.date(calendar);
-        Assert.assertEquals(date2, calendar);
+        Assertions.assertEquals(date2, calendar);
 
         LocalDate date3 = basicParamRequestService.date(LocalDate.parse("2001-05-23"));
-        Assert.assertEquals(LocalDate.parse("2001-05-23"), date3);
+        Assertions.assertEquals(LocalDate.parse("2001-05-23"), date3);
 
         LocalTime date4 = basicParamRequestService.date(LocalTime.parse("09:30:05.123"));
-        Assert.assertEquals(LocalTime.parse("09:30:05.123"), date4);
+        Assertions.assertEquals(LocalTime.parse("09:30:05.123"), date4);
 
         LocalDateTime date5 = basicParamRequestService.date(LocalDateTime.parse("2023-03-08T09:30:05"));
-        Assert.assertEquals(LocalDateTime.parse("2023-03-08T09:30:05"), date5);
+        Assertions.assertEquals(LocalDateTime.parse("2023-03-08T09:30:05"), date5);
 
         ZonedDateTime date6 = basicParamRequestService.date(ZonedDateTime.parse("2021-06-11T10:00:00+02:00"));
-        Assert.assertEquals(ZonedDateTime.parse("2021-06-11T10:00:00+02:00"), date6);
+        Assertions.assertEquals(ZonedDateTime.parse("2021-06-11T10:00:00+02:00"), date6);
     }
 
     @Test
@@ -144,7 +144,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(Integer.class);
-        Assert.assertEquals(Integer.valueOf(2), result.getBody());
+        Assertions.assertEquals(Integer.valueOf(2), result.getBody());
     }
 
     @Test
@@ -154,7 +154,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(Byte.class);
-        Assert.assertEquals(Byte.valueOf((byte) 2), result.getBody());
+        Assertions.assertEquals(Byte.valueOf((byte) 2), result.getBody());
     }
 
     @Test
@@ -164,7 +164,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(Long.class);
-        Assert.assertEquals(Long.valueOf(2), result.getBody());
+        Assertions.assertEquals(Long.valueOf(2), result.getBody());
     }
 
     @Test
@@ -174,7 +174,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(Double.class);
-        Assert.assertEquals(Double.valueOf(2.3), result.getBody());
+        Assertions.assertEquals(Double.valueOf(2.3), result.getBody());
     }
 
     @Test
@@ -184,7 +184,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(Short.class);
-        Assert.assertEquals(Short.valueOf((short) 2), result.getBody());
+        Assertions.assertEquals(Short.valueOf((short) 2), result.getBody());
     }
 
     @Test
@@ -194,7 +194,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(Character.class);
-        Assert.assertEquals(Character.valueOf((char) ('a' + 'b')), result.getBody());
+        Assertions.assertEquals(Character.valueOf((char) ('a' + 'b')), result.getBody());
     }
 
     @Test
@@ -204,7 +204,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(Boolean.class);
-        Assert.assertEquals(Boolean.FALSE, result.getBody());
+        Assertions.assertEquals(Boolean.FALSE, result.getBody());
     }
 
     @Test
@@ -215,7 +215,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(Float.class);
-        Assert.assertEquals(2.3f, result.getBody(), 0.00001f);
+        Assertions.assertEquals(2.3f, result.getBody(), 0.00001f);
     }
 
     @Test
@@ -225,7 +225,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(Integer.class);
-        Assert.assertEquals(Integer.valueOf(2), result.getBody());
+        Assertions.assertEquals(Integer.valueOf(2), result.getBody());
     }
 
     @Test
@@ -235,7 +235,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(Byte.class);
-        Assert.assertEquals(Byte.valueOf((byte) 2), result.getBody());
+        Assertions.assertEquals(Byte.valueOf((byte) 2), result.getBody());
     }
 
     @Test
@@ -245,7 +245,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(Long.class);
-        Assert.assertEquals(Long.valueOf(2), result.getBody());
+        Assertions.assertEquals(Long.valueOf(2), result.getBody());
     }
 
     @Test
@@ -255,7 +255,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(Double.class);
-        Assert.assertEquals(Double.valueOf(2.3), result.getBody());
+        Assertions.assertEquals(Double.valueOf(2.3), result.getBody());
     }
 
     @Test
@@ -265,7 +265,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(Short.class);
-        Assert.assertEquals(Short.valueOf((short) 2), result.getBody());
+        Assertions.assertEquals(Short.valueOf((short) 2), result.getBody());
     }
 
     @Test
@@ -275,7 +275,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(Character.class);
-        Assert.assertEquals(Character.valueOf((char) ('a' + 'b')), result.getBody());
+        Assertions.assertEquals(Character.valueOf((char) ('a' + 'b')), result.getBody());
     }
 
     @Test
@@ -285,7 +285,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(Boolean.class);
-        Assert.assertEquals(Boolean.FALSE, result.getBody());
+        Assertions.assertEquals(Boolean.FALSE, result.getBody());
     }
 
     @Test
@@ -295,7 +295,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(BigInteger.class);
-        Assert.assertEquals(new BigInteger("6000000000"), result.getBody());
+        Assertions.assertEquals(new BigInteger("6000000000"), result.getBody());
     }
 
     @Test
@@ -305,7 +305,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(BigDecimal.class);
-        Assert.assertEquals(new BigDecimal("2.3"), result.getBody());
+        Assertions.assertEquals(new BigDecimal("2.3"), result.getBody());
     }
 
     @Test
@@ -315,7 +315,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});
-        Assert.assertArrayEquals(new int[] {1, 1}, result.getBody());
+        Assertions.assertArrayEquals(new int[] {1, 1}, result.getBody());
     }
 
     @Test
@@ -325,7 +325,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});
-        Assert.assertArrayEquals(new long[] {1L, 1L}, result.getBody());
+        Assertions.assertArrayEquals(new long[] {1L, 1L}, result.getBody());
     }
 
     @Test
@@ -343,7 +343,7 @@ public class BasicParamRequestIT extends BaseTest {
                         throw new RuntimeException(e);
                     }
                 });
-        Assert.assertEquals(formatter.parse("2023-03-08 09:30:05"), result);
+        Assertions.assertEquals(formatter.parse("2023-03-08 09:30:05"), result);
     }
 
     @Test
@@ -353,7 +353,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(LocalDate.class);
-        Assert.assertEquals(LocalDate.parse("2001-05-23"), result.getBody());
+        Assertions.assertEquals(LocalDate.parse("2001-05-23"), result.getBody());
     }
 
     @Test
@@ -375,7 +375,7 @@ public class BasicParamRequestIT extends BaseTest {
                 });
         Calendar instance = Calendar.getInstance();
         instance.setTime(formatter.parse("2023-03-08 09:30:05"));
-        Assert.assertEquals(instance, result);
+        Assertions.assertEquals(instance, result);
     }
 
     @Test
@@ -385,7 +385,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(Instant.class);
-        Assert.assertEquals(Instant.parse("2023-03-08T09:30:05Z"), result.getBody());
+        Assertions.assertEquals(Instant.parse("2023-03-08T09:30:05Z"), result.getBody());
     }
 
     @Test
@@ -395,7 +395,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(LocalTime.class);
-        Assert.assertEquals(LocalTime.parse("09:30:05.123"), result.getBody());
+        Assertions.assertEquals(LocalTime.parse("09:30:05.123"), result.getBody());
     }
 
     @Test
@@ -408,7 +408,7 @@ public class BasicParamRequestIT extends BaseTest {
                     String str = mapper.readValue(response.getBody(), String.class);
                     return LocalDateTime.parse(str, formatter);
                 });
-        Assert.assertEquals(LocalDateTime.parse("2024-04-28 10:00:00", formatter), result);
+        Assertions.assertEquals(LocalDateTime.parse("2024-04-28 10:00:00", formatter), result);
     }
 
     @Test
@@ -424,7 +424,7 @@ public class BasicParamRequestIT extends BaseTest {
                     return LocalDateTime.parse(value.substring(0, i), formatter)
                             .atZone(ZoneId.of(value.substring(i + 1, value.length() - 1)));
                 });
-        Assert.assertEquals(LocalDateTime.parse("2021-06-11T10:00:00", formatter)
+        Assertions.assertEquals(LocalDateTime.parse("2021-06-11T10:00:00", formatter)
                 .atZone(ZoneId.systemDefault()), result);
     }
 
@@ -435,7 +435,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(Color.class);
-        Assert.assertEquals(Color.RED, result.getBody());
+        Assertions.assertEquals(Color.RED, result.getBody());
     }
 
     @Test
@@ -445,7 +445,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(Double.class);
-        Assert.assertEquals(Double.valueOf("1.1"), result.getBody());
+        Assertions.assertEquals(Double.valueOf("1.1"), result.getBody());
     }
 
     @Test
@@ -455,7 +455,7 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.TEXT_PLAIN)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("Hello world", result.getBody());
+        Assertions.assertEquals("Hello world", result.getBody());
     }
 
     @Test
@@ -465,6 +465,6 @@ public class BasicParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(Integer.class);
-        Assert.assertEquals(Integer.valueOf(1), result.getBody());
+        Assertions.assertEquals(Integer.valueOf(1), result.getBody());
     }
 }

--- a/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-jaxrs/src/test/java/org/apache/dubbo/rest/demo/test/ComplexParamRequestIT.java
+++ b/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-jaxrs/src/test/java/org/apache/dubbo/rest/demo/test/ComplexParamRequestIT.java
@@ -34,8 +34,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -52,35 +52,35 @@ public class ComplexParamRequestIT extends BaseTest {
     public void test() {
         List<User> list = List.of(new User(1L, "1", 1), new User(2L, "2", 2));
         List<User> result1 = complexParamRequestService.list(list);
-        Assert.assertEquals(list, result1);
+        Assertions.assertEquals(list, result1);
 
         Set<User> set = Set.of(new User(1L, "1", 1), new User(2L, "2", 2));
         Set<User> result2 = complexParamRequestService.set(set);
-        Assert.assertEquals(set, result2);
+        Assertions.assertEquals(set, result2);
 
         User[] arr = {new User(1L, "1", 1), new User(2L, "2", 2)};
         User[] result3 = complexParamRequestService.array(arr);
-        Assert.assertArrayEquals(arr, result3);
+        Assertions.assertArrayEquals(arr, result3);
 
         Map<String, User> map = Map.of("user1", new User(1L, "1", 1), "user2", new User(2L, "2", 2));
         Map<String, User> result4 = complexParamRequestService.stringMap(map);
-        Assert.assertEquals(map, result4);
+        Assertions.assertEquals(map, result4);
 
         MultivaluedHashMap<String, String> valueMap = new MultivaluedHashMap<>();
         valueMap.add("arg1", "Hello");
         valueMap.add("arg2", "world");
         List<String> result5 = complexParamRequestService.testMapForm(valueMap);
-        Assert.assertEquals(valueMap.values().stream().flatMap(List::stream).toList(), result5);
+        Assertions.assertEquals(valueMap.values().stream().flatMap(List::stream).toList(), result5);
 
         String result6 = complexParamRequestService.testMapHeader("Head");
-        Assert.assertEquals("Head", result6);
+        Assertions.assertEquals("Head", result6);
 
         Map<String, String> stringMap = Map.of("Hello", "World");
         List<String> result7 = complexParamRequestService.testMapParam(stringMap);
-        Assert.assertEquals(stringMap.values().stream().toList(), result7);
+        Assertions.assertEquals(stringMap.values().stream().toList(), result7);
 
         Person person = complexParamRequestService.testXml(new Person("1"));
-        Assert.assertEquals(new Person("1"), person);
+        Assertions.assertEquals(new Person("1"), person);
 
     }
 
@@ -96,7 +96,7 @@ public class ComplexParamRequestIT extends BaseTest {
                 .body(list)
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});
-        Assert.assertEquals(list, response.getBody());
+        Assertions.assertEquals(list, response.getBody());
     }
 
     @Test
@@ -111,7 +111,7 @@ public class ComplexParamRequestIT extends BaseTest {
                 .body(set)
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});
-        Assert.assertEquals(set, response.getBody());
+        Assertions.assertEquals(set, response.getBody());
     }
 
     @Test
@@ -124,7 +124,7 @@ public class ComplexParamRequestIT extends BaseTest {
                 .body(array)
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});
-        Assert.assertArrayEquals(array, response.getBody());
+        Assertions.assertArrayEquals(array, response.getBody());
     }
 
     @Test
@@ -139,7 +139,7 @@ public class ComplexParamRequestIT extends BaseTest {
                 .body(map)
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});
-        Assert.assertEquals(map, response.getBody());
+        Assertions.assertEquals(map, response.getBody());
     }
 
     @Test
@@ -151,7 +151,7 @@ public class ComplexParamRequestIT extends BaseTest {
                 .header("headers", "Head")
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});
-        Assert.assertEquals("Head", response.getBody());
+        Assertions.assertEquals("Head", response.getBody());
     }
 
     @Test
@@ -162,7 +162,7 @@ public class ComplexParamRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});
-        Assert.assertEquals(List.of("Hello", "World"), response.getBody());
+        Assertions.assertEquals(List.of("Hello", "World"), response.getBody());
     }
 
     @Test
@@ -176,7 +176,7 @@ public class ComplexParamRequestIT extends BaseTest {
                 .body(map)
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});
-        Assert.assertEquals(List.of("Hello"), response.getBody());
+        Assertions.assertEquals(List.of("Hello"), response.getBody());
     }
 
     @Test
@@ -193,8 +193,8 @@ public class ComplexParamRequestIT extends BaseTest {
                 .body(writer.toString())
                 .retrieve()
                 .body(String.class);
-        Assert.assertNotNull(result);
-        Assert.assertEquals(person, jaxbContext.createUnmarshaller().unmarshal(new StringReader(result)));
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(person, jaxbContext.createUnmarshaller().unmarshal(new StringReader(result)));
     }
 
     @Test
@@ -206,7 +206,7 @@ public class ComplexParamRequestIT extends BaseTest {
                 .header("cookie", "cookie=1")
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("1", response.getBody());
+        Assertions.assertEquals("1", response.getBody());
     }
 
     @Test
@@ -218,7 +218,7 @@ public class ComplexParamRequestIT extends BaseTest {
                 .header("name", "world")
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("world", response.getBody());
+        Assertions.assertEquals("world", response.getBody());
     }
 
     @Test
@@ -229,7 +229,7 @@ public class ComplexParamRequestIT extends BaseTest {
                 .accept(MediaType.TEXT_PLAIN)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("/complex/uri", response.getBody());
+        Assertions.assertEquals("/complex/uri", response.getBody());
     }
 
     @Test
@@ -243,7 +243,7 @@ public class ComplexParamRequestIT extends BaseTest {
                 .body(map)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("Li", response.getBody());
+        Assertions.assertEquals("Li", response.getBody());
     }
 
 }

--- a/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-jaxrs/src/test/java/org/apache/dubbo/rest/demo/test/DemoServiceIT.java
+++ b/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-jaxrs/src/test/java/org/apache/dubbo/rest/demo/test/DemoServiceIT.java
@@ -19,8 +19,8 @@ package org.apache.dubbo.rest.demo.test;
 import org.apache.dubbo.config.annotation.DubboReference;
 import org.apache.dubbo.rest.demo.DemoService;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.LinkedMultiValueMap;
@@ -35,16 +35,16 @@ public class DemoServiceIT extends BaseTest {
     @Test
     public void test() {
         String result = demoService.hello("world");
-        Assert.assertEquals("Hello world", result);
+        Assertions.assertEquals("Hello world", result);
 
         String res = demoService.deleteUserById("1");
-        Assert.assertEquals("1", res);
+        Assertions.assertEquals("1", res);
 
         int userById = demoService.findUserById(1);
-        Assert.assertEquals(1, userById);
+        Assertions.assertEquals(1, userById);
 
         Long formBody = demoService.testFormBody(1L);
-        Assert.assertEquals(Long.valueOf(1), formBody);
+        Assertions.assertEquals(Long.valueOf(1), formBody);
 
     }
 
@@ -55,7 +55,7 @@ public class DemoServiceIT extends BaseTest {
                 .accept(MediaType.TEXT_PLAIN)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("Hello world", result.getBody());
+        Assertions.assertEquals("Hello world", result.getBody());
     }
 
     @Test
@@ -66,7 +66,7 @@ public class DemoServiceIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(Integer.class);
-        Assert.assertEquals(Integer.valueOf(1), response.getBody());
+        Assertions.assertEquals(Integer.valueOf(1), response.getBody());
     }
 
     @Test
@@ -80,7 +80,7 @@ public class DemoServiceIT extends BaseTest {
                 .body(map)
                 .retrieve()
                 .toEntity(Long.class);
-        Assert.assertEquals(Long.valueOf(1), response.getBody());
+        Assertions.assertEquals(Long.valueOf(1), response.getBody());
     }
 
     @Test
@@ -91,7 +91,7 @@ public class DemoServiceIT extends BaseTest {
                 .accept(MediaType.TEXT_PLAIN)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("1", response.getBody());
+        Assertions.assertEquals("1", response.getBody());
     }
 
 }

--- a/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-jaxrs/src/test/java/org/apache/dubbo/rest/demo/test/ExpansionServiceIT.java
+++ b/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-jaxrs/src/test/java/org/apache/dubbo/rest/demo/test/ExpansionServiceIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.dubbo.rest.demo.test;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClient;
@@ -32,7 +32,7 @@ public class ExpansionServiceIT extends BaseTest {
                 .accept(MediaType.TEXT_PLAIN)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("Hello world response-filter", response.getBody());
+        Assertions.assertEquals("Hello world response-filter", response.getBody());
 
     }
 
@@ -44,7 +44,7 @@ public class ExpansionServiceIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("Hello world intercept", response.getBody());
+        Assertions.assertEquals("Hello world intercept", response.getBody());
     }
 
     @Test
@@ -55,7 +55,7 @@ public class ExpansionServiceIT extends BaseTest {
                 .accept(MediaType.TEXT_PLAIN)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("test-exception", response.getBody());
+        Assertions.assertEquals("test-exception", response.getBody());
     }
 
 }

--- a/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-jaxrs/src/test/java/org/apache/dubbo/rest/demo/test/HttpMethodRequestIT.java
+++ b/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-jaxrs/src/test/java/org/apache/dubbo/rest/demo/test/HttpMethodRequestIT.java
@@ -21,8 +21,8 @@ import org.apache.dubbo.rest.demo.routine.HttpMethodRequestService;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -35,25 +35,25 @@ public class HttpMethodRequestIT extends BaseTest {
     @Test
     public void test() {
         String result = httpMethodRequestService.sayHelloPut("world");
-        Assert.assertEquals("Hello world", result);
+        Assertions.assertEquals("Hello world", result);
 
         result = httpMethodRequestService.sayHelloGet("world");
-        Assert.assertEquals("Hello world", result);
+        Assertions.assertEquals("Hello world", result);
 
         result = httpMethodRequestService.sayHelloPut("world");
-        Assert.assertEquals("Hello world", result);
+        Assertions.assertEquals("Hello world", result);
 
         result = httpMethodRequestService.sayHelloDelete("world");
-        Assert.assertEquals("Hello world", result);
+        Assertions.assertEquals("Hello world", result);
 
         result = httpMethodRequestService.sayHelloPatch("world");
-        Assert.assertEquals("Hello world", result);
+        Assertions.assertEquals("Hello world", result);
 
         result = httpMethodRequestService.sayHelloOptions("world");
-        Assert.assertEquals("Hello world", result);
+        Assertions.assertEquals("Hello world", result);
 
         result = httpMethodRequestService.sayHelloHead("world");
-        Assert.assertEquals("Hello world", result);
+        Assertions.assertEquals("Hello world", result);
     }
 
     @Test
@@ -64,7 +64,7 @@ public class HttpMethodRequestIT extends BaseTest {
                 .retrieve()
                 .toEntity(String.class);
 
-        Assert.assertEquals("Hello world", result.getBody());
+        Assertions.assertEquals("Hello world", result.getBody());
     }
 
     @Test
@@ -77,7 +77,7 @@ public class HttpMethodRequestIT extends BaseTest {
                 .retrieve()
                 .toEntity(String.class);
 
-        Assert.assertEquals("Hello world", result.getBody());
+        Assertions.assertEquals("Hello world", result.getBody());
     }
 
     @Test
@@ -88,7 +88,7 @@ public class HttpMethodRequestIT extends BaseTest {
                 .retrieve()
                 .toEntity(String.class);
 
-        Assert.assertEquals("Hello world", result.getBody());
+        Assertions.assertEquals("Hello world", result.getBody());
     }
 
     @Test
@@ -99,7 +99,7 @@ public class HttpMethodRequestIT extends BaseTest {
                 .retrieve()
                 .toBodilessEntity();
 
-        Assert.assertEquals(HttpStatus.OK, result.getStatusCode());
+        Assertions.assertEquals(HttpStatus.OK, result.getStatusCode());
     }
 
     @Test
@@ -110,7 +110,7 @@ public class HttpMethodRequestIT extends BaseTest {
                 .retrieve()
                 .toEntity(String.class);
 
-        Assert.assertEquals("Hello world", result.getBody());
+        Assertions.assertEquals("Hello world", result.getBody());
     }
 
     @Test
@@ -121,7 +121,7 @@ public class HttpMethodRequestIT extends BaseTest {
                 .retrieve()
                 .toEntity(String.class);
 
-        Assert.assertEquals("Hello world", result.getBody());
+        Assertions.assertEquals("Hello world", result.getBody());
     }
 
     @Test
@@ -132,7 +132,7 @@ public class HttpMethodRequestIT extends BaseTest {
                 .retrieve()
                 .toEntity(String.class);
 
-        Assert.assertEquals("Hello world", result.getBody());
+        Assertions.assertEquals("Hello world", result.getBody());
     }
 
 }

--- a/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-jaxrs/src/test/java/org/apache/dubbo/rest/demo/test/MappingRequestServiceIT.java
+++ b/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-jaxrs/src/test/java/org/apache/dubbo/rest/demo/test/MappingRequestServiceIT.java
@@ -19,8 +19,8 @@ package org.apache.dubbo.rest.demo.test;
 import org.apache.dubbo.config.annotation.DubboReference;
 import org.apache.dubbo.rest.demo.routine.MappingRequestService;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClient;
@@ -33,43 +33,43 @@ public class MappingRequestServiceIT extends BaseTest {
     @Test
     public void test() {
         String result1 = mappingRequestService.testService("world");
-        Assert.assertEquals("Hello world", result1);
+        Assertions.assertEquals("Hello world", result1);
 
         String result2 = mappingRequestService.testInterface("world");
-        Assert.assertEquals("Hello world", result2);
+        Assertions.assertEquals("Hello world", result2);
 
         String result3 = mappingRequestService.testPathOne("world");
-        Assert.assertEquals("Hello world", result3);
+        Assertions.assertEquals("Hello world", result3);
 
         int result4 = mappingRequestService.testPathInt(1);
-        Assert.assertEquals(1, result4);
+        Assertions.assertEquals(1, result4);
 
         String result5 = mappingRequestService.testPathParam("a", "b");
-        Assert.assertEquals("ab", result5);
+        Assertions.assertEquals("ab", result5);
 
         String result6 = mappingRequestService.testPathTwo("world");
-        Assert.assertEquals("Hello world", result6);
+        Assertions.assertEquals("Hello world", result6);
 
         String result7 = mappingRequestService.testPathParamTwo("a", "b");
-        Assert.assertEquals("ab", result7);
+        Assertions.assertEquals("ab", result7);
 
         String result8 = mappingRequestService.testPathZero("world");
-        Assert.assertEquals("Hello world", result8);
+        Assertions.assertEquals("Hello world", result8);
 
         String result9 = mappingRequestService.testPathAny("world");
-        Assert.assertEquals("Hello world", result9);
+        Assertions.assertEquals("Hello world", result9);
 
         String result10 = mappingRequestService.testConsumesAJ("world");
-        Assert.assertEquals("Hello world", result10);
+        Assertions.assertEquals("Hello world", result10);
 
         String result11 = mappingRequestService.testConsumesAll("world");
-        Assert.assertEquals("Hello world", result11);
+        Assertions.assertEquals("Hello world", result11);
 
         String result12 = mappingRequestService.testProducesAJ("world");
-        Assert.assertEquals("Hello world", result12);
+        Assertions.assertEquals("Hello world", result12);
 
         String result13 = mappingRequestService.testProducesAll("world");
-        Assert.assertEquals("Hello world", result13);
+        Assertions.assertEquals("Hello world", result13);
     }
 
     @Test
@@ -80,7 +80,7 @@ public class MappingRequestServiceIT extends BaseTest {
                 .accept(MediaType.TEXT_PLAIN)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("Hello world", response.getBody());
+        Assertions.assertEquals("Hello world", response.getBody());
     }
 
     @Test
@@ -91,7 +91,7 @@ public class MappingRequestServiceIT extends BaseTest {
                 .accept(MediaType.TEXT_PLAIN)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("Hello world", response.getBody());
+        Assertions.assertEquals("Hello world", response.getBody());
     }
 
     @Test
@@ -102,7 +102,7 @@ public class MappingRequestServiceIT extends BaseTest {
                 .accept(MediaType.TEXT_PLAIN)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("Hello world", response.getBody());
+        Assertions.assertEquals("Hello world", response.getBody());
     }
 
     @Test
@@ -113,7 +113,7 @@ public class MappingRequestServiceIT extends BaseTest {
                 .accept(MediaType.TEXT_PLAIN)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("Hello world", response.getBody());
+        Assertions.assertEquals("Hello world", response.getBody());
     }
 
     @Test
@@ -124,7 +124,7 @@ public class MappingRequestServiceIT extends BaseTest {
                 .accept(MediaType.TEXT_PLAIN)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("Hello world", response.getBody());
+        Assertions.assertEquals("Hello world", response.getBody());
     }
 
     @Test
@@ -135,7 +135,7 @@ public class MappingRequestServiceIT extends BaseTest {
                 .accept(MediaType.TEXT_PLAIN)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("ISN1111CHINESE", response.getBody());
+        Assertions.assertEquals("ISN1111CHINESE", response.getBody());
     }
 
     @Test
@@ -146,7 +146,7 @@ public class MappingRequestServiceIT extends BaseTest {
                 .accept(MediaType.TEXT_PLAIN)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("FG", response.getBody());
+        Assertions.assertEquals("FG", response.getBody());
     }
 
     @Test
@@ -157,7 +157,7 @@ public class MappingRequestServiceIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(Integer.class);
-        Assert.assertEquals(Integer.valueOf(1), response.getBody());
+        Assertions.assertEquals(Integer.valueOf(1), response.getBody());
     }
 
     @Test
@@ -168,7 +168,7 @@ public class MappingRequestServiceIT extends BaseTest {
                 .accept(MediaType.TEXT_PLAIN)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("Hello world", response.getBody());
+        Assertions.assertEquals("Hello world", response.getBody());
     }
 
     @Test
@@ -179,7 +179,7 @@ public class MappingRequestServiceIT extends BaseTest {
                 .accept(MediaType.TEXT_PLAIN)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("Hello world", response.getBody());
+        Assertions.assertEquals("Hello world", response.getBody());
     }
 
     @Test
@@ -190,7 +190,7 @@ public class MappingRequestServiceIT extends BaseTest {
                 .accept(MediaType.TEXT_PLAIN)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("Hello world", response.getBody());
+        Assertions.assertEquals("Hello world", response.getBody());
     }
 
     @Test
@@ -201,7 +201,7 @@ public class MappingRequestServiceIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("\"Hello world\"", response.getBody());
+        Assertions.assertEquals("\"Hello world\"", response.getBody());
     }
 
     @Test
@@ -212,7 +212,7 @@ public class MappingRequestServiceIT extends BaseTest {
                 .accept(MediaType.TEXT_PLAIN)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("Hello world", response.getBody());
+        Assertions.assertEquals("Hello world", response.getBody());
     }
 
 }

--- a/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-jaxrs/src/test/java/org/apache/dubbo/rest/demo/test/ParamTransferRequestIT.java
+++ b/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-jaxrs/src/test/java/org/apache/dubbo/rest/demo/test/ParamTransferRequestIT.java
@@ -23,8 +23,8 @@ import org.apache.dubbo.rest.demo.routine.ParamTransferRequestService;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -39,61 +39,61 @@ public class ParamTransferRequestIT extends BaseTest {
     @Test
     public void test() {
         String result1 = paramTransferRequestService.sayHello("world");
-        Assert.assertEquals("Hello world", result1);
+        Assertions.assertEquals("Hello world", result1);
 
         String result2 = paramTransferRequestService.sayForm("world");
-        Assert.assertEquals("Hello world", result2);
+        Assertions.assertEquals("Hello world", result2);
 
         String result3 = paramTransferRequestService.sayPath("1");
-        Assert.assertEquals("Hello 1", result3);
+        Assertions.assertEquals("Hello 1", result3);
 
         String result4 = paramTransferRequestService.sayHeader("world");
-        Assert.assertEquals("Hello world", result4);
+        Assertions.assertEquals("Hello world", result4);
 
         String result5 = paramTransferRequestService.sayCookie("1");
-        Assert.assertEquals("Hello 1", result5);
+        Assertions.assertEquals("Hello 1", result5);
 
         List<String> result6 = paramTransferRequestService.sayCookie(List.of("1", "2"));
-        Assert.assertEquals(List.of("1", "2"), result6);
+        Assertions.assertEquals(List.of("1", "2"), result6);
 
         Map<String, String> result7 = paramTransferRequestService.sayCookie(Map.of("c1", "c", "c2", "d"));
-        Assert.assertEquals(Map.of("c1", "c", "c2", "d"), result7);
+        Assertions.assertEquals(Map.of("c1", "c", "c2", "d"), result7);
 
         String result8 = paramTransferRequestService.sayHeader(Map.of("name", "Hello"));
-        Assert.assertEquals("Hello", result8);
+        Assertions.assertEquals("Hello", result8);
 
         String result9 = paramTransferRequestService.sayNoAnnoParam("world");
-        Assert.assertEquals("world", result9);
+        Assertions.assertEquals("world", result9);
 
         String[] result10 = paramTransferRequestService.sayNoAnnoArrayParam(new String[] {"Hello", "world"});
-        Assert.assertArrayEquals(new String[] {"Hello", "world"}, result10);
+        Assertions.assertArrayEquals(new String[] {"Hello", "world"}, result10);
 
         List<Long> result12 = paramTransferRequestService.sayList(List.of(1L, 2L, 3L));
-        Assert.assertEquals(List.of(1L, 2L, 3L), result12);
+        Assertions.assertEquals(List.of(1L, 2L, 3L), result12);
 
         List<String> result13 = paramTransferRequestService.sayNoAnnoListParam(List.of("Hello", "world"));
-        Assert.assertEquals(List.of("Hello", "world"), result13);
+        Assertions.assertEquals(List.of("Hello", "world"), result13);
 
         Map<String, String> result14 = paramTransferRequestService.sayNoAnnoStringMapParam(Map.of("a", "world", "b", "hello"));
-        Assert.assertEquals(Map.of("a", "world", "b", "hello"), result14);
+        Assertions.assertEquals(Map.of("a", "world", "b", "hello"), result14);
 
         String result15 = paramTransferRequestService.sayPath("1");
-        Assert.assertEquals("Hello 1", result15);
+        Assertions.assertEquals("Hello 1", result15);
 
         List<String> result16 = paramTransferRequestService.sayQueryList(List.of("Hello ", "world"));
-        Assert.assertEquals(List.of("Hello ", "world"), result16);
+        Assertions.assertEquals(List.of("Hello ", "world"), result16);
 
         Map<String, String> result18 = paramTransferRequestService.sayQueryMap(Map.of("a", "world", "b", "hello"));
-        Assert.assertEquals(Map.of("a", "world", "b", "hello"), result18);
+        Assertions.assertEquals(Map.of("a", "world", "b", "hello"), result18);
 
         Map<String, List<String>> result19 = paramTransferRequestService.sayQueryStringMap(Map.of("arg1", List.of("Hello", "world"), "arg2", List.of("!")));
-        Assert.assertEquals(Map.of("arg1", List.of("Hello", "world"), "arg2", List.of("!")), result19);
+        Assertions.assertEquals(Map.of("arg1", List.of("Hello", "world"), "arg2", List.of("!")), result19);
 
         Map<String, String> result20 = paramTransferRequestService.sayStringMap(Map.of("Hello", "world"));
-        Assert.assertEquals(Map.of("Hello", "world"), result20);
+        Assertions.assertEquals(Map.of("Hello", "world"), result20);
 
         User result21 = paramTransferRequestService.sayUser(new User(1L, "1", 1));
-        Assert.assertEquals(new User(1L, "1", 1), result21);
+        Assertions.assertEquals(new User(1L, "1", 1), result21);
     }
 
     @Test
@@ -103,7 +103,7 @@ public class ParamTransferRequestIT extends BaseTest {
                 .accept(MediaType.TEXT_PLAIN)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("Hello world", response.getBody());
+        Assertions.assertEquals("Hello world", response.getBody());
     }
 
     @Test
@@ -113,7 +113,7 @@ public class ParamTransferRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});
-        Assert.assertEquals(List.of("Hello ", "world"), response.getBody());
+        Assertions.assertEquals(List.of("Hello ", "world"), response.getBody());
     }
 
     @Test
@@ -123,7 +123,7 @@ public class ParamTransferRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});
-        Assert.assertEquals(Map.of("arg1", List.of("Hello", "world"), "arg2", List.of("!")), response.getBody());
+        Assertions.assertEquals(Map.of("arg1", List.of("Hello", "world"), "arg2", List.of("!")), response.getBody());
 
     }
 
@@ -134,7 +134,7 @@ public class ParamTransferRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});
-        Assert.assertEquals(Map.of("a", "world", "b", "hello"), response.getBody());
+        Assertions.assertEquals(Map.of("a", "world", "b", "hello"), response.getBody());
     }
 
     @Test
@@ -143,7 +143,7 @@ public class ParamTransferRequestIT extends BaseTest {
                 .uri(toUri("/param/noAnnoParam?name={name}"), "world")
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("world", response.getBody());
+        Assertions.assertEquals("world", response.getBody());
     }
 
     @Test
@@ -152,7 +152,7 @@ public class ParamTransferRequestIT extends BaseTest {
                 .uri(toUri("/param/noAnnoListParam?value={value}&value={value}"), "Hello ", "world")
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});
-        Assert.assertEquals(List.of("Hello ", "world"), response.getBody());
+        Assertions.assertEquals(List.of("Hello ", "world"), response.getBody());
     }
 
     @Test
@@ -162,7 +162,7 @@ public class ParamTransferRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});
-        Assert.assertArrayEquals(new String[] {"Hello", "world"}, response.getBody());
+        Assertions.assertArrayEquals(new String[] {"Hello", "world"}, response.getBody());
 
     }
 
@@ -173,7 +173,7 @@ public class ParamTransferRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});
-        Assert.assertEquals(Map.of("a", "world", "b", "hello"), response.getBody());
+        Assertions.assertEquals(Map.of("a", "world", "b", "hello"), response.getBody());
     }
 
     @Test
@@ -183,7 +183,7 @@ public class ParamTransferRequestIT extends BaseTest {
                 .accept(MediaType.TEXT_PLAIN)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("Hello 1", response.getBody());
+        Assertions.assertEquals("Hello 1", response.getBody());
     }
 
     @Test
@@ -196,7 +196,7 @@ public class ParamTransferRequestIT extends BaseTest {
                 .body(map)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("Hello world", response.getBody());
+        Assertions.assertEquals("Hello world", response.getBody());
 
     }
 
@@ -208,7 +208,7 @@ public class ParamTransferRequestIT extends BaseTest {
                 .header("name", "world")
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("Hello world", response.getBody());
+        Assertions.assertEquals("Hello world", response.getBody());
     }
 
     @Test
@@ -218,7 +218,7 @@ public class ParamTransferRequestIT extends BaseTest {
                 .header("name", "Hello")
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("Hello", response.getBody());
+        Assertions.assertEquals("Hello", response.getBody());
     }
 
     @Test
@@ -229,7 +229,7 @@ public class ParamTransferRequestIT extends BaseTest {
                 .header("Cookie", "cookieId=1")
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("Hello 1", response.getBody());
+        Assertions.assertEquals("Hello 1", response.getBody());
     }
 
     @Test
@@ -239,7 +239,7 @@ public class ParamTransferRequestIT extends BaseTest {
                 .header("Cookie", "cookieId=1")
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});
-        Assert.assertEquals(List.of("1"), response.getBody());
+        Assertions.assertEquals(List.of("1"), response.getBody());
     }
 
     @Test
@@ -249,7 +249,7 @@ public class ParamTransferRequestIT extends BaseTest {
                 .header("Cookie", "c1=c")
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});
-        Assert.assertEquals(Map.of("c1", "c"), response.getBody());
+        Assertions.assertEquals(Map.of("c1", "c"), response.getBody());
     }
 
     @Test
@@ -259,7 +259,7 @@ public class ParamTransferRequestIT extends BaseTest {
                 .accept(MediaType.TEXT_PLAIN)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("Hello world", result.getBody());
+        Assertions.assertEquals("Hello world", result.getBody());
     }
 
     @Test
@@ -269,7 +269,7 @@ public class ParamTransferRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});
-        Assert.assertEquals(List.of("Hello", "world"), result.getBody());
+        Assertions.assertEquals(List.of("Hello", "world"), result.getBody());
     }
 
     @Test
@@ -279,7 +279,7 @@ public class ParamTransferRequestIT extends BaseTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("{\"name\":[\"world\"]}", result.getBody());
+        Assertions.assertEquals("{\"name\":[\"world\"]}", result.getBody());
     }
 
     @Test
@@ -290,7 +290,7 @@ public class ParamTransferRequestIT extends BaseTest {
                 .body(new User(1L, "1", 1))
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});
-        Assert.assertEquals(new User(1L, "1", 1), response.getBody());
+        Assertions.assertEquals(new User(1L, "1", 1), response.getBody());
     }
 
     @Test
@@ -301,7 +301,7 @@ public class ParamTransferRequestIT extends BaseTest {
                 .body(List.of(1L, 2L, 3L))
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});
-        Assert.assertEquals(List.of(1L, 2L, 3L), response.getBody());
+        Assertions.assertEquals(List.of(1L, 2L, 3L), response.getBody());
     }
 
     @Test
@@ -312,7 +312,7 @@ public class ParamTransferRequestIT extends BaseTest {
                 .body(Map.of("Hello", "world"))
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});
-        Assert.assertEquals(Map.of("Hello", "world"), response.getBody());
+        Assertions.assertEquals(Map.of("Hello", "world"), response.getBody());
     }
 
     @Test
@@ -323,7 +323,7 @@ public class ParamTransferRequestIT extends BaseTest {
                 .header("name", "Hello world")
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("Hello world", result.getBody());
+        Assertions.assertEquals("Hello world", result.getBody());
     }
 
     @Test
@@ -333,7 +333,7 @@ public class ParamTransferRequestIT extends BaseTest {
                 .accept(MediaType.TEXT_PLAIN)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("GET", result.getBody());
+        Assertions.assertEquals("GET", result.getBody());
     }
 
     @Test
@@ -343,6 +343,6 @@ public class ParamTransferRequestIT extends BaseTest {
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("world", result.getBody());
+        Assertions.assertEquals("world", result.getBody());
     }
 }

--- a/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-openapi-basic/src/test/java/org/apache/dubbo/rest/demo/test/ConsumerIT.java
+++ b/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-openapi-basic/src/test/java/org/apache/dubbo/rest/demo/test/ConsumerIT.java
@@ -19,8 +19,8 @@ package org.apache.dubbo.rest.demo.test;
 
 import org.apache.dubbo.config.annotation.DubboReference;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.web.client.RestClient;
 
@@ -44,8 +44,8 @@ public class ConsumerIT {
                 retrieve().
                 body(String.class);
         System.out.println(result);
-        Assert.assertNotNull("OpenAPI documentation response should not be null", result);
-        Assert.assertTrue(result.contains("/org.apache.dubbo.rest.demo.DemoService/hello"));
-        Assert.assertTrue(result.contains("/org.apache.dubbo.rest.demo.DemoService/helloUser"));
+        Assertions.assertNotNull("OpenAPI documentation response should not be null", result);
+        Assertions.assertTrue(result.contains("/org.apache.dubbo.rest.demo.DemoService/hello"));
+        Assertions.assertTrue(result.contains("/org.apache.dubbo.rest.demo.DemoService/helloUser"));
     }
 }

--- a/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-openapi-basic/src/test/java/org/apache/dubbo/rest/demo/test/ConsumerIT.java
+++ b/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-openapi-basic/src/test/java/org/apache/dubbo/rest/demo/test/ConsumerIT.java
@@ -17,21 +17,21 @@
 
 package org.apache.dubbo.rest.demo.test;
 
-import org.apache.dubbo.config.annotation.DubboReference;
+import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.client.RestClient;
 
 
-@SpringBootTest
+@EnableDubbo
+@ExtendWith(SpringExtension.class)
 public class ConsumerIT {
 
     private static final String HOST = System.getProperty("dubbo.address", "localhost");
     private final RestClient webClient = RestClient.create();
-
-    @DubboReference(url = "tri://${dubbo.address:localhost}:50052")
 
     private static String toUri(String path) {
         return "http://" + HOST + ":50052/" + path;

--- a/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-spring-security/spring-security-resource-server/src/test/java/ResourceServerIT.java
+++ b/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-spring-security/spring-security-resource-server/src/test/java/ResourceServerIT.java
@@ -21,12 +21,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
 
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 
@@ -35,7 +35,7 @@ import java.util.Base64;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @EnableDubbo
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class ResourceServerIT {
 
     //    @LocalServerPort
@@ -51,48 +51,48 @@ public class ResourceServerIT {
     private static final String HOST = System.getProperty("resource.address", "localhost");
 
     @Test
-        public void testGetUserEndpoint() {
-            String credentials = clientId + ":" + clientSecret;
-            String encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes());
+    public void testGetUserEndpoint() {
+        String credentials = clientId + ":" + clientSecret;
+        String encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes());
 
-            // build RestClient request
-            RestClient restClient = RestClient.builder().build();
-            String url = "http://"+ OAUTH2HOST + ":9000/oauth2/token";
+        // build RestClient request
+        RestClient restClient = RestClient.builder().build();
+        String url = "http://"+ OAUTH2HOST + ":9000/oauth2/token";
 
+        try {
+            // make a post request
+            String response = restClient.post()
+                    .uri(url)
+                    .header(HttpHeaders.AUTHORIZATION, "Basic " + encodedCredentials)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                    .body("grant_type=client_credentials&scope=read")
+                    .retrieve()
+                    .body(String.class);
+
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode jsonNode = objectMapper.readTree(response);
+            String accessToken = jsonNode.get("access_token").asText();
+
+            // Use the access token to authenticate the request to the /user endpoint
+            assert accessToken != null;
+            String userUrl = "http://" + HOST + ":50051/hello/sayHello/World";
             try {
-                // make a post request
-                String response = restClient.post()
-                        .uri(url)
-                        .header(HttpHeaders.AUTHORIZATION, "Basic " + encodedCredentials)
-                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-                        .body("grant_type=client_credentials&scope=read")
+                String userResponse = restClient.get()
+                        .uri(userUrl)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                         .retrieve()
                         .body(String.class);
 
-                ObjectMapper objectMapper = new ObjectMapper();
-                JsonNode jsonNode = objectMapper.readTree(response);
-                String accessToken = jsonNode.get("access_token").asText();
-
-                // Use the access token to authenticate the request to the /user endpoint
-                assert accessToken != null;
-                String userUrl = "http://" + HOST + ":50051/hello/sayHello/World";
-                try {
-                    String userResponse = restClient.get()
-                            .uri(userUrl)
-                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-                            .retrieve()
-                            .body(String.class);
-
-                    assertEquals("\"Hello, World\"", userResponse, "error");
-                } catch (RestClientResponseException e) {
-                    System.err.println("Error Response: " + e.getResponseBodyAsString());
-                    Assertions.fail("Request failed with response: " + e.getResponseBodyAsString());
-                }
-
-            } catch (JsonProcessingException e) {
-                throw new RuntimeException(e);
+                assertEquals("\"Hello, World\"", userResponse, "error");
+            } catch (RestClientResponseException e) {
+                System.err.println("Error Response: " + e.getResponseBodyAsString());
+                Assertions.fail("Request failed with response: " + e.getResponseBodyAsString());
             }
+
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
         }
+    }
 
     @Test
     public void testGetUserEndpointWithInvalidToken() {

--- a/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-springmvc/src/test/java/org/apache/dubbo/rest/demo/test/BaseTest.java
+++ b/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-springmvc/src/test/java/org/apache/dubbo/rest/demo/test/BaseTest.java
@@ -19,12 +19,13 @@ package org.apache.dubbo.rest.demo.test;
 
 import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
 
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.RestClient;
 
 @EnableDubbo
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public abstract class BaseTest {
 
     protected static final String HOST = System.getProperty("dubbo.address", "localhost");

--- a/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-springmvc/src/test/java/org/apache/dubbo/rest/demo/test/ConsumerIT.java
+++ b/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-springmvc/src/test/java/org/apache/dubbo/rest/demo/test/ConsumerIT.java
@@ -26,8 +26,8 @@ import java.util.LinkedList;
 import java.util.List;
 
 import com.alibaba.fastjson2.JSON;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.MediaType;
@@ -49,7 +49,7 @@ public class ConsumerIT extends BaseTest {
     public void getParam() {
         String id = "123";
         String res = demoService.getParam(id);
-        Assert.assertEquals(PREFIX + id, res);
+        Assertions.assertEquals(PREFIX + id, res);
     }
 
     @Test
@@ -61,14 +61,14 @@ public class ConsumerIT extends BaseTest {
                 .retrieve()
                 .toEntity(String.class);
 
-        Assert.assertEquals("\"" + PREFIX + id + "\"", responseEntity.getBody());
+        Assertions.assertEquals("\"" + PREFIX + id + "\"", responseEntity.getBody());
     }
 
     @Test
     public void getVariable() {
         String id = "123";
         String res = demoService.getVariable(id);
-        Assert.assertEquals(PREFIX + id, res);
+        Assertions.assertEquals(PREFIX + id, res);
     }
 
     @Test
@@ -80,14 +80,14 @@ public class ConsumerIT extends BaseTest {
                 .retrieve()
                 .toEntity(String.class);
 
-        Assert.assertEquals("\"" + PREFIX + id + "\"", responseEntity.getBody());
+        Assertions.assertEquals("\"" + PREFIX + id + "\"", responseEntity.getBody());
     }
 
     @Test
     public void getMuchParam() {
         String id = "123", name = "test";
         String res = demoService.getMuchParam(id, name);
-        Assert.assertEquals(PREFIX + id + " " + name, res);
+        Assertions.assertEquals(PREFIX + id + " " + name, res);
     }
 
     @Test
@@ -99,14 +99,14 @@ public class ConsumerIT extends BaseTest {
                 .retrieve()
                 .toEntity(String.class);
 
-        Assert.assertEquals("\"" + PREFIX + id + " " + name + "\"", responseEntity.getBody());
+        Assertions.assertEquals("\"" + PREFIX + id + " " + name + "\"", responseEntity.getBody());
     }
 
     @Test
     public void getMuchVariable() {
         String id = "123", name = "test";
         String res = demoService.getMuchVariable(id, name);
-        Assert.assertEquals(PREFIX + id + " " + name, res);
+        Assertions.assertEquals(PREFIX + id + " " + name, res);
     }
 
     @Test
@@ -118,14 +118,14 @@ public class ConsumerIT extends BaseTest {
                 .retrieve()
                 .toEntity(String.class);
 
-        Assert.assertEquals("\"" + PREFIX + id + " " + name + "\"", responseEntity.getBody());
+        Assertions.assertEquals("\"" + PREFIX + id + " " + name + "\"", responseEntity.getBody());
     }
 
     @Test
     public void getReg() {
         String name = "test", version = "2.2.1", ext = ".txt";
         String res = demoService.getReg(name, version, ext);
-        Assert.assertEquals(PREFIX + name + " " + version + " " + ext, res);
+        Assertions.assertEquals(PREFIX + name + " " + version + " " + ext, res);
     }
 
     @Test
@@ -138,7 +138,7 @@ public class ConsumerIT extends BaseTest {
                 .toEntity(String.class);
 
         // 因为已经解析了json 那么不需要再变成json格式了
-        Assert.assertEquals(PREFIX + name + " " + version + " " + ext, responseEntity.getBody());
+        Assertions.assertEquals(PREFIX + name + " " + version + " " + ext, responseEntity.getBody());
     }
 
     @Test
@@ -146,7 +146,7 @@ public class ConsumerIT extends BaseTest {
         String name = "123";
         String requestBody = "{\"name\": \"" + name + "\"}";
         String res = demoService.postBody(requestBody);
-        Assert.assertEquals(PREFIX + name, res);
+        Assertions.assertEquals(PREFIX + name, res);
     }
 
     @Test
@@ -160,14 +160,14 @@ public class ConsumerIT extends BaseTest {
                 .retrieve()
                 .toEntity(String.class);
 
-        Assert.assertEquals("\"" + PREFIX + name + "\"", responseEntity.getBody());
+        Assertions.assertEquals("\"" + PREFIX + name + "\"", responseEntity.getBody());
     }
 
     @Test
     public void postParam() {
         String name = "123";
         String res = demoService.postParam(name);
-        Assert.assertEquals(PREFIX + name, res);
+        Assertions.assertEquals(PREFIX + name, res);
     }
 
     @Test
@@ -179,14 +179,14 @@ public class ConsumerIT extends BaseTest {
                 .retrieve()
                 .toEntity(String.class);
 
-        Assert.assertEquals("\"" + PREFIX + id + "\"", responseEntity.getBody());
+        Assertions.assertEquals("\"" + PREFIX + id + "\"", responseEntity.getBody());
     }
 
     @Test
     public void postVariable() {
         String name = "123";
         String res = demoService.postVariable(name);
-        Assert.assertEquals(PREFIX + name, res);
+        Assertions.assertEquals(PREFIX + name, res);
     }
 
     @Test
@@ -198,7 +198,7 @@ public class ConsumerIT extends BaseTest {
                 .retrieve()
                 .toEntity(String.class);
 
-        Assert.assertEquals("\"" + PREFIX + id + "\"", responseEntity.getBody());
+        Assertions.assertEquals("\"" + PREFIX + id + "\"", responseEntity.getBody());
     }
 
     @Test
@@ -206,7 +206,7 @@ public class ConsumerIT extends BaseTest {
         String id = "123";
         String requestBody = "{\"id\": \"" + id + "\"}";
         String res = demoService.postUseConsumes(requestBody);
-        Assert.assertEquals(PREFIX + id, res);
+        Assertions.assertEquals(PREFIX + id, res);
     }
 
     @Test
@@ -220,7 +220,7 @@ public class ConsumerIT extends BaseTest {
                 .retrieve()
                 .toEntity(String.class);
 
-        Assert.assertEquals("\"" + PREFIX + id + "\"", responseEntity.getBody());
+        Assertions.assertEquals("\"" + PREFIX + id + "\"", responseEntity.getBody());
     }
 
     @Test
@@ -228,7 +228,7 @@ public class ConsumerIT extends BaseTest {
         String id = "123";
         String requestBody = "{\"id\":\"" + id + "\"}";
         String res = demoService.postUseParams(requestBody);
-        Assert.assertEquals(PREFIX + id, res);
+        Assertions.assertEquals(PREFIX + id, res);
     }
 
     @Test
@@ -242,14 +242,14 @@ public class ConsumerIT extends BaseTest {
                 .retrieve()
                 .toEntity(String.class);
 
-        Assert.assertEquals("\"" + PREFIX + id + "\"", responseEntity.getBody());
+        Assertions.assertEquals("\"" + PREFIX + id + "\"", responseEntity.getBody());
     }
 
     @Test
     public void getHead() {
         String id = "123";
         String res = demoService.getHead(id);
-        Assert.assertEquals(PREFIX + id, res);
+        Assertions.assertEquals(PREFIX + id, res);
     }
 
     @Test
@@ -262,7 +262,7 @@ public class ConsumerIT extends BaseTest {
                 .retrieve()
                 .toEntity(String.class);
 
-        Assert.assertEquals("\"" + PREFIX + id + "\"", responseEntity.getBody());
+        Assertions.assertEquals("\"" + PREFIX + id + "\"", responseEntity.getBody());
     }
 
     @Test
@@ -280,7 +280,7 @@ public class ConsumerIT extends BaseTest {
                 .retrieve()
                 .toEntity(String.class);
 
-        Assert.assertEquals("\"" + PREFIX + id + " " + name + "\"", responseEntity.getBody());
+        Assertions.assertEquals("\"" + PREFIX + id + " " + name + "\"", responseEntity.getBody());
     }
 
     @Test
@@ -291,7 +291,7 @@ public class ConsumerIT extends BaseTest {
 
         String json = JSON.toJSONString(map);
 
-        Assert.assertEquals(PREFIX + "123" + " 456", demoService.postMapUser(json));
+        Assertions.assertEquals(PREFIX + "123" + " 456", demoService.postMapUser(json));
     }
 
     // 出现问题
@@ -310,13 +310,13 @@ public class ConsumerIT extends BaseTest {
                 .retrieve()
                 .toEntity(String.class);
 
-        Assert.assertEquals("\"" + PREFIX + "123" + " 456" + "\"", responseEntity.getBody());
+        Assertions.assertEquals("\"" + PREFIX + "123" + " 456" + "\"", responseEntity.getBody());
     }
 
     @Test
     public void putUpdateId() {
         String id = "123";
-        Assert.assertEquals(PREFIX + id, demoService.putUpdateId(id));
+        Assertions.assertEquals(PREFIX + id, demoService.putUpdateId(id));
     }
 
     @Test
@@ -326,13 +326,13 @@ public class ConsumerIT extends BaseTest {
                 .uri(toUri("/demo/put/update/{id}"), id)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("\"" + PREFIX + id + "\"", response.getBody());
+        Assertions.assertEquals("\"" + PREFIX + id + "\"", response.getBody());
     }
 
     @Test
     public void deleteId() {
         String id = "123";
-        Assert.assertEquals(PREFIX + id, demoService.deleteId(id));
+        Assertions.assertEquals(PREFIX + id, demoService.deleteId(id));
     }
 
     @Test
@@ -343,13 +343,13 @@ public class ConsumerIT extends BaseTest {
                 .uri(toUri("/demo/delete/{id}"), id)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("\"" + PREFIX + id + "\"", response.getBody());
+        Assertions.assertEquals("\"" + PREFIX + id + "\"", response.getBody());
     }
 
     @Test
     public void patchById() {
         String id = "123";
-        Assert.assertEquals(PREFIX + id + " jack", demoService.patchById(id, new User(123L, "jack").stringToJson()));
+        Assertions.assertEquals(PREFIX + id + " jack", demoService.patchById(id, new User(123L, "jack").stringToJson()));
     }
 
     @Test
@@ -363,24 +363,24 @@ public class ConsumerIT extends BaseTest {
                 .body(requestBody)
                 .retrieve()
                 .toEntity(String.class);
-        Assert.assertEquals("\"" + PREFIX + id + " jack" + "\"", response.getBody());
+        Assertions.assertEquals("\"" + PREFIX + id + " jack" + "\"", response.getBody());
     }
 
     @Test
     public void primitive() {
-        Assert.assertEquals(1 + 2, demoService.primitiveInt(1, 2));
+        Assertions.assertEquals(1 + 2, demoService.primitiveInt(1, 2));
 
-        Assert.assertEquals(1L + 2L, demoService.primitiveLong(1L, 2L));
+        Assertions.assertEquals(1L + 2L, demoService.primitiveLong(1L, 2L));
 
-        Assert.assertEquals(1 + 2L, demoService.primitiveByte((byte) 1, 2L));
+        Assertions.assertEquals(1 + 2L, demoService.primitiveByte((byte) 1, 2L));
 
-        Assert.assertEquals(3L, demoService.primitiveShort((short) 1, 2L, 1));
+        Assertions.assertEquals(3L, demoService.primitiveShort((short) 1, 2L, 1));
     }
 
     @Test
     public void filterGet() {
         String name = "123";
-        Assert.assertEquals(name, filterService.filterGet(name));
+        Assertions.assertEquals(name, filterService.filterGet(name));
     }
 
     @Test
@@ -392,7 +392,7 @@ public class ConsumerIT extends BaseTest {
                 .retrieve()
                 .toEntity(String.class);
 
-        Assert.assertEquals(name, response.getBody());
+        Assertions.assertEquals(name, response.getBody());
     }
 
     @Test
@@ -401,7 +401,7 @@ public class ConsumerIT extends BaseTest {
         userList.add(new User(123L, "jack"));
         userList.add(new User(345L, "mack"));
 
-        Assert.assertEquals(userList, demoService.postList(userList));
+        Assertions.assertEquals(userList, demoService.postList(userList));
     }
 
     @Test
@@ -417,7 +417,7 @@ public class ConsumerIT extends BaseTest {
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});
 
-        Assert.assertEquals(userList, response.getBody());
+        Assertions.assertEquals(userList, response.getBody());
     }
 
 }

--- a/2-advanced/dubbo-samples-triple-rest/pom.xml
+++ b/2-advanced/dubbo-samples-triple-rest/pom.xml
@@ -85,14 +85,6 @@
     </dependencies>
   </dependencyManagement>
 
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
-
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
1. ```JUnit4``` at triple rest cases should be replaced by ```JUnit5```, otherwise running ```mvn verify``` with ```maven-failsafe-plugin``` and JDK17+ (needed by Triple rest compilation) will get ```Test run: 0``` result.
2. Fix ConsumerIT.java of dubbo-samples-triple-rest-openapi-basic to avoid the test case trying to connect local zookeeper service.