### PR TITLE
Change Debian docker test image from buster to bullseye

### DIFF
--- a/.github/workflows/dubbo-3_2.yml
+++ b/.github/workflows/dubbo-3_2.yml
@@ -211,7 +211,7 @@ jobs:
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: Build test image
         run: |
-          cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
+          cd test && bash ./build-test-image.sh
       - name: Run tests
         run: cd test && bash ./run-tests.sh
       - name: Upload test result

--- a/.github/workflows/dubbo-3_3.yml
+++ b/.github/workflows/dubbo-3_3.yml
@@ -203,7 +203,7 @@ jobs:
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: Build test image
         run: |
-          cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
+          cd test && bash ./build-test-image.sh
       - name: Run tests
         run: cd test && bash ./run-tests.sh
       - name: Upload test result

--- a/.github/workflows/nightly-dubbo-3.yml
+++ b/.github/workflows/nightly-dubbo-3.yml
@@ -165,7 +165,7 @@ jobs:
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: Build test image
         run: |
-          cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
+          cd test && bash ./build-test-image.sh
       - name: Run tests
         run: cd test && bash ./run-tests.sh
       - name: Upload test result

--- a/test/dubbo-test-runner/src/docker/Dockerfile
+++ b/test/dubbo-test-runner/src/docker/Dockerfile
@@ -14,7 +14,7 @@
 #   limitations under the License.
 
 ARG JAVA_VER=8
-FROM openjdk:${JAVA_VER}-jdk-buster
+FROM openjdk:${JAVA_VER}-jdk-bullseye
 
 ARG DEBIAN_MIRROR
 RUN if [ -n "$DEBIAN_MIRROR" ]; then \


### PR DESCRIPTION
the ```buster``` debian-archive was moved from ```http://archive.debian.org/debian-archive``` to a new URL, since we don't know whether the new URL is temporary or not, it might be better to upgrade the test image from ```buster``` to lastest version - ```bullseye```.