### PR TITLE
fix: select Spring 6 REST adapter for samples

### DIFF
--- a/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-spring-security/spring-security-resource-server/pom.xml
+++ b/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-spring-security/spring-security-resource-server/pom.xml
@@ -94,6 +94,30 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>dubbo-rest-spring6</id>
+      <activation>
+        <property>
+          <name>dubbo.rest.spring6</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.dubbo</groupId>
+          <artifactId>dubbo-spring-boot-3-autoconfigure</artifactId>
+          <version>${dubbo.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.dubbo</groupId>
+          <artifactId>dubbo-rest-spring6</artifactId>
+          <version>${dubbo.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
       <plugin>

--- a/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-springmvc/pom.xml
+++ b/2-advanced/dubbo-samples-triple-rest/dubbo-samples-triple-rest-springmvc/pom.xml
@@ -56,6 +56,30 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>dubbo-rest-spring6</id>
+      <activation>
+        <property>
+          <name>dubbo.rest.spring6</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.dubbo</groupId>
+          <artifactId>dubbo-spring-boot-3-autoconfigure</artifactId>
+          <version>${dubbo.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.dubbo</groupId>
+          <artifactId>dubbo-rest-spring6</artifactId>
+          <version>${dubbo.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
## What changed

- add an opt-in `dubbo-rest-spring6` Maven profile to the Spring MVC Triple REST sample
- add the same profile to the Spring Security resource-server sample
- when enabled with `-Ddubbo.rest.spring6=true`, explicitly select:
  - `dubbo-spring-boot-3-autoconfigure`
  - `dubbo-rest-spring6`

## Why

apache/dubbo#16394 separates the Spring 5 and Spring 6 REST adapters and removes the legacy `dubbo-rest-spring` implementation from the aggregate `dubbo` JAR.

These Spring Boot 3 samples use Spring MVC mappings, so they must explicitly choose the Spring 6 / Jakarta adapter when tested against the candidate Dubbo build.

## Compatibility

The profile is disabled by default. Normal sample builds therefore remain compatible with the current released Dubbo baseline, which does not provide `dubbo-rest-spring6`.

After a Dubbo release containing `dubbo-rest-spring6` becomes the samples baseline, these dependencies can become unconditional and the temporary activation property can be removed.

The profile selects only `dubbo-rest-spring6`; it does not add the legacy `dubbo-rest-spring` adapter.

## Validation

With apache/dubbo#16394 at `ea51d470b1` and `-Ddubbo.version=3.3.7-SNAPSHOT -Dspring.version=6.1.5 -Ddubbo.rest.spring6=true`:

- the Spring MVC sample dependency tree contains `dubbo-spring-boot-3-autoconfigure` and `dubbo-rest-spring6`, with no legacy adapter
- the Spring Security resource-server dependency tree contains the same explicit Spring 6 composition, with no legacy adapter
- the Spring MVC provider registered 48 REST mappings and all 36 `ConsumerIT` tests passed
- the Spring Security provider registered its Spring MVC REST mappings and both `ResourceServerIT` tests passed
- with the profile disabled, the packaged Spring MVC sample contains neither REST Spring adapter and `/demo/hello` returns `404 Invoker not found`
- all current checks for this PR pass; those checks intentionally leave the profile disabled because the released Dubbo baseline does not provide `dubbo-rest-spring6`
- `git diff --check` passed

## CI coordination

This PR depends on the new artifact from apache/dubbo#16394. Conversely, the samples workflow in apache/dubbo#16394 currently checks out `dubbo-samples@master` and does not enable this opt-in profile. Merging this PR unchanged by itself therefore does not make the core PR's samples checks green; the cross-repository ref/profile activation or merge sequence must be coordinated separately.

## Related

- depends on apache/dubbo#16394
