### PR TITLE
fix: resolve version matching issues in case-versions.conf files

### DIFF
--- a/2-advanced/dubbo-samples-spi-compatible/case-versions.conf
+++ b/2-advanced/dubbo-samples-spi-compatible/case-versions.conf
@@ -20,6 +20,6 @@
 # Supported component versions of the test case
 
 # Spring app
-dubbo.version=[ ">=3.0 <3.3.0" ]
+dubbo.version=[ ">=3.0 <3.4.0" ]
 spring.version=4.*, 5.*
 java.version= [>= 8]

--- a/3-extensions/protocol/dubbo-samples-http/case-versions.conf
+++ b/3-extensions/protocol/dubbo-samples-http/case-versions.conf
@@ -20,6 +20,6 @@
 # Supported component versions of the test case
 
 # Spring app
-dubbo.version=2.7*
+dubbo.version=2.7*, 3.*
 spring.version=4.*, 5.*
 java.version= [<= 11]

--- a/3-extensions/protocol/dubbo-samples-rest/case-versions.conf
+++ b/3-extensions/protocol/dubbo-samples-rest/case-versions.conf
@@ -20,6 +20,6 @@
 # Supported component versions of the test case
 
 # Spring app
-dubbo.version=[ 2.7*, < 3.3.0 ]
+dubbo.version=[ 2.7*, < 3.4.0 ]
 spring.version=4.*, 5.*
 java.version= [>= 8]

--- a/3-extensions/protocol/dubbo-samples-thrift/case-versions.conf
+++ b/3-extensions/protocol/dubbo-samples-thrift/case-versions.conf
@@ -20,6 +20,6 @@
 # Supported component versions of the test case
 
 # Spring app
-dubbo.version=2.7*
+dubbo.version=2.7*, 3.*
 spring.version=4.*, 5.*
 java.version= [>= 8]

--- a/3-extensions/protocol/dubbo-samples-webservice/case-versions.conf
+++ b/3-extensions/protocol/dubbo-samples-webservice/case-versions.conf
@@ -2,6 +2,6 @@
 # Supported component versions of the test case
 
 # Spring app
-dubbo.version=2.7*
+dubbo.version=2.7*, 3.*
 spring.version=4.*, 5.*
 java.version= [>= 8]

--- a/3-extensions/registry/dubbo-samples-consul/case-versions.conf
+++ b/3-extensions/registry/dubbo-samples-consul/case-versions.conf
@@ -20,6 +20,6 @@
 # Supported component versions of the test case
 
 # Spring app
-dubbo.version=2.7*
+dubbo.version=2.7*, 3.*
 spring.version=4.*, 5.*
 java.version= [<= 11]

--- a/3-extensions/registry/dubbo-samples-default-config/case-versions.conf
+++ b/3-extensions/registry/dubbo-samples-default-config/case-versions.conf
@@ -20,6 +20,6 @@
 # Supported component versions of the test case
 
 # Spring app
-dubbo.version=2.7*
+dubbo.version=2.7*, 3.*
 spring.version=4.*, 5.*
 java.version= [<= 11]

--- a/3-extensions/serialization/dubbo-samples-protobuf/case-versions.conf
+++ b/3-extensions/serialization/dubbo-samples-protobuf/case-versions.conf
@@ -20,7 +20,7 @@
 # Supported component versions of the test case
 
 # Spring app
-dubbo.version=2.7*
+dubbo.version=2.7*, 3.*
 spring.version=4.*, 5.*
 java.version= [>= 8]
 compiler.version=0.0.*, 3.*

--- a/3-extensions/serialization/dubbo-samples-protostuff/case-versions.conf
+++ b/3-extensions/serialization/dubbo-samples-protostuff/case-versions.conf
@@ -20,6 +20,6 @@
 # Supported component versions of the test case
 
 # SpringBoot app
-dubbo.version=2.7*
+dubbo.version=2.7*, 3.*
 spring-boot.version=2.*
 java.version= [>= 8]

--- a/3-extensions/serialization/dubbo-samples-serialization/dubbo-samples-serialization-java/case-versions.conf
+++ b/3-extensions/serialization/dubbo-samples-serialization/dubbo-samples-serialization-java/case-versions.conf
@@ -20,6 +20,6 @@
 # Supported component versions of the test case
 
 # Spring app
-dubbo.version= [ < 3.3]
+dubbo.version= [ < 3.4]
 spring.version=6.*
 java.version= [>= 17]

--- a/4-governance/dubbo-samples-metrics-prometheus/case-versions.conf
+++ b/4-governance/dubbo-samples-metrics-prometheus/case-versions.conf
@@ -20,6 +20,6 @@
 # Supported component versions of the test case
 
 # Spring app
-dubbo.version[ >= 3.3.0 ]
+dubbo.version=[ >= 3.3.0 ]
 spring.version=4.*, 5.*
 java.version= [>= 8]

--- a/4-governance/dubbo-samples-zipkin/case-versions.conf
+++ b/4-governance/dubbo-samples-zipkin/case-versions.conf
@@ -20,5 +20,5 @@
 # Supported component versions of the test case
 
 # Spring app
-dubbo.version=[ <2.7.8, >=2.7.9, !3.* ]
+dubbo.version=2.7*, 3.*
 spring.version=[ 4.*, 5.* ]


### PR DESCRIPTION
This commit fixes version matching issues that were preventing tests from running with the current CI environment version 3.3.6-SNAPSHOT. The changes include: 
- Remove overly restrictive version exclusions (!3.*) 
- Adjust version range bounds to include 3.3.x versions 
- Fix syntax errors in version rules - Add support for 3.* versions in samples that only supported 2.7* 
- Ensure all samples can run with the available Dubbo version