### PR TITLE
fix(samples): add missing case-runtime-parameter.conf files for governance samples

### DIFF
--- a/4-governance/dubbo-samples-applevel-override/case-runtime-parameter.conf
+++ b/4-governance/dubbo-samples-applevel-override/case-runtime-parameter.conf
@@ -1,0 +1,20 @@
+#
+#
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+-Ddubbo.protocol.name=dubbo -Ddubbo.protocol.serialization=hessian2
+

--- a/4-governance/dubbo-samples-conditionrouterv31/case-runtime-parameter.conf
+++ b/4-governance/dubbo-samples-conditionrouterv31/case-runtime-parameter.conf
@@ -1,0 +1,20 @@
+#
+#
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+-Ddubbo.protocol.name=dubbo -Ddubbo.protocol.serialization=hessian2
+

--- a/4-governance/dubbo-samples-configconditionrouter/case-runtime-parameter.conf
+++ b/4-governance/dubbo-samples-configconditionrouter/case-runtime-parameter.conf
@@ -1,0 +1,20 @@
+#
+#
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+-Ddubbo.protocol.name=dubbo -Ddubbo.protocol.serialization=hessian2
+

--- a/4-governance/dubbo-samples-metrics-prometheus/case-runtime-parameter.conf
+++ b/4-governance/dubbo-samples-metrics-prometheus/case-runtime-parameter.conf
@@ -1,0 +1,20 @@
+#
+#
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+-Ddubbo.protocol.name=dubbo -Ddubbo.protocol.serialization=hessian2
+

--- a/4-governance/dubbo-samples-metrics-spring-boot/case-runtime-parameter.conf
+++ b/4-governance/dubbo-samples-metrics-spring-boot/case-runtime-parameter.conf
@@ -1,0 +1,20 @@
+#
+#
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+-Ddubbo.protocol.name=dubbo -Ddubbo.protocol.serialization=hessian2
+

--- a/4-governance/dubbo-samples-sentinel/case-runtime-parameter.conf
+++ b/4-governance/dubbo-samples-sentinel/case-runtime-parameter.conf
@@ -1,0 +1,20 @@
+#
+#
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+-Ddubbo.protocol.name=dubbo -Ddubbo.protocol.serialization=hessian2
+

--- a/4-governance/dubbo-samples-servicelevel-override/case-runtime-parameter.conf
+++ b/4-governance/dubbo-samples-servicelevel-override/case-runtime-parameter.conf
@@ -1,0 +1,20 @@
+#
+#
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+-Ddubbo.protocol.name=dubbo -Ddubbo.protocol.serialization=hessian2
+

--- a/4-governance/dubbo-samples-spring-boot-hystrix/case-runtime-parameter.conf
+++ b/4-governance/dubbo-samples-spring-boot-hystrix/case-runtime-parameter.conf
@@ -1,0 +1,20 @@
+#
+#
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+-Ddubbo.protocol.name=dubbo -Ddubbo.protocol.serialization=hessian2
+

--- a/4-governance/dubbo-samples-spring-hystrix/case-runtime-parameter.conf
+++ b/4-governance/dubbo-samples-spring-hystrix/case-runtime-parameter.conf
@@ -1,0 +1,20 @@
+#
+#
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+-Ddubbo.protocol.name=dubbo -Ddubbo.protocol.serialization=hessian2
+

--- a/4-governance/dubbo-samples-ssl/case-runtime-parameter.conf
+++ b/4-governance/dubbo-samples-ssl/case-runtime-parameter.conf
@@ -1,0 +1,20 @@
+#
+#
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+-Ddubbo.protocol.name=dubbo -Ddubbo.protocol.serialization=hessian2
+

--- a/4-governance/dubbo-samples-tagrouter/case-runtime-parameter.conf
+++ b/4-governance/dubbo-samples-tagrouter/case-runtime-parameter.conf
@@ -1,0 +1,20 @@
+#
+#
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+-Ddubbo.protocol.name=dubbo -Ddubbo.protocol.serialization=hessian2
+

--- a/4-governance/dubbo-samples-zipkin/case-runtime-parameter.conf
+++ b/4-governance/dubbo-samples-zipkin/case-runtime-parameter.conf
@@ -1,0 +1,20 @@
+#
+#
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+-Ddubbo.protocol.name=dubbo -Ddubbo.protocol.serialization=hessian2
+


### PR DESCRIPTION
## Problem Description
Fix the issue where CI tests were failing due to missing `case-runtime-parameter.conf` files in governance samples. Previously, CI logs would output `case runtime config not found: .../case-runtime-parameter.conf` errors, causing test failures.

## Changes Made
- Add missing `case-runtime-parameter.conf` files for 12 governance samples in 4-governance directory
- Follow Apache License 2.0 format consistently across all new configuration files
- Include basic Dubbo protocol configuration parameters (`dubbo.protocol.name=dubbo` and `dubbo.protocol.serialization=hessian2`)
- Only add configuration files to samples that have `case-configuration.yml` files

## Files Modified
- `4-governance/dubbo-samples-applevel-override/case-runtime-parameter.conf` (new)
- `4-governance/dubbo-samples-conditionrouterv31/case-runtime-parameter.conf` (new)
- `4-governance/dubbo-samples-configconditionrouter/case-runtime-parameter.conf` (new)
- `4-governance/dubbo-samples-metrics-prometheus/case-runtime-parameter.conf` (new)
- `4-governance/dubbo-samples-metrics-spring-boot/case-runtime-parameter.conf` (new)
- `4-governance/dubbo-samples-sentinel/case-runtime-parameter.conf` (new)
- `4-governance/dubbo-samples-servicelevel-override/case-runtime-parameter.conf` (new)
- `4-governance/dubbo-samples-spring-boot-hystrix/case-runtime-parameter.conf` (new)
- `4-governance/dubbo-samples-spring-hystrix/case-runtime-parameter.conf` (new)
- `4-governance/dubbo-samples-ssl/case-runtime-parameter.conf` (new)
- `4-governance/dubbo-samples-tagrouter/case-runtime-parameter.conf` (new)
- `4-governance/dubbo-samples-zipkin/case-runtime-parameter.conf` (new)

## Technical Details
- Each configuration file includes proper Apache License 2.0 header
- Runtime parameters set to: `-Ddubbo.protocol.name=dubbo -Ddubbo.protocol.serialization=hessian2`
- Configuration format matches existing samples in the repository
- Files are only added to samples that have `case-configuration.yml` files

## Related Issue
Related to apache/dubbo#15473