### PR TITLE
Update maven version to 3.8.9 for Dockerfile in dubbo-samples native image build

### DIFF
--- a/11-quickstart/README.md
+++ b/11-quickstart/README.md
@@ -15,12 +15,7 @@ $ ./mvnw clean install
 This will install all the modules especially `quickstart-api` in the local maven repo.
 
 ### Run quick start demo
-Enter `quickstart-service` directory:
-```shell
-$ cd 11-quickstart/quickstart-service
-```
-
-then, run the following command to start Dubbo process:
+Step into '11-quickstart' directory, run the following command to start Dubbo process:
 ```shell
 $ ./mvnw compile -pl quickstart-service exec:java -Dexec.mainClass="org.apache.dubbo.samples.quickstart.QuickStartApplication"
 ```

--- a/test/dubbo-test-runner/src/native/Dockerfile
+++ b/test/dubbo-test-runner/src/native/Dockerfile
@@ -20,9 +20,9 @@ RUN yum -y update && \
     yum install -y wget && \
     yum install -y gzip
 
-RUN wget https://dlcdn.apache.org/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz && \
-    tar xvf apache-maven-3.9.6-bin.tar.gz -C /opt && \
-    mv /opt/apache-maven-3.9.6/ /opt/maven
+RUN wget https://dlcdn.apache.org/maven/maven-3/3.8.9/binaries/apache-maven-3.8.9-bin.tar.gz && \
+    tar xvf apache-maven-3.8.9-bin.tar.gz  -C /opt && \
+    mv /opt/apache-maven-3.8.9/ /opt/maven
 
 ENV MAVEN_HOME /opt/maven
 ENV PATH $MAVEN_HOME/bin:$PATH


### PR DESCRIPTION
Official Maven 3.9.6 image returns 404, breaking the native-image build.
Replacing with 3.8.9 (still available) restores the Dockerfile build.