### PR TITLE
Bump netty from 4.2.9.Final to 4.2.12.Final

### DIFF
--- a/1-basic/dubbo-samples-spring-boot/pom.xml
+++ b/1-basic/dubbo-samples-spring-boot/pom.xml
@@ -55,7 +55,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.2.9.Final</version>
+                <version>4.2.12.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/2-advanced/dubbo-samples-callback/pom.xml
+++ b/2-advanced/dubbo-samples-callback/pom.xml
@@ -55,7 +55,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.2.9.Final</version>
+                <version>4.2.12.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/2-advanced/dubbo-samples-environment-keys/pom.xml
+++ b/2-advanced/dubbo-samples-environment-keys/pom.xml
@@ -50,7 +50,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.2.9.Final</version>
+                <version>4.2.12.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/2-advanced/dubbo-samples-triple-http3/pom.xml
+++ b/2-advanced/dubbo-samples-triple-http3/pom.xml
@@ -49,7 +49,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.2.9.Final</version>
+                <version>4.2.12.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-openapi-basic/pom.xml
+++ b/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-openapi-basic/pom.xml
@@ -40,7 +40,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.2.9.Final</version>
+        <version>4.2.12.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-spring-security/pom.xml
+++ b/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-spring-security/pom.xml
@@ -35,7 +35,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.2.9.Final</version>
+        <version>4.2.12.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/2-advanced/dubbo-samples-triple-rest/pom.xml
+++ b/2-advanced/dubbo-samples-triple-rest/pom.xml
@@ -56,7 +56,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.2.9.Final</version>
+        <version>4.2.12.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/2-advanced/dubbo-samples-triple-servlet/pom.xml
+++ b/2-advanced/dubbo-samples-triple-servlet/pom.xml
@@ -49,7 +49,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.2.9.Final</version>
+                <version>4.2.12.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/2-advanced/dubbo-samples-triple-streaming/pom.xml
+++ b/2-advanced/dubbo-samples-triple-streaming/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
           <groupId>io.netty</groupId>
           <artifactId>netty-bom</artifactId>
-          <version>4.2.9.Final</version>
+          <version>4.2.12.Final</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/3-extensions/registry/dubbo-samples-nacos/dubbo-samples-nacos-registry/pom.xml
+++ b/3-extensions/registry/dubbo-samples-nacos/dubbo-samples-nacos-registry/pom.xml
@@ -49,7 +49,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.2.9.Final</version>
+                <version>4.2.12.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/4-governance/dubbo-samples-sentinel/dubbo-samples-sentinel-consumer/pom.xml
+++ b/4-governance/dubbo-samples-sentinel/dubbo-samples-sentinel-consumer/pom.xml
@@ -48,7 +48,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.2.9.Final</version>
+                <version>4.2.12.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/4-governance/dubbo-samples-sentinel/dubbo-samples-sentinel-provider/pom.xml
+++ b/4-governance/dubbo-samples-sentinel/dubbo-samples-sentinel-provider/pom.xml
@@ -47,7 +47,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.2.9.Final</version>
+                <version>4.2.12.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Notice: 
```Commit 994e887``` - Support QuicheQuicSslEngine hostname identification algorithm (https://github.com/netty/netty/pull/16426) - has been merged since Netty4.2.11.Final.
Results:
Hostname verificiation algorithm is configurable and enforced since Netty 4.2.11.Final