### PR TITLE
Add os-maven-plugin to maven extensions of dubbo-samples-triple-http3

### DIFF
--- a/2-advanced/dubbo-samples-triple-http3/case-versions.conf
+++ b/2-advanced/dubbo-samples-triple-http3/case-versions.conf
@@ -19,6 +19,6 @@
 
 # Spring app
 # because https://github.com/netty/netty/issues/15306 disabled
-dubbo.version=[>3.4]
+dubbo.version=[ >= 3.3.6 ]
 spring.version=6.*
 java.version= [>= 17]

--- a/2-advanced/dubbo-samples-triple-http3/pom.xml
+++ b/2-advanced/dubbo-samples-triple-http3/pom.xml
@@ -152,6 +152,7 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- add os-maven-plugin to plugins just for Eclipse m2e, not for `mvn install` -->
             <plugin>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
@@ -183,6 +184,14 @@
                 </executions>
             </plugin>
         </plugins>
+        <extensions>
+          <!-- add os-maven-plugin to extensions for `mvn install` -->
+          <extension>
+            <groupId>kr.motd.maven</groupId>
+            <artifactId>os-maven-plugin</artifactId>
+            <version>${maven_os_plugin_version}</version>
+          </extension>
+        </extensions>
     </build>
 
     <repositories>


### PR DESCRIPTION
detect OS type for netty-codec-http3 during ```mvn install``` because the native quic classifier of netty-codec-http3 4.2.2.Final is defined by ```${os.detected.name}-${os.detected.arch}```