### PR TITLE
Add nacos mysql schema sql file to docker file from github.com

### DIFF
--- a/test/build-nacos-image.sh
+++ b/test/build-nacos-image.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
 mkdir nacos-mysql
-curl -o nacos-mysql/Dockerfile https://raw.githubusercontent.com/nacos-group/nacos-docker/master/example/image/mysql/5.7/Dockerfile
+
+#curl -o nacos-mysql/Dockerfile https://raw.githubusercontent.com/nacos-group/nacos-docker/master/example/image/mysql/5.7/Dockerfile
+
+#Since mysql-schema.sql is not found at https://raw.githubusercontent.com, we add it from github.com:
+cat > nacos-mysql/Dockerfile << EOF
+FROM mysql:5.7.40
+ADD https://github.com/alibaba/nacos/blob/master/distribution/conf/mysql-schema.sql /docker-entrypoint-initdb.d/nacos-mysql.sql
+RUN chown -R mysql:mysql /docker-entrypoint-initdb.d/nacos-mysql.sql
+EXPOSE 3306
+CMD ["mysqld", "--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci"]
+EOF
+
 docker build -t nacos-mysql:5.7 nacos-mysql/


### PR DESCRIPTION
Right now, ```mysql-schema.sql``` is not found at https://raw.githubusercontent.com
<img width="910" height="165" alt="e4034b9d6607fd8e8a46c54797e27560" src="https://github.com/user-attachments/assets/1909e3dd-295d-460d-bb9d-6e2425311f6f" />

so we should not use ```https://raw.githubusercontent.com/nacos-group/nacos-docker/master/example/image/mysql/5.7/Dockerfile``` directly anymore.

<img width="1155" height="250" alt="991bd154cf81087d60be0118d323cd10" src="https://github.com/user-attachments/assets/73bbee26-f6fd-41fb-91c3-33e2663c05f8" />
