### PR TITLE
Replace simpleclient_pushgateway dependency with dubbo-metrics-prometheus dependency to prepare to bump prometheus version

### DIFF
--- a/4-governance/dubbo-samples-metrics-prometheus/dubbo-samples-metrics-prometheus-consumer/pom.xml
+++ b/4-governance/dubbo-samples-metrics-prometheus/dubbo-samples-metrics-prometheus-consumer/pom.xml
@@ -65,8 +65,8 @@
           <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>
-          <groupId>io.prometheus</groupId>
-          <artifactId>simpleclient_pushgateway</artifactId>
+          <groupId>org.apache.dubbo</groupId>
+          <artifactId>dubbo-metrics-prometheus</artifactId>
         </dependency>
     </dependencies>
 

--- a/4-governance/dubbo-samples-metrics-prometheus/dubbo-samples-metrics-prometheus-consumer/src/test/java/org/apache/dubbo/samples/metrics/prometheus/consumer/ConsumerMetricsIT.java
+++ b/4-governance/dubbo-samples-metrics-prometheus/dubbo-samples-metrics-prometheus-consumer/src/test/java/org/apache/dubbo/samples/metrics/prometheus/consumer/ConsumerMetricsIT.java
@@ -147,7 +147,7 @@ public class ConsumerMetricsIT {
         }
         context.stop();
         for (String metricKey : notExistedList) {
-            logger.error("metric key:{} don't exists", metricKey);
+            logger.error("metric key:{} doesn't exist", metricKey);
         }
         Assert.assertTrue(notExistedList.isEmpty());
     }

--- a/4-governance/dubbo-samples-metrics-prometheus/dubbo-samples-metrics-prometheus-provider/pom.xml
+++ b/4-governance/dubbo-samples-metrics-prometheus/dubbo-samples-metrics-prometheus-provider/pom.xml
@@ -67,8 +67,8 @@
           <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>
-          <groupId>io.prometheus</groupId>
-          <artifactId>simpleclient_pushgateway</artifactId>
+          <groupId>org.apache.dubbo</groupId>
+          <artifactId>dubbo-metrics-prometheus</artifactId>
         </dependency>
     </dependencies>
 

--- a/4-governance/dubbo-samples-metrics-prometheus/dubbo-samples-metrics-prometheus-provider/src/test/java/org/apache/dubbo/samples/metrics/prometheus/provider/ProviderMetricsIT.java
+++ b/4-governance/dubbo-samples-metrics-prometheus/dubbo-samples-metrics-prometheus-provider/src/test/java/org/apache/dubbo/samples/metrics/prometheus/provider/ProviderMetricsIT.java
@@ -163,7 +163,7 @@ public class ProviderMetricsIT {
         }
         context.stop();
         for (String metricKey : notExistedList) {
-            logger.error("metric key:{} don't exists", metricKey);
+            logger.error("metric key:{} doesn't exist", metricKey);
         }
         Assert.assertTrue(notExistedList.isEmpty());
     }

--- a/4-governance/dubbo-samples-metrics-prometheus/pom.xml
+++ b/4-governance/dubbo-samples-metrics-prometheus/pom.xml
@@ -37,8 +37,8 @@
         <module>dubbo-samples-metrics-prometheus-consumer</module>
     </modules>
 
-    <name>Dubbo Samples Metrics Prometheus</name>
-    <description>Dubbo Samples Metrics Prometheus</description>
+    <name>Dubbo Samples Metrics Prometheus for Spring Boot 2</name>
+    <description>Dubbo Samples Metrics Prometheus for Spring Boot 2</description>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
With Spring Boot 3.5.x, the old simpleclient-based Prometheus stack is no longer brought in through the Spring Boot / Micrometer dependency path, so we might add the required Prometheus client dependencies and the old/new Prometheus client compatibility logic into ```dubbo-metrics-prometheus``` and depend on ```dubbo-metrics-prometheus``` to solve the problem.