### PR TITLE
fix(samples): ensure MetricsConfig is present for metrics-related samples

### DIFF
--- a/4-governance/dubbo-samples-metrics-prometheus/dubbo-samples-metrics-prometheus-consumer/src/main/resources/dubbo-demo-consumer.xml
+++ b/4-governance/dubbo-samples-metrics-prometheus/dubbo-samples-metrics-prometheus-consumer/src/main/resources/dubbo-demo-consumer.xml
@@ -30,7 +30,7 @@
     <dubbo:config-center address="zookeeper://${zookeeper.address:127.0.0.1}:2181" />
     <dubbo:metadata-report address="zookeeper://${zookeeper.address:127.0.0.1}:2181" />
 
-    <dubbo:metrics protocol="prometheus" enable-jvm="false">
+    <dubbo:metrics protocol="prometheus" enable-jvm="false" enabled="true">
         <dubbo:histogram enabled="true"/>
     </dubbo:metrics>
 

--- a/4-governance/dubbo-samples-metrics-prometheus/dubbo-samples-metrics-prometheus-provider/src/main/resources/dubbo-demo-provider.xml
+++ b/4-governance/dubbo-samples-metrics-prometheus/dubbo-samples-metrics-prometheus-provider/src/main/resources/dubbo-demo-provider.xml
@@ -30,7 +30,7 @@
     <dubbo:config-center address="zookeeper://${zookeeper.address:127.0.0.1}:2181" />
     <dubbo:metadata-report address="zookeeper://${zookeeper.address:127.0.0.1}:2181" />
 
-    <dubbo:metrics protocol="prometheus" enable-jvm="false" >
+    <dubbo:metrics protocol="prometheus" enable-jvm="false" enabled="true" >
         <dubbo:histogram enabled="true"/>
     </dubbo:metrics>
 

--- a/4-governance/dubbo-samples-metrics-spring-boot/src/main/resources/application.yaml
+++ b/4-governance/dubbo-samples-metrics-spring-boot/src/main/resources/application.yaml
@@ -32,4 +32,5 @@ dubbo:
     address: zookeeper://${ZOOKEEPER_ADDRESS:127.0.0.1}:2181
   metrics:
     protocol: prometheus
+    enable: true
     # enable-jvm-metrics: true


### PR DESCRIPTION
## Problem Description
Fix the issue where metrics logs were not being printed normally in Dubbo samples due to missing or incomplete MetricsConfig. Previously, samples would output `[DUBBO] The MetricsConfig not exist, will not export metrics service.`

## Changes Made
- Add or fix MetricsConfig configuration in metrics-spring-boot and metrics-prometheus samples
- Ensure metrics service is properly enabled and protocol is set where required
- Only modify samples that previously output the MetricsConfig missing warning

## Files Modified
- `4-governance/dubbo-samples-metrics-spring-boot/src/main/resources/application.yaml`
- `4-governance/dubbo-samples-metrics-prometheus/dubbo-samples-metrics-prometheus-provider/src/main/resources/dubbo-demo-provider.xml`
- `4-governance/dubbo-samples-metrics-prometheus/dubbo-samples-metrics-prometheus-consumer/src/main/resources/dubbo-demo-consumer.xml`

## Technical Details
- Added `enable: true` to Dubbo metrics configuration in Spring Boot sample
- Added `enabled="true"` attribute to `<dubbo:metrics ...>` in XML-based prometheus samples
- Followed Dubbo community coding and commit standards

## Related Issue
Related to apache/dubbo#15473