### PR TITLE
Add sleep times

### DIFF
--- a/test/dubbo-scenario-builder/src/main/resources/scenario.sh
+++ b/test/dubbo-scenario-builder/src/main/resources/scenario.sh
@@ -207,6 +207,9 @@ sleep 5
       read -r -d '' _ </dev/tty
     fi
 
+    echo "[$scenario_name] Waiting 5 seconds for jacoco agent to finish writing its exec file .." | tee -a $scenario_log
+    sleep 5
+
     echo "[$scenario_name] Stopping containers .." | tee -a $scenario_log
     docker compose -p ${project_name} -f ${compose_file} kill 2>&1 | tee -a $scenario_log > /dev/null
 #fi


### PR DESCRIPTION
1. for jacoco agent to finish writing its exec file after runing tests,
```
Error:  Failed to execute goal org.codehaus.mojo:exec-maven-plugin:3.5.1:java (default-cli) on project dubbo-test-jacoco-merger: An exception occurred while executing the Java class. null: EOFException -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.codehaus.mojo:exec-maven-plugin:3.5.1:java (default-cli) on project dubbo-test-jacoco-merger: An exception occurred while executing the Java class. null
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:333)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:316)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:212)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:174)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:75)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:162)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:159)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:105)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:73)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:53)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:118)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:261)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:173)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:101)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:906)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:283)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:206)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:103)
    at java.lang.reflect.Method.invoke (Method.java:580)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:255)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:201)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:361)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:314)
Caused by: org.apache.maven.plugin.MojoExecutionException: An exception occurred while executing the Java class. null
    at org.codehaus.mojo.exec.ExecJavaMojo.execute (ExecJavaMojo.java:349)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:126)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:328)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:316)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:212)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:174)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:75)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:162)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:159)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:105)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:73)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:53)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:118)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:261)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:173)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:101)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:906)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:283)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:206)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:103)
    at java.lang.reflect.Method.invoke (Method.java:580)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:255)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:201)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:361)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:314)
Caused by: java.io.EOFException
    at java.io.DataInputStream.readUnsignedByte (DataInputStream.java:297)
    at java.io.DataInputStream.readByte (DataInputStream.java:275)
    at org.jacoco.core.internal.data.CompactDataInput.readBooleanArray (CompactDataInput.java:64)
    at org.jacoco.core.data.ExecutionDataReader.readExecutionData (ExecutionDataReader.java:150)
    at org.jacoco.core.data.ExecutionDataReader.readBlock (ExecutionDataReader.java:116)
    at org.jacoco.core.data.ExecutionDataReader.read (ExecutionDataReader.java:93)
    at org.jacoco.core.tools.ExecFileLoader.load (ExecFileLoader.java:60)
    at org.jacoco.core.tools.ExecFileLoader.load (ExecFileLoader.java:74)
    at org.jacoco.cli.internal.commands.Merge.loadExecutionData (Merge.java:61)
    at org.jacoco.cli.internal.commands.Merge.execute (Merge.java:45)
    at org.jacoco.cli.internal.Main.execute (Main.java:90)
    at org.jacoco.cli.internal.Main.main (Main.java:105)
    at org.apache.dubbo.test.JacocoMerge.main (JacocoMerge.java:45)
    at org.codehaus.mojo.exec.ExecJavaMojo.doMain (ExecJavaMojo.java:371)
    at org.codehaus.mojo.exec.ExecJavaMojo.doExec (ExecJavaMojo.java:360)
    at org.codehaus.mojo.exec.ExecJavaMojo.lambda$execute$0 (ExecJavaMojo.java:280)
    at java.lang.Thread.run (Thread.java:1583)
```

According to https://github.com/jacoco/jacoco/issues/901, 
```
this happens due to a truncated (or not fully written) exec file. So the problem is when your exec file is written. This situation typically occurs when the Java process is not properly shut down (or has been killed). We also learned from users that this happens within docker file system.
```

2. for metrics data collection,
```
07:45:33.562 |-ERROR [main] cs.prometheus.consumer.ConsumerMetricsIT:143 -| metric key:dubbo_provider_rt_milliseconds_p99 don't exists
07:45:33.563 |-ERROR [main] cs.prometheus.consumer.ConsumerMetricsIT:143 -| metric key:dubbo_provider_rt_milliseconds_p90 don't exists
07:45:33.563 |-ERROR [main] cs.prometheus.consumer.ConsumerMetricsIT:143 -| metric key:dubbo_provider_rt_max_milliseconds_aggregate don't exists
07:45:33.563 |-ERROR [main] cs.prometheus.consumer.ConsumerMetricsIT:143 -| metric key:dubbo_provider_requests_business_failed_aggregate don't exists
07:45:33.564 |-ERROR [main] cs.prometheus.consumer.ConsumerMetricsIT:143 -| metric key:dubbo_provider_requests_failed_service_unavailable_total_aggregate don't exists
07:45:33.564 |-ERROR [main] cs.prometheus.consumer.ConsumerMetricsIT:143 -| metric key:dubbo_provider_requests_limit_aggregate don't exists
07:45:33.564 |-ERROR [main] cs.prometheus.consumer.ConsumerMetricsIT:143 -| metric key:dubbo_provider_qps_total don't exists
07:45:33.564 |-ERROR [main] cs.prometheus.consumer.ConsumerMetricsIT:143 -| metric key:dubbo_provider_rt_milliseconds_p50 don't exists
07:45:33.565 |-ERROR [main] cs.prometheus.consumer.ConsumerMetricsIT:143 -| metric key:dubbo_provider_requests_succeed_aggregate don't exists
07:45:33.565 |-ERROR [main] cs.prometheus.consumer.ConsumerMetricsIT:143 -| metric key:dubbo_provider_rt_milliseconds_p95 don't exists
07:45:33.565 |-ERROR [main] cs.prometheus.consumer.ConsumerMetricsIT:143 -| metric key:dubbo_provider_requests_failed_aggregate don't exists
07:45:33.565 |-ERROR [main] cs.prometheus.consumer.ConsumerMetricsIT:143 -| metric key:dubbo_provider_rt_avg_milliseconds_aggregate don't exists
07:45:33.566 |-ERROR [main] cs.prometheus.consumer.ConsumerMetricsIT:143 -| metric key:dubbo_provider_requests_failed_total_aggregate don't exists
07:45:33.566 |-ERROR [main] cs.prometheus.consumer.ConsumerMetricsIT:143 -| metric key:dubbo_provider_requests_failed_network_total_aggregate don't exists
07:45:33.566 |-ERROR [main] cs.prometheus.consumer.ConsumerMetricsIT:143 -| metric key:dubbo_provider_rt_min_milliseconds_aggregate don't exists
07:45:33.566 |-ERROR [main] cs.prometheus.consumer.ConsumerMetricsIT:143 -| metric key:dubbo_provider_requests_failed_codec_total_aggregate don't exists
07:45:33.566 |-ERROR [main] cs.prometheus.consumer.ConsumerMetricsIT:143 -| metric key:dubbo_provider_requests_timeout_failed_aggregate don't exists
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 13.665 s <<< FAILURE! - in org.apache.dubbo.samples.metrics.prometheus.consumer.ConsumerMetricsIT
test(org.apache.dubbo.samples.metrics.prometheus.consumer.ConsumerMetricsIT)  Time elapsed: 13.529 s  <<< FAILURE!
```