### PR TITLE
fix: standardize QoS configuration value in hystrix sample

### DIFF
--- a/4-governance/dubbo-samples-spring-hystrix/src/main/resources/spring/hystrix-dubbo-provider.properties
+++ b/4-governance/dubbo-samples-spring-hystrix/src/main/resources/spring/hystrix-dubbo-provider.properties
@@ -17,7 +17,7 @@
 #
 #
 dubbo.application.name=hystrix-annotation-provider
-dubbo.application.qos.enable=disable
+dubbo.application.qos.enable=false
 dubbo.registry.address=zookeeper://${zookeeper.address:127.0.0.1}:2181
 dubbo.protocol.name=dubbo
 dubbo.protocol.port=20885


### PR DESCRIPTION
Replace non-standard QoS configuration value 'disable' with standard boolean value 'false' in hystrix sample.
This change aligns with Dubbo's configuration best practices while maintaining the same functionality.