### PR TITLE
[test] Fix typos in log messages

### DIFF
--- a/2-advanced/dubbo-samples-service-discovery/dubbo-servicediscovery-migration/dubbo-servicediscovery-migration-consumer/src/main/java/org/apache/dubbo/demo/consumer/Application.java
+++ b/2-advanced/dubbo-samples-service-discovery/dubbo-servicediscovery-migration/dubbo-servicediscovery-migration-consumer/src/main/java/org/apache/dubbo/demo/consumer/Application.java
@@ -42,7 +42,7 @@ public class Application implements CommandLineRunner {
 
     @Override
     public void run(String... args) {
-        System.out.println("demoServiceFromDual reponse ===>  "+demoServiceFromDual.sayHello("123"));
+        System.out.println("demoServiceFromDual response ===>  "+demoServiceFromDual.sayHello("123"));
         System.out.println("demoServiceFromService response ===> " +demoServiceFromService.sayHello("456"));
         System.out.println("demoServiceFromNormal response ===> "+demoServiceFromNormal.sayHello("000"));
     }

--- a/2-advanced/dubbo-samples-tengine/dubbo-samples-tengine-provider/src/main/java/org/apache/dubbo/samples/tengine/provider/DemoServiceImpl.java
+++ b/2-advanced/dubbo-samples-tengine/dubbo-samples-tengine-provider/src/main/java/org/apache/dubbo/samples/tengine/provider/DemoServiceImpl.java
@@ -78,7 +78,7 @@ public class DemoServiceImpl implements DemoService {
                 System.out.println("dubbo test: status empty");
                 ret.put("body", "dubbo failed");
             } else {
-                System.out.println("dubbo test: unkown test");
+                System.out.println("dubbo test: unknown test");
             }
 
             return ret;
@@ -203,7 +203,7 @@ public class DemoServiceImpl implements DemoService {
                 System.out.println("dubbo test: status empty");
                 ret.put("body", "dubbo failed");
             } else {
-                System.out.println("dubbo test: unkown test");
+                System.out.println("dubbo test: unknown test");
             }
 
             return ret;


### PR DESCRIPTION
Fix spelling mistakes in log messages:
1. Fix typo in Application.java:
   - reponse -> response in log message
   ```java
   System.out.println("demoServiceFromDual reponse ===>  "+...)
   ```
   -> 
   ```java
   System.out.println("demoServiceFromDual response ===>  "+...)
   ```

2. Fix typo in DemoServiceImpl.java:
   - unkown -> unknown in log messages (2 places)
   ```java
   System.out.println("dubbo test: unkown test");
   ```
   -> 
   ```java
   System.out.println("dubbo test: unknown test");
   ```

## What is the purpose of the change?

Fix typos in log messages to improve code readability and maintain consistent spelling across the codebase. These changes are similar to other typo fixes in the project and only affect test code and log messages.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo-samples/issues) field for the change (not applicable - simple typo fixes)
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure GitHub actions can pass.