### PR TITLE
Build test image with mirrors.aliyun.com

### DIFF
--- a/test/build-test-image.sh
+++ b/test/build-test-image.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-# Use mirror:
-# DEBIAN_MIRROR=http://mirrors.aliyun.com ./build-test-image.sh
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-$DIR/dubbo-test-runner/build.sh
+# Use mirror:
+# DEBIAN_MIRROR=http://mirrors.aliyun.com $DIR/dubbo-test-runner/build.sh
+# No mirror:
+# $DIR/dubbo-test-runner/build.sh
+
+DEBIAN_MIRROR=http://mirrors.aliyun.com $DIR/dubbo-test-runner/build.sh
 
 $DIR/build-nacos-image.sh


### PR DESCRIPTION
because it seemed that ```deb.debian.org``` removed ubuntun release file.
```
#8 [3/5] RUN apt-get update &&   apt-get install -y telnet &&   rm -rf /var/lib/apt/lists/*
#8 0.190 Ign:1 http://deb.debian.org/debian buster InRelease
#8 0.200 Get:2 http://deb.debian.org/debian-security buster/updates InRelease [34.8 kB]
#8 0.209 Ign:3 http://deb.debian.org/debian buster-updates InRelease
#8 0.212 Err:4 http://deb.debian.org/debian buster Release
#8 0.212   404  Not Found [IP: 199.232.98.132 80]
#8 0.214 Err:5 http://deb.debian.org/debian buster-updates Release
#8 0.214   404  Not Found [IP: 199.232.98.132 80]
```