### PR TITLE
Set debian mirror to debian-archive for buster version that associate with current ubuntu-latest github-action

### DIFF
--- a/.github/workflows/dubbo-3_2.yml
+++ b/.github/workflows/dubbo-3_2.yml
@@ -211,7 +211,7 @@ jobs:
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: Build test image
         run: |
-          cd test && bash ./build-test-image.sh
+          cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
       - name: Run tests
         run: cd test && bash ./run-tests.sh
       - name: Upload test result

--- a/.github/workflows/dubbo-3_3.yml
+++ b/.github/workflows/dubbo-3_3.yml
@@ -203,7 +203,7 @@ jobs:
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: Build test image
         run: |
-          cd test && bash ./build-test-image.sh
+          cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
       - name: Run tests
         run: cd test && bash ./run-tests.sh
       - name: Upload test result

--- a/.github/workflows/nightly-dubbo-3.yml
+++ b/.github/workflows/nightly-dubbo-3.yml
@@ -165,7 +165,7 @@ jobs:
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: Build test image
         run: |
-          cd test && bash ./build-test-image.sh
+          cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
       - name: Run tests
         run: cd test && bash ./run-tests.sh
       - name: Upload test result


### PR DESCRIPTION
The buster version that current github docker building action ```ubuntu-latest``` used had been taken from Debian main site to the archive site since July 12, 2025.