### PR TITLE
fix: add missing dubbo.application.name for docker sample

### DIFF
--- a/2-advanced/dubbo-samples-docker/src/main/resources/application.properties
+++ b/2-advanced/dubbo-samples-docker/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+
+# Dubbo application name configuration
+dubbo.application.name=dubbo-samples-docker-provider


### PR DESCRIPTION
## Problem Description
Fix the issue where application name logs were not being printed normally in Dubbo samples due to missing `dubbo.application.name` configuration. Previously, samples would output `Dubbo Application[1.0](unknown) is created` instead of showing the proper application name.

## Changes Made
- Add missing `dubbo.application.name` configuration in docker sample
- Only modify samples that previously output the application name as 'unknown'

## Files Modified
- `2-advanced/dubbo-samples-docker/src/main/resources/application.properties`

## Technical Details
- Added `dubbo.application.name=dubbo-samples-docker-provider` to application.properties

## Related Issue
Related to apache/dubbo#15473