### PR TITLE
 dubbo-sample-async-result example (#15567)

### DIFF
--- a/1-basic/dubbo-samples-api-idl/build/generated/source/proto/main/java/org/apache/dubbo/samples/tri/unary/DubboGreeterTriple.java
+++ b/1-basic/dubbo-samples-api-idl/build/generated/source/proto/main/java/org/apache/dubbo/samples/tri/unary/DubboGreeterTriple.java
@@ -17,8 +17,8 @@
 
 package org.apache.dubbo.samples.tri.unary;
 
-import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.stream.StreamObserver;
+import org.apache.dubbo.common.URL;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.PathResolver;
 import org.apache.dubbo.rpc.RpcException;
@@ -29,18 +29,20 @@ import org.apache.dubbo.rpc.model.ServiceDescriptor;
 import org.apache.dubbo.rpc.model.StubMethodDescriptor;
 import org.apache.dubbo.rpc.model.StubServiceDescriptor;
 import org.apache.dubbo.rpc.service.Destroyable;
+import org.apache.dubbo.rpc.stub.BiStreamMethodHandler;
+import org.apache.dubbo.rpc.stub.ServerStreamMethodHandler;
 import org.apache.dubbo.rpc.stub.StubInvocationUtil;
 import org.apache.dubbo.rpc.stub.StubInvoker;
 import org.apache.dubbo.rpc.stub.StubMethodHandler;
 import org.apache.dubbo.rpc.stub.StubSuppliers;
 import org.apache.dubbo.rpc.stub.UnaryStubMethodHandler;
 
+import com.google.protobuf.Message;
+
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
-
-import com.google.protobuf.Message;
+import java.util.concurrent.CompletableFuture;
 
 public final class DubboGreeterTriple {
 
@@ -101,7 +103,6 @@ public final class DubboGreeterTriple {
             return StubInvocationUtil.unaryCall(invoker, greetMethod, request);
         }
 
-        @Override
         public CompletableFuture<org.apache.dubbo.samples.tri.unary.GreeterReply> greetAsync(org.apache.dubbo.samples.tri.unary.GreeterRequest request){
             return StubInvocationUtil.unaryCall(invoker, greetAsyncMethod, request);
         }

--- a/1-basic/dubbo-samples-api-idl/build/generated/source/proto/main/java/org/apache/dubbo/samples/tri/unary/Greeter.java
+++ b/1-basic/dubbo-samples-api-idl/build/generated/source/proto/main/java/org/apache/dubbo/samples/tri/unary/Greeter.java
@@ -17,6 +17,12 @@
 
 package org.apache.dubbo.samples.tri.unary;
 
+import org.apache.dubbo.common.stream.StreamObserver;
+import com.google.protobuf.Message;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.concurrent.CompletableFuture;
 
 public interface Greeter extends org.apache.dubbo.rpc.model.DubboStub {

--- a/1-basic/dubbo-samples-api-idl/build/generated/source/proto/main/java/org/apache/dubbo/samples/tri/unary/GreeterReply.java
+++ b/1-basic/dubbo-samples-api-idl/build/generated/source/proto/main/java/org/apache/dubbo/samples/tri/unary/GreeterReply.java
@@ -52,7 +52,7 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs =
+      com.google.protobuf.ByteString bs = 
           (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       message_ = s;
@@ -68,7 +68,7 @@ private static final long serialVersionUID = 0L;
       getMessageBytes() {
     java.lang.Object ref = message_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b =
+      com.google.protobuf.ByteString b = 
           com.google.protobuf.ByteString.copyFromUtf8(
               (java.lang.String) ref);
       message_ = b;
@@ -82,12 +82,8 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
-    if (isInitialized == 1) {
-        return true;
-    }
-    if (isInitialized == 0) {
-        return false;
-    }
+    if (isInitialized == 1) return true;
+    if (isInitialized == 0) return false;
 
     memoizedIsInitialized = 1;
     return true;
@@ -105,9 +101,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public int getSerializedSize() {
     int size = memoizedSize;
-    if (size != -1) {
-        return size;
-    }
+    if (size != -1) return size;
 
     size = 0;
     if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(message_)) {
@@ -129,12 +123,8 @@ private static final long serialVersionUID = 0L;
     org.apache.dubbo.samples.tri.unary.GreeterReply other = (org.apache.dubbo.samples.tri.unary.GreeterReply) obj;
 
     if (!getMessage()
-        .equals(other.getMessage())) {
-        return false;
-    }
-    if (!getUnknownFields().equals(other.getUnknownFields())) {
-        return false;
-    }
+        .equals(other.getMessage())) return false;
+    if (!getUnknownFields().equals(other.getUnknownFields())) return false;
     return true;
   }
 
@@ -326,9 +316,7 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(org.apache.dubbo.samples.tri.unary.GreeterReply other) {
-      if (other == org.apache.dubbo.samples.tri.unary.GreeterReply.getDefaultInstance()) {
-          return this;
-      }
+      if (other == org.apache.dubbo.samples.tri.unary.GreeterReply.getDefaultInstance()) return this;
       if (!other.getMessage().isEmpty()) {
         message_ = other.message_;
         bitField0_ |= 0x00000001;
@@ -387,7 +375,6 @@ private static final long serialVersionUID = 0L;
      * <code>string message = 1;</code>
      * @return The message.
      */
-    @Override
     public java.lang.String getMessage() {
       java.lang.Object ref = message_;
       if (!(ref instanceof java.lang.String)) {
@@ -404,12 +391,11 @@ private static final long serialVersionUID = 0L;
      * <code>string message = 1;</code>
      * @return The bytes for message.
      */
-    @Override
     public com.google.protobuf.ByteString
         getMessageBytes() {
       java.lang.Object ref = message_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         message_ = b;

--- a/1-basic/dubbo-samples-api-idl/build/generated/source/proto/main/java/org/apache/dubbo/samples/tri/unary/GreeterRequest.java
+++ b/1-basic/dubbo-samples-api-idl/build/generated/source/proto/main/java/org/apache/dubbo/samples/tri/unary/GreeterRequest.java
@@ -52,7 +52,7 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs =
+      com.google.protobuf.ByteString bs = 
           (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       name_ = s;
@@ -68,7 +68,7 @@ private static final long serialVersionUID = 0L;
       getNameBytes() {
     java.lang.Object ref = name_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b =
+      com.google.protobuf.ByteString b = 
           com.google.protobuf.ByteString.copyFromUtf8(
               (java.lang.String) ref);
       name_ = b;
@@ -82,12 +82,8 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
-    if (isInitialized == 1) {
-        return true;
-    }
-    if (isInitialized == 0) {
-        return false;
-    }
+    if (isInitialized == 1) return true;
+    if (isInitialized == 0) return false;
 
     memoizedIsInitialized = 1;
     return true;
@@ -105,9 +101,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public int getSerializedSize() {
     int size = memoizedSize;
-    if (size != -1) {
-        return size;
-    }
+    if (size != -1) return size;
 
     size = 0;
     if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
@@ -129,12 +123,8 @@ private static final long serialVersionUID = 0L;
     org.apache.dubbo.samples.tri.unary.GreeterRequest other = (org.apache.dubbo.samples.tri.unary.GreeterRequest) obj;
 
     if (!getName()
-        .equals(other.getName())) {
-        return false;
-    }
-    if (!getUnknownFields().equals(other.getUnknownFields())) {
-        return false;
-    }
+        .equals(other.getName())) return false;
+    if (!getUnknownFields().equals(other.getUnknownFields())) return false;
     return true;
   }
 
@@ -326,9 +316,7 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(org.apache.dubbo.samples.tri.unary.GreeterRequest other) {
-      if (other == org.apache.dubbo.samples.tri.unary.GreeterRequest.getDefaultInstance()) {
-          return this;
-      }
+      if (other == org.apache.dubbo.samples.tri.unary.GreeterRequest.getDefaultInstance()) return this;
       if (!other.getName().isEmpty()) {
         name_ = other.name_;
         bitField0_ |= 0x00000001;
@@ -387,7 +375,6 @@ private static final long serialVersionUID = 0L;
      * <code>string name = 1;</code>
      * @return The name.
      */
-    @Override
     public java.lang.String getName() {
       java.lang.Object ref = name_;
       if (!(ref instanceof java.lang.String)) {
@@ -404,12 +391,11 @@ private static final long serialVersionUID = 0L;
      * <code>string name = 1;</code>
      * @return The bytes for name.
      */
-    @Override
     public com.google.protobuf.ByteString
         getNameBytes() {
       java.lang.Object ref = name_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         name_ = b;

--- a/1-basic/dubbo-samples-spring-boot-idl/dubbo-samples-spring-boot-idl-consumer/build/generated/source/proto/main/java/org/apache/dubbo/springboot/demo/idl/DubboGreeterTriple.java
+++ b/1-basic/dubbo-samples-spring-boot-idl/dubbo-samples-spring-boot-idl-consumer/build/generated/source/proto/main/java/org/apache/dubbo/springboot/demo/idl/DubboGreeterTriple.java
@@ -17,8 +17,8 @@
 
 package org.apache.dubbo.springboot.demo.idl;
 
-import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.stream.StreamObserver;
+import org.apache.dubbo.common.URL;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.PathResolver;
 import org.apache.dubbo.rpc.RpcException;
@@ -29,18 +29,20 @@ import org.apache.dubbo.rpc.model.ServiceDescriptor;
 import org.apache.dubbo.rpc.model.StubMethodDescriptor;
 import org.apache.dubbo.rpc.model.StubServiceDescriptor;
 import org.apache.dubbo.rpc.service.Destroyable;
+import org.apache.dubbo.rpc.stub.BiStreamMethodHandler;
+import org.apache.dubbo.rpc.stub.ServerStreamMethodHandler;
 import org.apache.dubbo.rpc.stub.StubInvocationUtil;
 import org.apache.dubbo.rpc.stub.StubInvoker;
 import org.apache.dubbo.rpc.stub.StubMethodHandler;
 import org.apache.dubbo.rpc.stub.StubSuppliers;
 import org.apache.dubbo.rpc.stub.UnaryStubMethodHandler;
 
+import com.google.protobuf.Message;
+
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
-
-import com.google.protobuf.Message;
+import java.util.concurrent.CompletableFuture;
 
 public final class DubboGreeterTriple {
 
@@ -101,7 +103,6 @@ public final class DubboGreeterTriple {
             return StubInvocationUtil.unaryCall(invoker, greetMethod, request);
         }
 
-        @Override
         public CompletableFuture<org.apache.dubbo.springboot.demo.idl.GreeterReply> greetAsync(org.apache.dubbo.springboot.demo.idl.GreeterRequest request){
             return StubInvocationUtil.unaryCall(invoker, greetAsyncMethod, request);
         }

--- a/1-basic/dubbo-samples-spring-boot-idl/dubbo-samples-spring-boot-idl-consumer/build/generated/source/proto/main/java/org/apache/dubbo/springboot/demo/idl/GreeterReply.java
+++ b/1-basic/dubbo-samples-spring-boot-idl/dubbo-samples-spring-boot-idl-consumer/build/generated/source/proto/main/java/org/apache/dubbo/springboot/demo/idl/GreeterReply.java
@@ -52,7 +52,7 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs =
+      com.google.protobuf.ByteString bs = 
           (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       message_ = s;
@@ -68,7 +68,7 @@ private static final long serialVersionUID = 0L;
       getMessageBytes() {
     java.lang.Object ref = message_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b =
+      com.google.protobuf.ByteString b = 
           com.google.protobuf.ByteString.copyFromUtf8(
               (java.lang.String) ref);
       message_ = b;
@@ -82,12 +82,8 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
-    if (isInitialized == 1) {
-        return true;
-    }
-    if (isInitialized == 0) {
-        return false;
-    }
+    if (isInitialized == 1) return true;
+    if (isInitialized == 0) return false;
 
     memoizedIsInitialized = 1;
     return true;
@@ -105,9 +101,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public int getSerializedSize() {
     int size = memoizedSize;
-    if (size != -1) {
-        return size;
-    }
+    if (size != -1) return size;
 
     size = 0;
     if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(message_)) {
@@ -129,12 +123,8 @@ private static final long serialVersionUID = 0L;
     org.apache.dubbo.springboot.demo.idl.GreeterReply other = (org.apache.dubbo.springboot.demo.idl.GreeterReply) obj;
 
     if (!getMessage()
-        .equals(other.getMessage())) {
-        return false;
-    }
-    if (!getUnknownFields().equals(other.getUnknownFields())) {
-        return false;
-    }
+        .equals(other.getMessage())) return false;
+    if (!getUnknownFields().equals(other.getUnknownFields())) return false;
     return true;
   }
 
@@ -326,9 +316,7 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(org.apache.dubbo.springboot.demo.idl.GreeterReply other) {
-      if (other == org.apache.dubbo.springboot.demo.idl.GreeterReply.getDefaultInstance()) {
-          return this;
-      }
+      if (other == org.apache.dubbo.springboot.demo.idl.GreeterReply.getDefaultInstance()) return this;
       if (!other.getMessage().isEmpty()) {
         message_ = other.message_;
         bitField0_ |= 0x00000001;
@@ -387,7 +375,6 @@ private static final long serialVersionUID = 0L;
      * <code>string message = 1;</code>
      * @return The message.
      */
-    @Override
     public java.lang.String getMessage() {
       java.lang.Object ref = message_;
       if (!(ref instanceof java.lang.String)) {
@@ -404,12 +391,11 @@ private static final long serialVersionUID = 0L;
      * <code>string message = 1;</code>
      * @return The bytes for message.
      */
-    @Override
     public com.google.protobuf.ByteString
         getMessageBytes() {
       java.lang.Object ref = message_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         message_ = b;

--- a/1-basic/dubbo-samples-spring-boot-idl/dubbo-samples-spring-boot-idl-consumer/build/generated/source/proto/main/java/org/apache/dubbo/springboot/demo/idl/GreeterRequest.java
+++ b/1-basic/dubbo-samples-spring-boot-idl/dubbo-samples-spring-boot-idl-consumer/build/generated/source/proto/main/java/org/apache/dubbo/springboot/demo/idl/GreeterRequest.java
@@ -52,7 +52,7 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs =
+      com.google.protobuf.ByteString bs = 
           (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       name_ = s;
@@ -68,7 +68,7 @@ private static final long serialVersionUID = 0L;
       getNameBytes() {
     java.lang.Object ref = name_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b =
+      com.google.protobuf.ByteString b = 
           com.google.protobuf.ByteString.copyFromUtf8(
               (java.lang.String) ref);
       name_ = b;
@@ -82,12 +82,8 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
-    if (isInitialized == 1) {
-        return true;
-    }
-    if (isInitialized == 0) {
-        return false;
-    }
+    if (isInitialized == 1) return true;
+    if (isInitialized == 0) return false;
 
     memoizedIsInitialized = 1;
     return true;
@@ -105,9 +101,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public int getSerializedSize() {
     int size = memoizedSize;
-    if (size != -1) {
-        return size;
-    }
+    if (size != -1) return size;
 
     size = 0;
     if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
@@ -129,12 +123,8 @@ private static final long serialVersionUID = 0L;
     org.apache.dubbo.springboot.demo.idl.GreeterRequest other = (org.apache.dubbo.springboot.demo.idl.GreeterRequest) obj;
 
     if (!getName()
-        .equals(other.getName())) {
-        return false;
-    }
-    if (!getUnknownFields().equals(other.getUnknownFields())) {
-        return false;
-    }
+        .equals(other.getName())) return false;
+    if (!getUnknownFields().equals(other.getUnknownFields())) return false;
     return true;
   }
 
@@ -326,9 +316,7 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(org.apache.dubbo.springboot.demo.idl.GreeterRequest other) {
-      if (other == org.apache.dubbo.springboot.demo.idl.GreeterRequest.getDefaultInstance()) {
-          return this;
-      }
+      if (other == org.apache.dubbo.springboot.demo.idl.GreeterRequest.getDefaultInstance()) return this;
       if (!other.getName().isEmpty()) {
         name_ = other.name_;
         bitField0_ |= 0x00000001;
@@ -387,7 +375,6 @@ private static final long serialVersionUID = 0L;
      * <code>string name = 1;</code>
      * @return The name.
      */
-    @Override
     public java.lang.String getName() {
       java.lang.Object ref = name_;
       if (!(ref instanceof java.lang.String)) {
@@ -404,12 +391,11 @@ private static final long serialVersionUID = 0L;
      * <code>string name = 1;</code>
      * @return The bytes for name.
      */
-    @Override
     public com.google.protobuf.ByteString
         getNameBytes() {
       java.lang.Object ref = name_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         name_ = b;

--- a/1-basic/dubbo-samples-spring-boot-idl/dubbo-samples-spring-boot-idl-provider/build/generated/source/proto/main/java/org/apache/dubbo/springboot/demo/idl/DubboGreeterTriple.java
+++ b/1-basic/dubbo-samples-spring-boot-idl/dubbo-samples-spring-boot-idl-provider/build/generated/source/proto/main/java/org/apache/dubbo/springboot/demo/idl/DubboGreeterTriple.java
@@ -17,8 +17,8 @@
 
 package org.apache.dubbo.springboot.demo.idl;
 
-import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.stream.StreamObserver;
+import org.apache.dubbo.common.URL;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.PathResolver;
 import org.apache.dubbo.rpc.RpcException;
@@ -29,18 +29,20 @@ import org.apache.dubbo.rpc.model.ServiceDescriptor;
 import org.apache.dubbo.rpc.model.StubMethodDescriptor;
 import org.apache.dubbo.rpc.model.StubServiceDescriptor;
 import org.apache.dubbo.rpc.service.Destroyable;
+import org.apache.dubbo.rpc.stub.BiStreamMethodHandler;
+import org.apache.dubbo.rpc.stub.ServerStreamMethodHandler;
 import org.apache.dubbo.rpc.stub.StubInvocationUtil;
 import org.apache.dubbo.rpc.stub.StubInvoker;
 import org.apache.dubbo.rpc.stub.StubMethodHandler;
 import org.apache.dubbo.rpc.stub.StubSuppliers;
 import org.apache.dubbo.rpc.stub.UnaryStubMethodHandler;
 
+import com.google.protobuf.Message;
+
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
-
-import com.google.protobuf.Message;
+import java.util.concurrent.CompletableFuture;
 
 public final class DubboGreeterTriple {
 
@@ -101,7 +103,6 @@ public final class DubboGreeterTriple {
             return StubInvocationUtil.unaryCall(invoker, greetMethod, request);
         }
 
-        @Override
         public CompletableFuture<org.apache.dubbo.springboot.demo.idl.GreeterReply> greetAsync(org.apache.dubbo.springboot.demo.idl.GreeterRequest request){
             return StubInvocationUtil.unaryCall(invoker, greetAsyncMethod, request);
         }

--- a/1-basic/dubbo-samples-spring-boot-idl/dubbo-samples-spring-boot-idl-provider/build/generated/source/proto/main/java/org/apache/dubbo/springboot/demo/idl/GreeterReply.java
+++ b/1-basic/dubbo-samples-spring-boot-idl/dubbo-samples-spring-boot-idl-provider/build/generated/source/proto/main/java/org/apache/dubbo/springboot/demo/idl/GreeterReply.java
@@ -52,7 +52,7 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs =
+      com.google.protobuf.ByteString bs = 
           (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       message_ = s;
@@ -68,7 +68,7 @@ private static final long serialVersionUID = 0L;
       getMessageBytes() {
     java.lang.Object ref = message_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b =
+      com.google.protobuf.ByteString b = 
           com.google.protobuf.ByteString.copyFromUtf8(
               (java.lang.String) ref);
       message_ = b;
@@ -82,12 +82,8 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
-    if (isInitialized == 1) {
-        return true;
-    }
-    if (isInitialized == 0) {
-        return false;
-    }
+    if (isInitialized == 1) return true;
+    if (isInitialized == 0) return false;
 
     memoizedIsInitialized = 1;
     return true;
@@ -105,9 +101,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public int getSerializedSize() {
     int size = memoizedSize;
-    if (size != -1) {
-        return size;
-    }
+    if (size != -1) return size;
 
     size = 0;
     if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(message_)) {
@@ -129,12 +123,8 @@ private static final long serialVersionUID = 0L;
     org.apache.dubbo.springboot.demo.idl.GreeterReply other = (org.apache.dubbo.springboot.demo.idl.GreeterReply) obj;
 
     if (!getMessage()
-        .equals(other.getMessage())) {
-        return false;
-    }
-    if (!getUnknownFields().equals(other.getUnknownFields())) {
-        return false;
-    }
+        .equals(other.getMessage())) return false;
+    if (!getUnknownFields().equals(other.getUnknownFields())) return false;
     return true;
   }
 
@@ -326,9 +316,7 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(org.apache.dubbo.springboot.demo.idl.GreeterReply other) {
-      if (other == org.apache.dubbo.springboot.demo.idl.GreeterReply.getDefaultInstance()) {
-          return this;
-      }
+      if (other == org.apache.dubbo.springboot.demo.idl.GreeterReply.getDefaultInstance()) return this;
       if (!other.getMessage().isEmpty()) {
         message_ = other.message_;
         bitField0_ |= 0x00000001;
@@ -387,7 +375,6 @@ private static final long serialVersionUID = 0L;
      * <code>string message = 1;</code>
      * @return The message.
      */
-    @Override
     public java.lang.String getMessage() {
       java.lang.Object ref = message_;
       if (!(ref instanceof java.lang.String)) {
@@ -404,12 +391,11 @@ private static final long serialVersionUID = 0L;
      * <code>string message = 1;</code>
      * @return The bytes for message.
      */
-    @Override
     public com.google.protobuf.ByteString
         getMessageBytes() {
       java.lang.Object ref = message_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         message_ = b;

--- a/1-basic/dubbo-samples-spring-boot-idl/dubbo-samples-spring-boot-idl-provider/build/generated/source/proto/main/java/org/apache/dubbo/springboot/demo/idl/GreeterRequest.java
+++ b/1-basic/dubbo-samples-spring-boot-idl/dubbo-samples-spring-boot-idl-provider/build/generated/source/proto/main/java/org/apache/dubbo/springboot/demo/idl/GreeterRequest.java
@@ -52,7 +52,7 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs =
+      com.google.protobuf.ByteString bs = 
           (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       name_ = s;
@@ -68,7 +68,7 @@ private static final long serialVersionUID = 0L;
       getNameBytes() {
     java.lang.Object ref = name_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b =
+      com.google.protobuf.ByteString b = 
           com.google.protobuf.ByteString.copyFromUtf8(
               (java.lang.String) ref);
       name_ = b;
@@ -82,12 +82,8 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
-    if (isInitialized == 1) {
-        return true;
-    }
-    if (isInitialized == 0) {
-        return false;
-    }
+    if (isInitialized == 1) return true;
+    if (isInitialized == 0) return false;
 
     memoizedIsInitialized = 1;
     return true;
@@ -105,9 +101,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public int getSerializedSize() {
     int size = memoizedSize;
-    if (size != -1) {
-        return size;
-    }
+    if (size != -1) return size;
 
     size = 0;
     if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
@@ -129,12 +123,8 @@ private static final long serialVersionUID = 0L;
     org.apache.dubbo.springboot.demo.idl.GreeterRequest other = (org.apache.dubbo.springboot.demo.idl.GreeterRequest) obj;
 
     if (!getName()
-        .equals(other.getName())) {
-        return false;
-    }
-    if (!getUnknownFields().equals(other.getUnknownFields())) {
-        return false;
-    }
+        .equals(other.getName())) return false;
+    if (!getUnknownFields().equals(other.getUnknownFields())) return false;
     return true;
   }
 
@@ -326,9 +316,7 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(org.apache.dubbo.springboot.demo.idl.GreeterRequest other) {
-      if (other == org.apache.dubbo.springboot.demo.idl.GreeterRequest.getDefaultInstance()) {
-          return this;
-      }
+      if (other == org.apache.dubbo.springboot.demo.idl.GreeterRequest.getDefaultInstance()) return this;
       if (!other.getName().isEmpty()) {
         name_ = other.name_;
         bitField0_ |= 0x00000001;
@@ -387,7 +375,6 @@ private static final long serialVersionUID = 0L;
      * <code>string name = 1;</code>
      * @return The name.
      */
-    @Override
     public java.lang.String getName() {
       java.lang.Object ref = name_;
       if (!(ref instanceof java.lang.String)) {
@@ -404,12 +391,11 @@ private static final long serialVersionUID = 0L;
      * <code>string name = 1;</code>
      * @return The bytes for name.
      */
-    @Override
     public com.google.protobuf.ByteString
         getNameBytes() {
       java.lang.Object ref = name_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         name_ = b;

--- a/2-advanced/dubbo-samples-async-result/Provider/pom.xml
+++ b/2-advanced/dubbo-samples-async-result/Provider/pom.xml
@@ -1,0 +1,85 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.dubbo.sample</groupId>
+    <artifactId>dubbo-samples-async-result-provider</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <java.version>17</java.version>
+        <spring.boot.version>3.3.2</spring.boot.version>
+        <dubbo.version>3.3.6-SNAPSHOT</dubbo.version>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>apache.snapshots</id>
+            <name>Apache Snapshots</name>
+            <url>https://repository.apache.org/content/repositories/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <!-- Dubbo Spring Boot Starter -->
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-spring-boot-starter</artifactId>
+            <version>${dubbo.version}</version>
+        </dependency>
+
+        <!-- Spring Boot Starter -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+
+        <!-- Spring Boot Starter Logging is included in spring-boot-starter, no need to declare separately -->
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Maven Compiler Plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+
+            <!-- Spring Boot Maven Plugin -->
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/2-advanced/dubbo-samples-async-result/Provider/src/main/java/org/apache/dubbo/samples/async/result/DemoServiceImpl.java
+++ b/2-advanced/dubbo-samples-async-result/Provider/src/main/java/org/apache/dubbo/samples/async/result/DemoServiceImpl.java
@@ -1,0 +1,18 @@
+package org.apache.dubbo.samples.async.result.provider;
+
+import org.apache.dubbo.config.annotation.DubboService;
+import org.apache.dubbo.samples.async.result.api.DemoService;
+
+@DubboService
+public class DemoServiceImpl implements DemoService {
+
+    @Override
+    public String sayHello(String name) {
+        // Synchronous return matching API
+        return "Hello, " + name;
+    }
+}
+
+
+
+

--- a/2-advanced/dubbo-samples-async-result/Provider/src/main/java/org/apache/dubbo/samples/async/result/ProviderApplication.java
+++ b/2-advanced/dubbo-samples-async-result/Provider/src/main/java/org/apache/dubbo/samples/async/result/ProviderApplication.java
@@ -1,0 +1,16 @@
+package org.apache.dubbo.samples.async.result.provider;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ProviderApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ProviderApplication.class, args);
+    }
+}
+
+
+
+

--- a/2-advanced/dubbo-samples-async-result/Provider/src/main/resources/application.yml
+++ b/2-advanced/dubbo-samples-async-result/Provider/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  main:
+    web-application-type: none
+
+dubbo:
+  application:
+    name: async-result-provider
+  protocol:
+    name: dubbo
+    port: 20880
+  registry:
+    address: zookeeper://127.0.0.1:2181
+  scan:
+    base-packages: org.apache.dubbo.samples.asyncresult

--- a/2-advanced/dubbo-samples-async-result/api/pom.xml
+++ b/2-advanced/dubbo-samples-async-result/api/pom.xml
@@ -1,0 +1,81 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.dubbo.sample</groupId>
+    <artifactId>dubbo-samples-async-result-api</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>dubbo-samples-async-result-api</name>
+
+    <properties>
+        <java.version>17</java.version>
+        <dubbo.version>3.3.4</dubbo.version>
+        <jackson.version>2.15.2</jackson.version>
+    </properties>
+
+    <dependencies>
+        <!-- Dubbo -->
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo</artifactId>
+            <version>${dubbo.version}</version>
+        </dependency>
+
+        <!-- Jackson for JSON serialization -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <!-- Apache snapshots repository (if you ever need snapshot versions) -->
+        <repository>
+            <id>apache.snapshots</id>
+            <name>Apache Snapshots</name>
+            <url>https://repository.apache.org/content/repositories/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <build>
+        <plugins>
+            <!-- Compiler plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+
+
+

--- a/2-advanced/dubbo-samples-async-result/api/src/main/java/org/apache/dubbo/sample/async/result/DemoService.java
+++ b/2-advanced/dubbo-samples-async-result/api/src/main/java/org/apache/dubbo/sample/async/result/DemoService.java
@@ -1,0 +1,5 @@
+package org.apache.dubbo.samples.async.result.api;
+
+public interface DemoService {
+    String sayHello(String name);
+}

--- a/2-advanced/dubbo-samples-async-result/consumer/pom.xml
+++ b/2-advanced/dubbo-samples-async-result/consumer/pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.dubbo.sample</groupId>
+    <artifactId>dubbo-sample-async-consumer</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <!-- Dependency on API module -->
+        <dependency>
+            <groupId>org.apache.dubbo.sample</groupId>
+            <artifactId>async-result-api</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+        <!-- Dubbo -->
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo</artifactId>
+            <version>3.3.6</version>
+        </dependency>
+
+        <!-- Jackson -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.16.4</version>
+        </dependency>
+    </dependencies>
+
+</project>
+
+
+
+
+

--- a/2-advanced/dubbo-samples-async-result/consumer/src/main/java/org/apache/dubbo/samples/async/result/ConsumerApplication.java
+++ b/2-advanced/dubbo-samples-async-result/consumer/src/main/java/org/apache/dubbo/samples/async/result/ConsumerApplication.java
@@ -1,0 +1,25 @@
+package org.apache.dubbo.sample.async.result.consumer;
+
+import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.config.ReferenceConfig;
+import org.apache.dubbo.config.bootstrap.DubboBootstrap;
+import org.apache.dubbo.sample.async.result.api.DemoService;
+
+import java.util.concurrent.CompletableFuture;
+
+public class ConsumerApplication {
+    public static void main(String[] args) throws Exception {
+        ReferenceConfig<DemoService> reference = new ReferenceConfig<>();
+        reference.setInterface(DemoService.class);
+
+        DubboBootstrap bootstrap = DubboBootstrap.getInstance();
+        bootstrap.application(new ApplicationConfig("async-result-consumer"))
+                 .reference(reference)
+                 .start();
+
+        DemoService demoService = reference.get();
+        CompletableFuture<String> result = demoService.sayHello("Dubbo");
+        System.out.println("Result: " + result.get());
+    }
+}
+

--- a/2-advanced/dubbo-samples-async-result/consumer/src/main/resources/application.yml
+++ b/2-advanced/dubbo-samples-async-result/consumer/src/main/resources/application.yml
@@ -1,0 +1,10 @@
+spring:
+  main:
+    web-application-type: none
+
+dubbo:
+  application:
+    name: async-result-consumer
+  registry:
+    address: zookeeper://127.0.0.1:2181
+

--- a/2-advanced/dubbo-samples-async-result/docker/consumer/dockerfile
+++ b/2-advanced/dubbo-samples-async-result/docker/consumer/dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:8-jdk-alpine
+
+WORKDIR /app
+
+# Copy built consumer jar
+COPY ../../dubbo-samples-async-result-consumer/target/*.jar app.jar
+
+EXPOSE 20880
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/2-advanced/dubbo-samples-async-result/docker/docker-compose.yml
+++ b/2-advanced/dubbo-samples-async-result/docker/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.8"
+
+services:
+  provider:
+    build:
+      context: ./provider
+    container_name: dubbo-samples-async-result-provider
+    ports:
+      - "20880:20880"
+    networks:
+      - dubbo-network
+
+  consumer:
+    build:
+      context: ./consumer
+    container_name: dubbo-samples-async-result-consumer
+    depends_on:
+      - provider
+    networks:
+      - dubbo-network
+
+networks:
+  dubbo-network:
+    driver: bridge
+

--- a/2-advanced/dubbo-samples-async-result/docker/provider/dockerfile
+++ b/2-advanced/dubbo-samples-async-result/docker/provider/dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:8-jdk-alpine
+
+WORKDIR /app
+
+# Copy built provider jar
+COPY ../../dubbo-samples-async-result-provider/target/*.jar app.jar
+
+EXPOSE 20880
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/2-advanced/dubbo-samples-async-result/docker/run-test.sh
+++ b/2-advanced/dubbo-samples-async-result/docker/run-test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+PROJECT_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+
+echo ">>> Building project..."
+mvn clean package -pl 2-advanced/dubbo-samples-async-result -am -DskipTests
+
+echo ">>> Starting Docker containers..."
+cd "$PROJECT_ROOT/docker"
+docker-compose up --build -d
+
+echo ">>> Waiting for services to start..."
+sleep 15
+
+echo ">>> Running async result test..."
+docker logs dubbo-samples-async-result-consumer | tee consumer.log
+
+echo ">>> Checking for success keyword in logs..."
+if grep -q "Async result received" consumer.log; then
+  echo "✅ Async result sample ran successfully."
+  exit 0
+else
+  echo "❌ Async result test failed."
+  exit 1
+fi
+
+echo ">>> Cleaning up..."
+docker-compose down

--- a/2-advanced/dubbo-samples-async-result/pom.xml
+++ b/2-advanced/dubbo-samples-async-result/pom.xml
@@ -1,0 +1,39 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.dubbo.sample</groupId>
+    <artifactId>dubbo-samples-async-result</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>dubbo-samples-async-result</name>
+
+    <modules>
+        <module>api</module>
+        <module>Provider</module>
+        <module>Consumer</module>
+    </modules>
+
+    <properties>
+        <java.version>17</java.version>
+        <dubbo.version>3.3.5</dubbo.version>
+        <spring.boot.version>3.2.0</spring.boot.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.dubbo</groupId>
+                <artifactId>dubbo-bom</artifactId>
+                <version>${dubbo.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>
+
+
+

--- a/2-advanced/pom.xml
+++ b/2-advanced/pom.xml
@@ -28,6 +28,7 @@
 
     <modules>
         <module>dubbo-samples-async</module>
+        <module>dubbo-samples-async-result</module>
         <module>dubbo-samples-attachment</module>
         <module>dubbo-samples-autowire</module>
         <module>dubbo-samples-cache</module>


### PR DESCRIPTION
This PR adds a new example module `dubbo-sample-async-result` under `dubbo-samples-advanced` to demonstrate asynchronous RPC using CompletableFuture.

## Features:
- Demonstrates async result handling using Dubbo
- Uses CompletableFuture for non-blocking calls
- Includes API, Provider, and Consumer modules
- Follows existing sample structure conventions

## Structure:
- api: Service interface
- provider: Async service implementation
- consumer: Async invocation example

## Verification:
- Successfully built using `mvn clean install`
- Provider and Consumer run successfully
- Verified async response flow between services

Fixes #15567