### PR TITLE
Migrate dubbo-samples-attachment to Spring Boot 3

### DIFF
--- a/2-advanced/dubbo-samples-attachment/case-versions.conf
+++ b/2-advanced/dubbo-samples-attachment/case-versions.conf
@@ -21,5 +21,5 @@
 
 # Spring app
 dubbo.version=[>= 3.1.0]
-spring.version=4.*, 5.*
-java.version= [>= 8]
+spring.version=6.*
+java.version= [>= 17]

--- a/2-advanced/dubbo-samples-attachment/pom.xml
+++ b/2-advanced/dubbo-samples-attachment/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>23</version>
+        <version>31</version>
         <relativePath/>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -36,12 +36,12 @@
     <description>Dubbo Samples Attachment</description>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <dubbo.version>3.3.1</dubbo.version>
-        <spring-boot.version>2.7.8</spring-boot.version>
+        <spring-boot.version>3.2.3</spring-boot.version>
         <junit.version>4.13.1</junit.version>
     </properties>
 


### PR DESCRIPTION
Part of #13862 (migrating samples to Spring Boot 3)

- Bump spring-boot.version from 2.7.8 to 3.2.3
- Bump maven.compiler.source/target from 1.8 to 17 (required by Spring Boot 3)
- Bump parent apache POM from 23 to 31
- Update case-versions.conf: spring.version=6.*, java.version=[>= 17]

No javax.* -> jakarta.* changes needed; no source file in this module references javax.*.

Verified: mvn clean install succeeds. Ran the actual demo consumer (AttachmentConsumer) end-to-end against a live Zookeeper registry and Provider instance - RPC calls succeed and attachment propagation behaves correctly (attachment present on first call, absent on the next, matching expected semantics).