### PR TITLE
fix(test): update maven version to 3.8.9 for Dockerfile in dubbo-samples native image build

### DIFF
--- a/11-quickstart/README.md
+++ b/11-quickstart/README.md
@@ -15,12 +15,7 @@ $ ./mvnw clean install
 This will install all the modules especially `quickstart-api` in the local maven repo.
 
 ### Run quick start demo
-Enter `quickstart-service` directory:
-```shell
-$ cd 11-quickstart/quickstart-service
-```
-
-then, run the following command to start Dubbo process:
+Step into '11-quickstart' directory, run the following command to start Dubbo process:
 ```shell
 $ ./mvnw compile -pl quickstart-service exec:java -Dexec.mainClass="org.apache.dubbo.samples.quickstart.QuickStartApplication"
 ```


### PR DESCRIPTION
The official maven 3.9.6 image URL has become unavailable (404).
Downgrade to 3.8.9 to restore successful Docker image builds.
Fixes https://github.com/apache/dubbo/issues/15653